### PR TITLE
table: handle non existent columns

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -97,13 +97,13 @@ func TestFilter(t *testing.T) {
 			filterExpr: logicalplan.And(
 				logicalplan.Col("labels.label5").RegexMatch(""),
 			),
-			rows: 3,
+			rows: 0,
 		},
 		"not regexp missing colum": {
 			filterExpr: logicalplan.And(
 				logicalplan.Col("labels.label5").RegexNotMatch("foo"),
 			),
-			rows: 3,
+			rows: 0,
 		},
 		"regexp mixed of missing/not missing colum": {
 			filterExpr: logicalplan.And(
@@ -117,13 +117,13 @@ func TestFilter(t *testing.T) {
 			filterExpr: logicalplan.And(
 				logicalplan.Col("labels.label5").NotEq(logicalplan.Literal("value4")),
 			),
-			rows: 3,
+			rows: 0,
 		},
 		"== missing colum": {
 			filterExpr: logicalplan.And(
 				logicalplan.Col("labels.label5").Eq(logicalplan.Literal("")),
 			),
-			rows: 3,
+			rows: 0,
 		},
 		"regexp and == string and != string": {
 			filterExpr: logicalplan.And(

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -2,6 +2,7 @@ package pqarrow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -16,6 +17,8 @@ import (
 	"github.com/polarsignals/frostdb/pqarrow/writer"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
+
+var ErrColumNotFound = errors.New("could not find column")
 
 // ParquetRowGroupToArrowSchema converts a parquet row group to an arrow schema.
 func ParquetRowGroupToArrowSchema(
@@ -211,6 +214,10 @@ func contiguousParquetRowGroupToArrowRecord(
 			}
 		}
 
+		if len(cols) == 0 {
+			return nil, ErrColumNotFound
+		}
+
 		return array.NewRecord(schema, cols, rows), nil
 	}
 
@@ -252,6 +259,9 @@ func contiguousParquetRowGroupToArrowRecord(
 		}
 	}
 
+	if len(cols) == 0 {
+		return nil, ErrColumNotFound
+	}
 	return array.NewRecord(schema, cols, rows), nil
 }
 

--- a/table.go
+++ b/table.go
@@ -366,6 +366,9 @@ func (t *Table) Iterator(
 				distinctColumns,
 			)
 			if err != nil {
+				if err == pqarrow.ErrColumNotFound {
+					continue
+				}
 				return fmt.Errorf("failed to convert row group to arrow record: %v", err)
 			}
 			err = iterator(record)


### PR DESCRIPTION
Co-authored-by: @metalmatze 

While testing system-wide (https://github.com/javierhonduco/parca-agent/tree/system-wide-v2), trying to select a `cgroup_id` in Parca's UI resulted in the following Panic:

```golang
panic: arrow/array: number of columns/fields mismatch

goroutine 16824 [running]:
github.com/apache/arrow/go/v8/arrow/array.NewRecord(0xc007a8e960, {0xc00e9cee40, 0x0, 0xc00e9ceee0?}, 0x0)
	/home/javierhonduco/go/pkg/mod/github.com/apache/arrow/go/v8@v8.0.0/arrow/array/record.go:149 +0x173
github.com/polarsignals/frostdb/pqarrow.contiguousParquetRowGroupToArrowRecord({0x4209b08, 0xc0089ced20}, {0x41fc6f8, 0x5e4c638}, {0x7f6bb853a458, 0xc023f5c228}, 0xc007a8e960, {0x0, 0x0?}, {0xc012cd1400, ...})
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/pqarrow/arrow.go:204 +0x60a
github.com/polarsignals/frostdb/pqarrow.ParquetRowGroupToArrowRecord({0x4209b08?, 0xc0089ced20?}, {0x41fc6f8?, 0x5e4c638?}, {0x7f6bb853a458?, 0xc023f5c228?}, 0x0?, {0x0?, 0x0?}, {0xc012cd1400, ...})
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/pqarrow/arrow.go:97 +0xa6
github.com/polarsignals/frostdb.(*Table).Iterator(0xc0000ac280, {0x4209b08, 0xc0089ced20}, 0xc006d3a730?, {0x41fc6f8, 0x5e4c638}, 0xc007a8e960, {0xc012cd13c0, 0x1, 0x1}, ...)
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/table.go:360 +0x61b
github.com/polarsignals/frostdb/query/physicalplan.(*TableScan).Execute.func1(0xc00e9cf101?)
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/query/physicalplan/physicalplan.go:86 +0x225
github.com/polarsignals/frostdb.(*Table).View(0xc0134e88c0?, 0x374e4d5?)
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/table.go:284 +0x29
github.com/polarsignals/frostdb/query/physicalplan.(*TableScan).Execute(0xc00f40a5a0, {0x4209b08?, 0xc0089ced20}, {0x41fc6f8?, 0x5e4c638})
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/query/physicalplan/physicalplan.go:73 +0x131
github.com/polarsignals/frostdb/query/physicalplan.(*OutputPlan).Execute(...)
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/query/physicalplan/physicalplan.go:58
github.com/polarsignals/frostdb/query.LocalQueryBuilder.Execute({{0x41fc6f8?, 0x5e4c638?}, {0xc0134e8840?}}, {0x4209b08, 0xc0089ced20}, 0xc012cd1310)
	/home/javierhonduco/go/pkg/mod/github.com/polarsignals/frostdb@v0.0.0-20220704101541-debb3561639d/query/engine.go:111 +0x115
github.com/parca-dev/parca/pkg/query.(*ColumnQueryAPI).Values(0xc0000ac4b0, {0x4209b08, 0xc0089ced20}, 0xc012cd1160?)
	/home/javierhonduco/code/parca/pkg/query/columnquery.go:127 +0x1a8
github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1._QueryService_Values_Handler.func1({0x4209b08, 0xc0089ced20}, {0x357c360?, 0xc00115ce40})
	/home/javierhonduco/code/parca/gen/proto/go/parca/query/v1alpha1/query_vtproto.pb.go:271 +0x78
github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors.UnaryServerInterceptor.func1({0x4209b08, 0xc0089ced20}, {0x357c360, 0xc00115ce40}, 0x0?, 0xc01e14c300)
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.0.0-rc.2.0.20201207153454-9f6bf00c00a7/interceptors/server.go:22 +0x21e
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x4209b08?, 0xc0089ced20?}, {0x357c360?, 0xc00115ce40?})
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1({0x4209b08, 0xc0089ced20}, {0x357c360, 0xc00115ce40}, 0x0?, 0xc00f40a4a0)
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0x87
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x4209b08?, 0xc0089ced20?}, {0x357c360?, 0xc00115ce40?})
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1({0x4209b08, 0xc0089ce810}, {0x357c360, 0xc00115ce40}, 0xc00f40a440, 0xc00f40a4c0)
	/home/javierhonduco/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.32.0/interceptor.go:325 +0x664
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1({0x4209b08?, 0xc0089ce810?}, {0x357c360?, 0xc00115ce40?})
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:25 +0x3a
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1({0x4209b08, 0xc0089ce810}, {0x357c360, 0xc00115ce40}, 0xc0089a2af0?, 0x30ac120?)
	/home/javierhonduco/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/chain.go:34 +0xbf
github.com/parca-dev/parca/gen/proto/go/parca/query/v1alpha1._QueryService_Values_Handler({0x358c700?, 0xc0000ac4b0}, {0x4209b08, 0xc0089ce810}, 0xc00115ccc0, 0xc0000d6f90)
	/home/javierhonduco/code/parca/gen/proto/go/parca/query/v1alpha1/query_vtproto.pb.go:273 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc001466fc0, {0x42181c0, 0xc01385e1b0}, 0xc0200c5320, 0xc0002c39b0, 0x5dec3f8, 0x0)
	/home/javierhonduco/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1283 +0xcfd
google.golang.org/grpc.(*Server).handleStream(0xc001466fc0, {0x42181c0, 0xc01385e1b0}, 0xc0200c5320, 0x0)
	/home/javierhonduco/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:1620 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/home/javierhonduco/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:922 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/home/javierhonduco/go/pkg/mod/google.golang.org/grpc@v1.47.0/server.go:920 +0x28a
```

We believe that this is due to the filter not being able to find any column with this name.

## Test plan
```
[javierhonduco@computer frostdb]$ go test .
ok  	github.com/polarsignals/frostdb	(cached)
```

With Parca Agent rebased off system-wide:

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/959128/177562900-57b22c34-4e63-48d5-8f6b-0f8c566a31a9.png">
