### PR TITLE
query/logicalplan: Better support for propagating DynamicColumns

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/segmentio/parquet-go"
 )
@@ -129,6 +130,15 @@ func NewSchema(
 func (s *Schema) ColumnByName(name string) (ColumnDefinition, bool) {
 	i, ok := s.columnIndexes[name]
 	if !ok {
+		// If column is dynamic the prefix before the dot
+		// should be a column with a schema
+		parts := strings.Split(name, ".")
+		if len(parts) == 2 {
+			i, ok = s.columnIndexes[parts[0]]
+			if ok {
+				return s.columns[i], true
+			}
+		}
 		return ColumnDefinition{}, false
 	}
 	return s.columns[i], true

--- a/dynparquet/schema_test.go
+++ b/dynparquet/schema_test.go
@@ -230,3 +230,26 @@ func TestMultipleIterations(t *testing.T) {
 	require.Equal(t, 3, i)
 	require.NoError(t, rows.Close())
 }
+
+func TestSchema_ColumnByName(t *testing.T) {
+	schema := NewSampleSchema()
+
+	def, ok := schema.ColumnByName("example_type")
+	require.True(t, ok)
+	require.False(t, def.Dynamic)
+	require.Equal(t, "example_type", def.Name)
+
+	def, ok = schema.ColumnByName("timestamp")
+	require.True(t, ok)
+	require.False(t, def.Dynamic)
+	require.Equal(t, "timestamp", def.Name)
+
+	def, ok = schema.ColumnByName("nonexistent")
+	require.False(t, ok)
+	require.Equal(t, ColumnDefinition{}, def)
+
+	def, ok = schema.ColumnByName("labels.test")
+	require.True(t, ok)
+	require.True(t, def.Dynamic)
+	require.Equal(t, "labels", def.Name)
+}

--- a/query/engine.go
+++ b/query/engine.go
@@ -96,7 +96,7 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(r arrow.Re
 	}
 
 	for _, optimizer := range logicalplan.DefaultOptimizers {
-		logicalPlan = optimizer.Optimize(logicalPlan)
+		logicalPlan = optimizer.Optimize(logicalPlan.InputSchema(), logicalPlan)
 	}
 
 	phyPlan, err := physicalplan.Build(

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -85,6 +85,9 @@ func (m DynamicColumnMatcher) Name() string {
 }
 
 func (m DynamicColumnMatcher) Match(columnName string) bool {
+	if m.ColumnName == columnName {
+		return true
+	}
 	return strings.HasPrefix(columnName, m.ColumnName+".")
 }
 

--- a/table.go
+++ b/table.go
@@ -427,7 +427,7 @@ func (t *Table) ArrowSchema(
 	}
 
 	rowGroups := []dynparquet.DynamicRowGroup{}
-	err = t.ActiveBlock().RowGroupIterator(ctx, tx, nil, filter,
+	err = t.ActiveBlock().RowGroupIterator(ctx, tx, filterExpr, filter,
 		func(rg dynparquet.DynamicRowGroup) bool {
 			rowGroups = append(rowGroups, rg)
 			return true


### PR DESCRIPTION
The logicalplan should better propagate columns that are dynamic such that they can be treated differently in the future.

This PR builds on top of #92 

Fixes #89 