### PR TITLE
Update parquet-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/oklog/ulid v1.3.1
 	github.com/prometheus/client_golang v1.12.1
-	github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb
+	github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220324141029-c4f11442aa33
 	go.uber.org/atomic v1.9.0
@@ -26,7 +26,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/goccy/go-json v0.7.10 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/klauspost/compress v1.15.2 // indirect
+	github.com/klauspost/compress v1.15.5 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/klauspost/asmfmt v1.3.1/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j
 github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.2 h1:3WH+AG7s2+T8o3nrM/8u2rdqUEcQhmga7smjrT41nAw=
 github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
+github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -410,6 +412,8 @@ github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a h1:GJ+IvAkKk+
 github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
 github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb h1:3RITWgLOUct6jLN+fKbP6UrItkOTq1WWV7iMC4pPF4U=
 github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
+github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff h1:Rssgq0QrKr1PEKO8RmPch2SqyBEm6Iq0jfUinfXB+Bc=
+github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This PR includes the following `parquet-go` changes: https://github.com/segmentio/parquet-go/compare/0733add4c2cb...edd371b528ff

## Test plan
```
[javierhonduco@computer frostdb]$ go test .
ok  	github.com/polarsignals/frostdb	(cached)
```

_edit_: as this includes https://github.com/segmentio/parquet-go/pull/224 I thought it would fix the issue with avx2 instructions in platforms that don't support them https://github.com/segmentio/parquet-go/issues/189, but turns out it doesn't fix all the instances just yet. This upgrade is still nice as there are some performance improvements + to incrementally upgrade our dependencies 