### PR TITLE
Add test cases in TestParquetNodeToType

### DIFF
--- a/pqarrow/convert/convert_test.go
+++ b/pqarrow/convert/convert_test.go
@@ -41,6 +41,83 @@ func TestParquetNodeToType(t *testing.T) {
 			parquetNode: parquet.Leaf(parquet.DoubleType),
 			msg:         "unsupported type: DOUBLE",
 		},
+		{
+			parquetNode: parquet.Leaf(parquet.BooleanType),
+			msg:         "unsupported type: BOOLEAN",
+		},
+		{
+			parquetNode: parquet.Int(32),
+			msg:         "unsupported int bit width",
+		},
+		{
+			parquetNode: parquet.Leaf(parquet.Int96Type),
+			msg:         "unsupported type: INT96",
+		},
+		{
+			parquetNode: parquet.Leaf(parquet.FloatType),
+			msg:         "unsupported type: FLOAT",
+		},
+		{
+			parquetNode: parquet.Leaf(parquet.DoubleType),
+			msg:         "unsupported type: DOUBLE",
+		},
+		{
+			parquetNode: parquet.Leaf(parquet.ByteArrayType),
+			msg:         "unsupported type: BYTE_ARRAY",
+		},
+		{
+			parquetNode: parquet.Leaf(parquet.FixedLenByteArrayType(8)),
+			msg:         "unsupported type: FIXED_LEN_BYTE_ARRAY(8)",
+		},
+		{
+			parquetNode: parquet.Decimal(0, 9, parquet.Int32Type),
+			msg:         "unsupported type: DECIMAL(0,9)",
+		},
+		{
+			parquetNode: parquet.UUID(),
+			msg:         "unsupported type: UUID",
+		},
+		{
+			parquetNode: parquet.Enum(),
+			msg:         "unsupported type: ENUM",
+		},
+		// This causes stack overflow.
+		//{
+		//	parquetNode: parquet.JSON(),
+		//	msg:         "unsupported type: JSON",
+		//},
+		{
+			parquetNode: parquet.BSON(),
+			msg:         "unsupported type: BSON",
+		},
+		{
+			parquetNode: parquet.Date(),
+			msg:         "unsupported type: DATE",
+		},
+		{
+			parquetNode: parquet.Time(parquet.Millisecond),
+			msg:         "unsupported type: TIME(isAdjustedToUTC=true,unit=MILLIS)",
+		},
+		{
+			parquetNode: parquet.Timestamp(parquet.Millisecond),
+			msg:         "unsupported type: TIMESTAMP(isAdjustedToUTC=true,unit=MILLIS)",
+		},
+		{
+			parquetNode: parquet.List(parquet.String()),
+			msg:         "unsupported type: LIST",
+		},
+		{
+			parquetNode: parquet.Map(
+				parquet.String(),
+				parquet.String(),
+			),
+			msg: "unsupported type: MAP",
+		},
+		{
+			parquetNode: parquet.Group{},
+			msg:         "unsupported type: group",
+		},
+		// nullType is unexported by segmentio/parquet-go.
 	}
 	for _, c := range errCases {
 		_, err := ParquetNodeToType(c.parquetNode)

--- a/pqarrow/convert/convert_test.go
+++ b/pqarrow/convert/convert_test.go
@@ -82,6 +82,7 @@ func TestParquetNodeToType(t *testing.T) {
 			msg:         "unsupported type: ENUM",
 		},
 		// This causes stack overflow.
+		// Fix PR: https://github.com/segmentio/parquet-go/pull/244
 		//{
 		//	parquetNode: parquet.JSON(),
 		//	msg:         "unsupported type: JSON",


### PR DESCRIPTION
This may be redundant, but it gives us an understanding of FrostDB's behavior and prevents changes like https://github.com/polarsignals/frostdb/pull/100.

Reference: https://github.com/segmentio/parquet-go/blob/edd371b528ffa7d9b637160d4fbd3b88f82698fa/type.go


Interestingly, JSON causes stack overflow, but I haven't looked into that yet.

```
=== RUN   TestParquetNodeToType
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc0201f8388 stack=[0xc0201f8000, 0xc0401f8000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x121ef33?, 0x1385f40?})
        /usr/local/Cellar/go/1.18.3/libexec/src/runtime/panic.go:992 +0x71
runtime.newstack()
        /usr/local/Cellar/go/1.18.3/libexec/src/runtime/stack.go:1101 +0x5cc
runtime.morestack()
        /usr/local/Cellar/go/1.18.3/libexec/src/runtime/asm_amd64.s:547 +0x8b

goroutine 35 [running]:
github.com/segmentio/parquet-go.(*jsonType).String(0x13e79b0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x2d fp=0xc0201f8398 sp=0xc0201f8390 pc=0x11a4ead
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f83b0 sp=0xc0201f8398 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f83c8 sp=0xc0201f83b0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f83e0 sp=0xc0201f83c8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f83f8 sp=0xc0201f83e0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8410 sp=0xc0201f83f8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8428 sp=0xc0201f8410 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8440 sp=0xc0201f8428 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8458 sp=0xc0201f8440 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8470 sp=0xc0201f8458 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8488 sp=0xc0201f8470 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f84a0 sp=0xc0201f8488 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f84b8 sp=0xc0201f84a0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f84d0 sp=0xc0201f84b8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f84e8 sp=0xc0201f84d0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8500 sp=0xc0201f84e8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8518 sp=0xc0201f8500 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8530 sp=0xc0201f8518 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8548 sp=0xc0201f8530 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8560 sp=0xc0201f8548 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8578 sp=0xc0201f8560 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8590 sp=0xc0201f8578 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f85a8 sp=0xc0201f8590 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f85c0 sp=0xc0201f85a8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f85d8 sp=0xc0201f85c0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f85f0 sp=0xc0201f85d8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8608 sp=0xc0201f85f0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8620 sp=0xc0201f8608 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8638 sp=0xc0201f8620 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8650 sp=0xc0201f8638 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8668 sp=0xc0201f8650 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8680 sp=0xc0201f8668 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8698 sp=0xc0201f8680 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f86b0 sp=0xc0201f8698 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f86c8 sp=0xc0201f86b0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f86e0 sp=0xc0201f86c8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f86f8 sp=0xc0201f86e0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8710 sp=0xc0201f86f8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8728 sp=0xc0201f8710 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8740 sp=0xc0201f8728 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8758 sp=0xc0201f8740 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8770 sp=0xc0201f8758 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8788 sp=0xc0201f8770 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f87a0 sp=0xc0201f8788 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f87b8 sp=0xc0201f87a0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f87d0 sp=0xc0201f87b8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f87e8 sp=0xc0201f87d0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8800 sp=0xc0201f87e8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8818 sp=0xc0201f8800 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8830 sp=0xc0201f8818 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8848 sp=0xc0201f8830 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8860 sp=0xc0201f8848 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8878 sp=0xc0201f8860 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8890 sp=0xc0201f8878 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f88a8 sp=0xc0201f8890 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f88c0 sp=0xc0201f88a8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f88d8 sp=0xc0201f88c0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f88f0 sp=0xc0201f88d8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8908 sp=0xc0201f88f0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8920 sp=0xc0201f8908 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8938 sp=0xc0201f8920 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8950 sp=0xc0201f8938 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8968 sp=0xc0201f8950 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8980 sp=0xc0201f8968 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8998 sp=0xc0201f8980 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f89b0 sp=0xc0201f8998 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f89c8 sp=0xc0201f89b0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f89e0 sp=0xc0201f89c8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f89f8 sp=0xc0201f89e0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a10 sp=0xc0201f89f8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a28 sp=0xc0201f8a10 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a40 sp=0xc0201f8a28 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a58 sp=0xc0201f8a40 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a70 sp=0xc0201f8a58 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8a88 sp=0xc0201f8a70 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8aa0 sp=0xc0201f8a88 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8ab8 sp=0xc0201f8aa0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8ad0 sp=0xc0201f8ab8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8ae8 sp=0xc0201f8ad0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b00 sp=0xc0201f8ae8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b18 sp=0xc0201f8b00 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b30 sp=0xc0201f8b18 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b48 sp=0xc0201f8b30 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b60 sp=0xc0201f8b48 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b78 sp=0xc0201f8b60 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8b90 sp=0xc0201f8b78 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8ba8 sp=0xc0201f8b90 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8bc0 sp=0xc0201f8ba8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8bd8 sp=0xc0201f8bc0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8bf0 sp=0xc0201f8bd8 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c08 sp=0xc0201f8bf0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c20 sp=0xc0201f8c08 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c38 sp=0xc0201f8c20 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c50 sp=0xc0201f8c38 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c68 sp=0xc0201f8c50 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c80 sp=0xc0201f8c68 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8c98 sp=0xc0201f8c80 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8cb0 sp=0xc0201f8c98 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8cc8 sp=0xc0201f8cb0 pc=0x11a4e99
github.com/segmentio/parquet-go.(*jsonType).String(0x0?)
        /Users/nozomu/go/pkg/mod/github.com/segmentio/parquet-go@v0.0.0-20220524213358-0733add4c2cb/type.go:944 +0x19 fp=0xc0201f8ce0 sp=0xc0201f8cc8 pc=0x11a4e99
...additional frames elided...
created by testing.(*T).Run
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1486 +0x35f

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000105860, {0x1221433?, 0x1274f2ba9f308?}, 0x12315d8)
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1487 +0x37a
testing.runTests.func1(0xc0001155c0?)
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1839 +0x6e
testing.tRunner(0xc000105860, 0xc000177cd8)
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1439 +0x102
testing.runTests(0xc0001355e0?, {0x13acc20, 0x1, 0x1}, {0x1455a68?, 0x40?, 0x13b7da0?})
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1837 +0x457
testing.(*M).Run(0xc0001355e0)
        /usr/local/Cellar/go/1.18.3/libexec/src/testing/testing.go:1719 +0x5d9
main.main()
        _testmain.go:47 +0x1aa
FAIL    github.com/polarsignals/frostdb/pqarrow/convert 2.168s
FAIL
```