### PR TITLE
Update parquet-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/oklog/ulid v1.3.1
 	github.com/prometheus/client_golang v1.12.1
-	github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff
+	github.com/segmentio/parquet-go v0.0.0-20220623195409-8b4d4260d8cb
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220324141029-c4f11442aa33
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.1/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.2 h1:3WH+AG7s2+T8o3nrM/8u2rdqUEcQhmga7smjrT41nAw=
-github.com/klauspost/compress v1.15.2/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
 github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -408,12 +406,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a h1:GJ+IvAkKk++n419fRBbGhCUXENGIsxh89aAZTe3TJVM=
-github.com/segmentio/parquet-go v0.0.0-20220511210326-4f4d804bcd3a/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
-github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb h1:3RITWgLOUct6jLN+fKbP6UrItkOTq1WWV7iMC4pPF4U=
-github.com/segmentio/parquet-go v0.0.0-20220524213358-0733add4c2cb/go.mod h1:DMN6PChc8JaI7whze9XQn1aCv+8D7nhQKMfL8zXNjX4=
-github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff h1:Rssgq0QrKr1PEKO8RmPch2SqyBEm6Iq0jfUinfXB+Bc=
-github.com/segmentio/parquet-go v0.0.0-20220616233901-edd371b528ff/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220623195409-8b4d4260d8cb h1:nGVNj4bt9Fn5rsEvLsuOoTuQGSdiSkPRH+BvKlIp5NY=
+github.com/segmentio/parquet-go v0.0.0-20220623195409-8b4d4260d8cb/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This PR includes the following `parquet-go` changes: https://github.com/segmentio/parquet-go/compare/edd371b528ff...8b4d4260d8, and will allow us to run in CPUs without `BMI2` instructions

## Test plan
```
[javierhonduco@computer frostdb]$ go test .
ok  	github.com/polarsignals/frostdb	(cached)
```
