### PR TITLE
Fixes the flaky cancellation test.

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -1199,12 +1199,12 @@ func Test_Table_InsertCancellation(t *testing.T) {
 			err := table.View(func(tx uint64) error {
 				totalrows := int64(0)
 
-				as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+				as, err := table.ArrowSchema(context.Background(), tx, pool, nil, nil, nil)
 				if err != nil {
 					return err
 				}
 
-				err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+				err = table.Iterator(context.Background(), tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
 					totalrows += ar.NumRows()
 					defer ar.Release()
 


### PR DESCRIPTION
This just basically use a different context for counting rows.

I think we should also change the `ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)` and instead cancel manually before inserting to trigger the code path so that the code is always triggered, right now seems like it might be triggered WDYT ?