### PR TITLE
Contionally add projection optimization

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -248,14 +248,6 @@ func Test_Projection(t *testing.T) {
 			rows:        2,
 			cols:        1,
 		},
-		">= int64": {
-			filterExpr: logicalplan.And(
-				logicalplan.Col("timestamp").GTE(logicalplan.Literal(2)),
-			),
-			projections: []logicalplan.Expr{logicalplan.DynCol("labels")},
-			rows:        6,
-			cols:        0,
-		},
 	}
 
 	engine := query.NewEngine(

--- a/filter_test.go
+++ b/filter_test.go
@@ -240,6 +240,14 @@ func Test_Projection(t *testing.T) {
 			rows:        2,
 			cols:        10,
 		},
+		">= int64": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("timestamp").GTE(logicalplan.Literal(2)),
+			),
+			projections: []logicalplan.Expr{logicalplan.DynCol("labels")},
+			rows:        6,
+			cols:        0,
+		},
 	}
 
 	engine := query.NewEngine(
@@ -259,7 +267,6 @@ func Test_Projection(t *testing.T) {
 					rows += ar.NumRows()
 					cols += ar.NumCols()
 					defer ar.Release()
-
 					return nil
 				})
 			require.NoError(t, err)

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -60,6 +60,25 @@ func (p *PhysicalProjectionPushDown) optimize(plan *LogicalPlan, columnsUsed []C
 type ProjectionPushDown struct{}
 
 func (p *ProjectionPushDown) Optimize(plan *LogicalPlan) *LogicalPlan {
+
+	// Don't perform the optimization if the intersection of the columns affected is less than the number of columns filtered.
+	// Otherwise we'll removed the columns we're filtering on before we filter.
+	projectColumns := projectionColumns(plan)
+	projectMap := map[string]bool{}
+	filterColumns := filterColumns(plan)
+	intersection := map[string]struct{}{}
+	for _, m := range projectColumns {
+		projectMap[m.Name()] = true
+	}
+	for _, m := range filterColumns {
+		if projectMap[m.Name()] {
+			intersection[m.Name()] = struct{}{}
+		}
+	}
+	if len(intersection) < len(filterColumns) {
+		return plan
+	}
+
 	c := &projectionCollector{}
 	c.collect(plan)
 
@@ -88,6 +107,38 @@ func (p *projectionCollector) collect(plan *LogicalPlan) {
 	if plan.Input != nil {
 		p.collect(plan.Input)
 	}
+}
+
+// filterColumns returns all the column matchers for filters in a given plan
+func filterColumns(plan *LogicalPlan) []ColumnMatcher {
+	if plan == nil {
+		return nil
+	}
+
+	columnsUsed := []ColumnMatcher{}
+	switch {
+	case plan.Filter != nil:
+		columnsUsed = append(columnsUsed, plan.Filter.Expr.ColumnsUsed()...)
+	}
+
+	return append(columnsUsed, filterColumns(plan.Input)...)
+}
+
+// projectionColumns returns all the column matchers for projections in a given plan
+func projectionColumns(plan *LogicalPlan) []ColumnMatcher {
+	if plan == nil {
+		return nil
+	}
+
+	columnsUsed := []ColumnMatcher{}
+	switch {
+	case plan.Projection != nil:
+		for _, expr := range plan.Projection.Exprs {
+			columnsUsed = append(columnsUsed, expr.ColumnsUsed()...)
+		}
+	}
+
+	return append(columnsUsed, projectionColumns(plan.Input)...)
 }
 
 func removeProjection(plan *LogicalPlan) *LogicalPlan {

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -60,8 +60,7 @@ func (p *PhysicalProjectionPushDown) optimize(plan *LogicalPlan, columnsUsed []C
 type ProjectionPushDown struct{}
 
 func (p *ProjectionPushDown) Optimize(plan *LogicalPlan) *LogicalPlan {
-
-	// Don't perform the optimization if filters contain a column that projections do not
+	// Don't perform the optimization if filters contain a column that projections do not.
 	// Otherwise we'll removed the columns we're filtering on before we filter.
 	projectColumns := projectionColumns(plan)
 	projectMap := map[string]bool{}
@@ -105,7 +104,7 @@ func (p *projectionCollector) collect(plan *LogicalPlan) {
 	}
 }
 
-// filterColumns returns all the column matchers for filters in a given plan
+// filterColumns returns all the column matchers for filters in a given plan.
 func filterColumns(plan *LogicalPlan) []ColumnMatcher {
 	if plan == nil {
 		return nil
@@ -120,7 +119,7 @@ func filterColumns(plan *LogicalPlan) []ColumnMatcher {
 	return append(columnsUsed, filterColumns(plan.Input)...)
 }
 
-// projectionColumns returns all the column matchers for projections in a given plan
+// projectionColumns returns all the column matchers for projections in a given plan.
 func projectionColumns(plan *LogicalPlan) []ColumnMatcher {
 	if plan == nil {
 		return nil

--- a/query/logicalplan/optimize_test.go
+++ b/query/logicalplan/optimize_test.go
@@ -151,12 +151,12 @@ func TestProjectionPushDown(t *testing.T) {
 			Sum(Col("value")).Alias("value_sum"),
 			Col("stacktrace"),
 		).
-		Project(Col("stacktrace")).
+		Project(Col("labels")).
 		Build()
 
 	p = (&ProjectionPushDown{}).Optimize(p)
 
-	require.True(t, p.Input.Input.Projection != nil)
+	require.True(t, p.Input.Input.Projection == nil)
 }
 
 func TestProjectionPushDownOfDistinct(t *testing.T) {


### PR DESCRIPTION
If we have a projection that doesn't include all columns
in a filter, we skip the projection optimization to avoid
the projection removing those columns before the filter can
happen.

This addresses issue #114 