### PR TITLE
Fix dynamic schema scan

### DIFF
--- a/table.go
+++ b/table.go
@@ -420,7 +420,11 @@ func (t *Table) SchemaIterator(
 			parquetFields := rg.Schema().Fields()
 			fieldNames := make([]string, 0, len(parquetFields))
 			for _, f := range parquetFields {
-				fieldNames = append(fieldNames, f.Name())
+				for _, p := range projections {
+					if p.Match(f.Name()) {
+						fieldNames = append(fieldNames, f.Name())
+					}
+				}
 			}
 
 			b.Field(0).(*array.StringBuilder).AppendValues(fieldNames, nil)


### PR DESCRIPTION
What if we had schema scans actually build a schema instead of returning a single column of `name`?

This allows us to do things like schema scans with dynamic projections since our query behavior is based on column names. Otherwise to support something like this we'd need to have each expr know if it's apart of a schema scan to behave differently.