### PR TITLE
Add type to ParquetNodeToTypeWithWriterFunc log

### DIFF
--- a/examples/simple.go
+++ b/examples/simple.go
@@ -91,7 +91,7 @@ func simpleSchema() *dynparquet.Schema {
 			Dynamic:       true,
 		}, {
 			Name:          "value",
-			StorageLayout: parquet.Leaf(parquet.DoubleType),
+			StorageLayout: parquet.Int(64),
 			Dynamic:       false,
 		}},
 		[]dynparquet.SortingColumn{

--- a/pqarrow/convert/convert.go
+++ b/pqarrow/convert/convert.go
@@ -26,7 +26,7 @@ func ParquetNodeToTypeWithWriterFunc(n parquet.Node) (arrow.DataType, func(b arr
 	lt := t.LogicalType()
 
 	if lt == nil {
-		return nil, nil, errors.New("unsupported type")
+		return nil, nil, errors.New("unsupported type: " + n.Type().String())
 	}
 
 	switch {
@@ -43,6 +43,6 @@ func ParquetNodeToTypeWithWriterFunc(n parquet.Node) (arrow.DataType, func(b arr
 			return nil, nil, errors.New("unsupported int bit width")
 		}
 	default:
-		return nil, nil, errors.New("unsupported type")
+		return nil, nil, errors.New("unsupported type: " + n.Type().String())
 	}
 }

--- a/pqarrow/convert/convert_test.go
+++ b/pqarrow/convert/convert_test.go
@@ -39,7 +39,7 @@ func TestParquetNodeToType(t *testing.T) {
 	}{
 		{
 			parquetNode: parquet.Leaf(parquet.DoubleType),
-			msg:         "unsupported type",
+			msg:         "unsupported type: DOUBLE",
 		},
 	}
 	for _, c := range errCases {


### PR DESCRIPTION
I was playing with the sample code and thought it would be easier to debug if the log showed the type of parquet.Node.

I also thought that Int64 was appropriate for the StorageLayout of value in the sample code.