### PR TITLE
pqarrow: Decouple Arrow Schema retrieval from Arrow Iterator

### DIFF
--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -107,6 +107,7 @@ type TableReader interface {
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
+		schema *arrow.Schema,
 		projection []ColumnMatcher,
 		filter Expr,
 		distinctColumns []ColumnMatcher,

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -27,6 +27,7 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
+	schema *arrow.Schema,
 	projection []ColumnMatcher,
 	filter Expr,
 	distinctColumns []ColumnMatcher,

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -69,11 +69,25 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 	if table == nil {
 		return errors.New("table not found")
 	}
+
 	err := table.View(func(tx uint64) error {
+		schema, err := table.ArrowSchema(
+			ctx,
+			tx,
+			pool,
+			s.options.Projection,
+			s.options.Filter,
+			s.options.Distinct,
+		)
+		if err != nil {
+			return err
+		}
+
 		return table.Iterator(
 			ctx,
 			tx,
 			pool,
+			schema,
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/apache/arrow/go/v8/arrow"
-
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/stretchr/testify/require"
 
@@ -29,6 +28,7 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
+	schema *arrow.Schema,
 	projection []logicalplan.ColumnMatcher,
 	filter logicalplan.Expr,
 	distinctColumns []logicalplan.ColumnMatcher,


### PR DESCRIPTION
Basically, we're now always creating an `arrow.Schema` from the given query and then passing that schema into the iterators building the actual `arrow.Record`. For the latter operation, the mapping becomes a  whole lot simpler since the arrow schema has a little index inside of it to do a lookup if a column should be included or not.
Performance isn't the main reason for this change though.