### PR TITLE
Avoid allocations when asking for schema fields.

### DIFF
--- a/dynparquet/concat.go
+++ b/dynparquet/concat.go
@@ -5,9 +5,10 @@ import "github.com/segmentio/parquet-go"
 type concatenatedDynamicRowGroup struct {
 	parquet.RowGroup
 	dynamicColumns map[string][]string
+	fields         []parquet.Field
 }
 
-func Concat(drg ...DynamicRowGroup) DynamicRowGroup {
+func Concat(fields []parquet.Field, drg ...DynamicRowGroup) DynamicRowGroup {
 	rg := make([]parquet.RowGroup, 0, len(drg))
 	for _, d := range drg {
 		rg = append(rg, d)
@@ -16,6 +17,7 @@ func Concat(drg ...DynamicRowGroup) DynamicRowGroup {
 	return &concatenatedDynamicRowGroup{
 		RowGroup:       parquet.MultiRowGroup(rg...),
 		dynamicColumns: drg[0].DynamicColumns(),
+		fields:         fields,
 	}
 }
 
@@ -24,5 +26,5 @@ func (c *concatenatedDynamicRowGroup) DynamicColumns() map[string][]string {
 }
 
 func (c *concatenatedDynamicRowGroup) DynamicRows() DynamicRowReader {
-	return newDynamicRowGroupReader(c)
+	return newDynamicRowGroupReader(c, c.fields)
 }

--- a/dynparquet/row_test.go
+++ b/dynparquet/row_test.go
@@ -109,6 +109,7 @@ func TestLess(t *testing.T) {
 		Schema:         rowGroups[0].Schema(),
 		DynamicColumns: rowGroups[0].DynamicColumns(),
 		Rows:           make([]parquet.Row, 1),
+		fields:         rowGroups[0].Schema().Fields(),
 	}
 	n, err := rowGroups[0].Rows().ReadRows(row1.Rows)
 	require.NoError(t, err)
@@ -118,6 +119,7 @@ func TestLess(t *testing.T) {
 		Schema:         rowGroups[1].Schema(),
 		DynamicColumns: rowGroups[1].DynamicColumns(),
 		Rows:           make([]parquet.Row, 1),
+		fields:         rowGroups[1].Schema().Fields(),
 	}
 	n, err = rowGroups[1].Rows().ReadRows(row2.Rows)
 	require.NoError(t, err)
@@ -127,6 +129,7 @@ func TestLess(t *testing.T) {
 		Schema:         rowGroups[2].Schema(),
 		DynamicColumns: rowGroups[2].DynamicColumns(),
 		Rows:           make([]parquet.Row, 1),
+		fields:         rowGroups[2].Schema().Fields(),
 	}
 	n, err = rowGroups[2].Rows().ReadRows(row3.Rows)
 	require.NoError(t, err)
@@ -177,6 +180,7 @@ func TestLessWithDynamicSchemas(t *testing.T) {
 		Schema:         rowGroups[0].Schema(),
 		DynamicColumns: rowGroups[0].DynamicColumns(),
 		Rows:           make([]parquet.Row, 1),
+		fields:         rowGroups[0].Schema().Fields(),
 	}
 	n, err := rowGroups[0].Rows().ReadRows(row1.Rows)
 	require.NoError(t, err)
@@ -186,6 +190,7 @@ func TestLessWithDynamicSchemas(t *testing.T) {
 		Schema:         rowGroups[1].Schema(),
 		DynamicColumns: rowGroups[1].DynamicColumns(),
 		Rows:           make([]parquet.Row, 1),
+		fields:         rowGroups[1].Schema().Fields(),
 	}
 	n, err = rowGroups[1].Rows().ReadRows(row2.Rows)
 	require.NoError(t, err)

--- a/table_test.go
+++ b/table_test.go
@@ -585,6 +585,10 @@ func Benchmark_Table_Insert_1000Rows_10Iters_10Writers(b *testing.B) {
 	benchmarkTableInserts(b, 1000, 10, 10)
 }
 
+func Benchmark_Table_Insert_100Rows_1000Iters_1Writers(b *testing.B) {
+	benchmarkTableInserts(b, 100, 1000, 1)
+}
+
 func Benchmark_Table_Insert_100Rows_100Iters_100Writers(b *testing.B) {
 	benchmarkTableInserts(b, 100, 100, 100)
 }


### PR DESCRIPTION
[`RowLessThan`](https://github.com/polarsignals/frostdb/blob/450025ff363cb7241d9a038dcaf74b8f2779f2ac/dynparquet/row.go#L40) is part of the hot path for ingestion.

This function was using `schema.Fields()` from parquet for each iterations which creates a new slice every-time but it's always the same.

This PR actually set it once for the schema and flows it down into the dynamic rows.

![image](https://user-images.githubusercontent.com/1053421/177417904-10600a17-be59-48e1-805a-ddd3db207128.png)

I've been running this in a dev cluster and it's gone from the profile, however there's still improvement require for this function, we need to find a way to cache sorting columns per dynamic rows.
