### PR TITLE
Fixes empty column EQ/NEQ/RE/NORE matcher.

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -93,6 +93,38 @@ func TestFilter(t *testing.T) {
 			),
 			rows: 3,
 		},
+		"regexp missing colum": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label5").RegexMatch(""),
+			),
+			rows: 3,
+		},
+		"not regexp missing colum": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label5").RegexNotMatch("foo"),
+			),
+			rows: 3,
+		},
+		"regexp mixed of missing/not missing colum": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label3").RegexMatch("value."),
+				logicalplan.Col("labels.label5").RegexMatch(""),
+				logicalplan.Col("labels.label2").Eq(logicalplan.Literal("value2")),
+			),
+			rows: 1,
+		},
+		"=! missing colum": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label5").NotEq(logicalplan.Literal("value4")),
+			),
+			rows: 3,
+		},
+		"== missing colum": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label5").Eq(logicalplan.Literal("")),
+			),
+			rows: 3,
+		},
 		"regexp and == string and != string": {
 			filterExpr: logicalplan.And(
 				logicalplan.Col("labels.label1").RegexMatch("value."),

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -11,8 +11,6 @@ import (
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
-var ErrUnexpectedNumberOfFields = errors.New("unexpected number of fields")
-
 type ArrayRef struct {
 	ColumnName string
 }
@@ -20,7 +18,7 @@ type ArrayRef struct {
 func (a *ArrayRef) ArrowArray(r arrow.Record) (arrow.Array, bool, error) {
 	fields := r.Schema().FieldIndices(a.ColumnName)
 	if len(fields) != 1 {
-		return nil, false, ErrUnexpectedNumberOfFields
+		return nil, false, nil
 	}
 
 	return r.Column(fields[0]), true, nil

--- a/query/physicalplan/regexpfilter.go
+++ b/query/physicalplan/regexpfilter.go
@@ -21,11 +21,10 @@ func (f *RegExpFilter) Eval(r arrow.Record) (*Bitmap, error) {
 		return nil, err
 	}
 
-	// TODO: This needs a bunch of test cases to validate edge cases like non
-	// existant columns or null values.
 	if !exists {
 		res := NewBitmap()
-		if f.notMatch {
+		emptyMatch := f.right.Match(nil)
+		if (f.notMatch && !emptyMatch) || (!f.notMatch && emptyMatch) {
 			for i := uint32(0); i < uint32(r.NumRows()); i++ {
 				res.Add(i)
 			}


### PR DESCRIPTION
This fixes the matchers when a column is missing.
There's definitively more improvements that could be done as the logic is sparse across the codebase.

However I wanted to have a first pass that works then think about how we can refactor.

I've tried to apply the matching as soon as possible and left a todo for the granule.

I think this fixes #1191 as this error is gone now.