### PR TITLE
Optimize combined distinct queries

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -158,7 +158,7 @@ func TestDBWithWAL(t *testing.T) {
 
 	pool := memory.NewGoAllocator()
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -168,6 +168,7 @@ func TestDBWithWAL(t *testing.T) {
 			tx,
 			pool,
 			as,
+			nil,
 			nil,
 			nil,
 			nil,

--- a/distinct_test.go
+++ b/distinct_test.go
@@ -202,7 +202,7 @@ func TestDistinctProjectionAlwaysTrue(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Release()
 
-	//t.Log(r)
+	// t.Log(r)
 	require.Equal(t, int64(3), r.NumCols())
 	require.Equal(t, int64(1), r.NumRows())
 }
@@ -276,7 +276,7 @@ func TestDistinctProjectionAlwaysFalse(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Release()
 
-	//t.Log(r)
+	// t.Log(r)
 	require.Equal(t, int64(3), r.NumCols())
 	require.Equal(t, int64(1), r.NumRows())
 }
@@ -372,7 +372,7 @@ func TestDistinctProjectionMixedBinaryProjection(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Release()
 
-	//t.Log(r)
+	// t.Log(r)
 	require.Equal(t, int64(3), r.NumCols())
 	require.Equal(t, int64(2), r.NumRows())
 }

--- a/pqarrow/arrow_test.go
+++ b/pqarrow/arrow_test.go
@@ -2,14 +2,17 @@ package pqarrow
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/google/uuid"
+	"github.com/segmentio/parquet-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 func TestMergeToArrow(t *testing.T) {
@@ -94,7 +97,7 @@ func TestMergeToArrow(t *testing.T) {
 	ctx := context.Background()
 	pool := memory.DefaultAllocator
 
-	as, err := ParquetRowGroupToArrowSchema(ctx, merge, nil, nil, nil)
+	as, err := ParquetRowGroupToArrowSchema(ctx, dynSchema, merge, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, as.Fields(), 8)
 	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.BinaryType{}})
@@ -138,7 +141,7 @@ func BenchmarkParquetToArrow(b *testing.B) {
 	ctx := context.Background()
 	pool := memory.NewGoAllocator()
 
-	schema, err := ParquetRowGroupToArrowSchema(ctx, buf, nil, nil, nil)
+	schema, err := ParquetRowGroupToArrowSchema(ctx, dynSchema, buf, nil, nil, nil, nil)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -154,4 +157,139 @@ func BenchmarkParquetToArrow(b *testing.B) {
 		)
 		require.NoError(b, err)
 	}
+}
+
+type minMax struct {
+	min parquet.Value
+	max parquet.Value
+}
+
+type fakeIndex struct {
+	minMax []minMax
+}
+
+func (i *fakeIndex) NumPages() int              { return len(i.minMax) }
+func (i *fakeIndex) NullCount(int) int64        { return 0 }
+func (i *fakeIndex) NullPage(int) bool          { return false }
+func (i *fakeIndex) MinValue(int) parquet.Value { return i.minMax[0].min }
+func (i *fakeIndex) MaxValue(int) parquet.Value { return i.minMax[0].max }
+func (i *fakeIndex) IsAscending() bool          { return false }
+func (i *fakeIndex) IsDescending() bool         { return false }
+
+func TestAllOrNoneGreaterThan(t *testing.T) {
+	typ := parquet.Int(64).Type()
+	cases := []struct {
+		name            string
+		value           parquet.Value
+		minMax          []minMax
+		allGreaterThan  bool
+		noneGreaterThan bool
+	}{{
+		name: "all_greater",
+		minMax: []minMax{
+			{parquet.ValueOf(int64(1)), parquet.ValueOf(int64(2))},
+			{parquet.ValueOf(int64(3)), parquet.ValueOf(int64(4))},
+		},
+		value:           parquet.ValueOf(int64(0)),
+		allGreaterThan:  true,
+		noneGreaterThan: false,
+	}, {
+		name: "none_greater",
+		minMax: []minMax{
+			{parquet.ValueOf(int64(1)), parquet.ValueOf(int64(2))},
+			{parquet.ValueOf(int64(3)), parquet.ValueOf(int64(4))},
+		},
+		value:           parquet.ValueOf(int64(5)),
+		allGreaterThan:  false,
+		noneGreaterThan: true,
+	}, {
+		name: "equal",
+		minMax: []minMax{
+			{parquet.ValueOf(int64(0)), parquet.ValueOf(int64(0))},
+			{parquet.ValueOf(int64(0)), parquet.ValueOf(int64(0))},
+		},
+		value:           parquet.ValueOf(int64(0)),
+		allGreaterThan:  false,
+		noneGreaterThan: true,
+	}, {
+		name: "middle",
+		minMax: []minMax{
+			{parquet.ValueOf(int64(1)), parquet.ValueOf(int64(2))},
+			{parquet.ValueOf(int64(3)), parquet.ValueOf(int64(4))},
+		},
+		value:           parquet.ValueOf(int64(3)),
+		allGreaterThan:  false,
+		noneGreaterThan: true,
+	}}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("%v", c.value), func(t *testing.T) {
+			index := &fakeIndex{minMax: c.minMax}
+			allGreaterThan, noneGreaterThan := allOrNoneGreaterThan(typ, index, c.value)
+			require.Equal(t, c.allGreaterThan, allGreaterThan)
+			require.Equal(t, c.noneGreaterThan, noneGreaterThan)
+		})
+	}
+}
+
+func TestDistinctBinaryExprOptimization(t *testing.T) {
+	dynSchema := dynparquet.NewSampleSchema()
+
+	samples := dynparquet.Samples{{
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 1,
+		Value:     1,
+	}, {
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 2,
+		Value:     2,
+	}}
+
+	buf, err := samples.ToBuffer(dynSchema)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	distinctColumns := []logicalplan.Expr{
+		logicalplan.Col("example_type"),
+		logicalplan.Col("timestamp").GT(logicalplan.Literal(int64(0))),
+	}
+	as, err := ParquetRowGroupToArrowSchema(
+		ctx,
+		dynSchema,
+		buf,
+		[]logicalplan.ColumnMatcher{
+			logicalplan.Col("example_type"),
+			logicalplan.Col("timestamp"),
+		},
+		nil,
+		nil,
+		distinctColumns,
+	)
+	require.NoError(t, err)
+	require.Len(t, as.Fields(), 3)
+	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.BinaryType{}})
+	require.Equal(t, as.Field(1), arrow.Field{Name: "timestamp", Type: &arrow.Int64Type{}})
+	require.Equal(t, as.Field(2), arrow.Field{Name: "timestamp > 0", Type: &arrow.BooleanType{}, Nullable: true})
+
+	pool := memory.DefaultAllocator
+	ar, err := ParquetRowGroupToArrowRecord(ctx, pool, buf, as, nil, distinctColumns)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), ar.NumRows())
+	require.Equal(t, int64(3), ar.NumCols())
+	require.Len(t, ar.Schema().Fields(), 3)
 }

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -1,0 +1,27 @@
+package pqarrow
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/scalar"
+	"github.com/segmentio/parquet-go"
+)
+
+func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
+	switch s := sc.(type) {
+	case *scalar.String:
+		return parquet.ValueOf(string(s.Data())), nil
+	case *scalar.Int64:
+		return parquet.ValueOf(s.Value), nil
+	case *scalar.FixedSizeBinary:
+		width := s.Type.(*arrow.FixedSizeBinaryType).ByteWidth
+		v := [16]byte{}
+		copy(v[:width], s.Data())
+		return parquet.ValueOf(v), nil
+	case nil:
+		return parquet.Value{}, nil
+	default:
+		return parquet.Value{}, fmt.Errorf("unsupported scalar type %T", s)
+	}
+}

--- a/query/logicalplan/builder_test.go
+++ b/query/logicalplan/builder_test.go
@@ -66,7 +66,7 @@ func TestLogicalPlanBuilderWithoutProjection(t *testing.T) {
 
 	require.Equal(t, &LogicalPlan{
 		Distinct: &Distinct{
-			Columns: []Expr{&Column{ColumnName: "labels.test"}},
+			Exprs: []Expr{&Column{ColumnName: "labels.test"}},
 		},
 		Input: &LogicalPlan{
 			TableScan: &TableScan{

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -108,27 +108,30 @@ type TableReader interface {
 		tx uint64,
 		pool memory.Allocator,
 		schema *arrow.Schema,
-		projection []ColumnMatcher,
+		physicalProjection []ColumnMatcher,
+		projection []Expr,
 		filter Expr,
-		distinctColumns []ColumnMatcher,
+		distinctColumns []Expr,
 		callback func(r arrow.Record) error,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		projection []ColumnMatcher,
+		physicalProjection []ColumnMatcher,
+		projection []Expr,
 		filter Expr,
-		distinctColumns []ColumnMatcher,
+		distinctColumns []Expr,
 		callback func(r arrow.Record) error,
 	) error
 	ArrowSchema(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		projection []ColumnMatcher,
+		physicalProjection []ColumnMatcher,
+		projection []Expr,
 		filter Expr, // TODO: We probably don't need this
-		distinctColumns []ColumnMatcher,
+		distinctColumns []Expr,
 	) (*arrow.Schema, error)
 	Schema() *dynparquet.Schema
 }
@@ -141,16 +144,19 @@ type TableScan struct {
 	TableProvider TableProvider
 	TableName     string
 
-	// Projection in this case means the columns that are to be read by the
-	// table scan.
-	Projection []ColumnMatcher
+	// PhysicalProjection describes the columns that are to be physically read
+	// by the table scan.
+	PhysicalProjection []ColumnMatcher
 
 	// Filter is the predicate that is to be applied by the table scan to rule
 	// out any blocks of data to be scanned at all.
 	Filter Expr
 
 	// Distinct describes the columns that are to be distinct.
-	Distinct []ColumnMatcher
+	Distinct []Expr
+
+	// Projection is the list of columns that are to be projected.
+	Projection []Expr
 }
 
 func (scan *TableScan) String() string {
@@ -165,16 +171,19 @@ type SchemaScan struct {
 	TableProvider TableProvider
 	TableName     string
 
-	// projection in this case means the columns that are to be read by the
-	// table scan.
-	Projection []ColumnMatcher
+	// PhysicalProjection describes the columns that are to be physically read
+	// by the table scan.
+	PhysicalProjection []ColumnMatcher
 
 	// filter is the predicate that is to be applied by the table scan to rule
 	// out any blocks of data to be scanned at all.
 	Filter Expr
 
 	// Distinct describes the columns that are to be distinct.
-	Distinct []ColumnMatcher
+	Distinct []Expr
+
+	// Projection is the list of columns that are to be projected.
+	Projection []Expr
 }
 
 func (s *SchemaScan) String() string {
@@ -224,7 +233,7 @@ func (f *Filter) String() string {
 }
 
 type Distinct struct {
-	Columns []Expr
+	Exprs []Expr
 }
 
 func (d *Distinct) String() string {

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -28,9 +28,10 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	projection []ColumnMatcher,
+	physicalProjection []ColumnMatcher,
+	projection []Expr,
 	filter Expr,
-	distinctColumns []ColumnMatcher,
+	distinctColumns []Expr,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -40,9 +41,10 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	projection []ColumnMatcher,
+	physicalProjection []ColumnMatcher,
+	projection []Expr,
 	filter Expr,
-	distinctColumns []ColumnMatcher,
+	distinctColumns []Expr,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -52,9 +54,10 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	projection []ColumnMatcher,
+	physicalProjection []ColumnMatcher,
+	projection []Expr,
 	filter Expr,
-	distinctColumns []ColumnMatcher,
+	distinctColumns []Expr,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }

--- a/query/logicalplan/optimize_test.go
+++ b/query/logicalplan/optimize_test.go
@@ -31,11 +31,11 @@ func TestOptimizePhysicalProjectionPushDown(t *testing.T) {
 		// duplicates because the statements just add the matchers for the
 		// columns they access. The optimizer could potentially deduplicate or
 		// use a more efficient datastructure in the future.
-		Projection: []ColumnMatcher{
-			StaticColumnMatcher{ColumnName: "stacktrace"},
-			StaticColumnMatcher{ColumnName: "stacktrace"},
-			StaticColumnMatcher{ColumnName: "value"},
-			StaticColumnMatcher{ColumnName: "labels.test"},
+		PhysicalProjection: []ColumnMatcher{
+			&Column{ColumnName: "stacktrace"},
+			&Column{ColumnName: "stacktrace"},
+			&Column{ColumnName: "value"},
+			&Column{ColumnName: "labels.test"},
 		},
 	},
 		// Projection -> Aggregate -> Filter -> TableScan
@@ -54,8 +54,8 @@ func TestOptimizeDistinctPushDown(t *testing.T) {
 
 	require.Equal(t, &TableScan{
 		TableName: "table1",
-		Distinct: []ColumnMatcher{
-			StaticColumnMatcher{ColumnName: "labels.test"},
+		Distinct: []Expr{
+			&Column{ColumnName: "labels.test"},
 		},
 	},
 		// Distinct -> TableScan
@@ -200,11 +200,11 @@ func TestAllOptimizers(t *testing.T) {
 		// duplicates because the statements just add the matchers for the
 		// columns they access. The optimizer could potentially deduplicate or
 		// use a more efficient datastructure in the future.
-		Projection: []ColumnMatcher{
-			StaticColumnMatcher{ColumnName: "stacktrace"},
-			StaticColumnMatcher{ColumnName: "stacktrace"},
-			StaticColumnMatcher{ColumnName: "value"},
-			StaticColumnMatcher{ColumnName: "labels.test"},
+		PhysicalProjection: []ColumnMatcher{
+			&Column{ColumnName: "stacktrace"},
+			&Column{ColumnName: "stacktrace"},
+			&Column{ColumnName: "value"},
+			&Column{ColumnName: "labels.test"},
 		},
 		Filter: &BinaryExpr{
 			Left: &Column{ColumnName: "labels.test"},

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -15,14 +15,14 @@ import (
 type Distinction struct {
 	pool     memory.Allocator
 	next     func(r arrow.Record) error
-	columns  []logicalplan.ColumnMatcher
+	columns  []logicalplan.Expr
 	hashSeed maphash.Seed
 
 	mtx  *sync.RWMutex
 	seen map[uint64]struct{}
 }
 
-func Distinct(pool memory.Allocator, columns []logicalplan.ColumnMatcher) *Distinction {
+func Distinct(pool memory.Allocator, columns []logicalplan.Expr) *Distinction {
 	return &Distinction{
 		pool:     pool,
 		columns:  columns,
@@ -44,7 +44,7 @@ func (d *Distinction) Callback(r arrow.Record) error {
 
 	for i, field := range r.Schema().Fields() {
 		for _, col := range d.columns {
-			if col.Match(field.Name) {
+			if col.MatchColumn(field.Name) {
 				distinctFields = append(distinctFields, field)
 				distinctFieldHashes = append(distinctFieldHashes, scalar.Hash(d.hashSeed, scalar.NewStringScalar(field.Name)))
 				distinctArrays = append(distinctArrays, r.Column(i))

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -75,6 +75,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
+			s.options.PhysicalProjection,
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
@@ -88,6 +89,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			tx,
 			pool,
 			schema,
+			s.options.PhysicalProjection,
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
@@ -117,6 +119,7 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
+			s.options.PhysicalProjection,
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
@@ -158,12 +161,7 @@ func Build(pool memory.Allocator, s *dynparquet.Schema, plan *logicalplan.Logica
 		case plan.Projection != nil:
 			phyPlan, err = Project(pool, plan.Projection.Exprs)
 		case plan.Distinct != nil:
-			matchers := make([]logicalplan.ColumnMatcher, 0, len(plan.Distinct.Columns))
-			for _, col := range plan.Distinct.Columns {
-				matchers = append(matchers, col.Matcher())
-			}
-
-			phyPlan = Distinct(pool, matchers)
+			phyPlan = Distinct(pool, plan.Distinct.Exprs)
 		case plan.Filter != nil:
 			phyPlan, err = Filter(pool, plan.Filter.Expr)
 		case plan.Aggregation != nil:

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -29,9 +29,10 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	projection []logicalplan.ColumnMatcher,
+	physicalProjection []logicalplan.ColumnMatcher,
+	projection []logicalplan.Expr,
 	filter logicalplan.Expr,
-	distinctColumns []logicalplan.ColumnMatcher,
+	distinctColumns []logicalplan.Expr,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -41,9 +42,10 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	projection []logicalplan.ColumnMatcher,
+	physicalProjection []logicalplan.ColumnMatcher,
+	projection []logicalplan.Expr,
 	filter logicalplan.Expr,
-	distinctColumns []logicalplan.ColumnMatcher,
+	distinctColumns []logicalplan.Expr,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -53,9 +55,10 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	projection []logicalplan.ColumnMatcher,
+	physicalProjection []logicalplan.ColumnMatcher,
+	projection []logicalplan.Expr,
 	filter logicalplan.Expr,
-	distinctColumns []logicalplan.ColumnMatcher,
+	distinctColumns []logicalplan.Expr,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }

--- a/table_test.go
+++ b/table_test.go
@@ -173,7 +173,7 @@ func TestTable(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -183,6 +183,7 @@ func TestTable(t *testing.T) {
 			tx,
 			pool,
 			as,
+			nil,
 			nil,
 			nil,
 			nil,
@@ -320,12 +321,12 @@ func Test_Table_GranuleSplit(t *testing.T) {
 
 	err = table.View(func(tx uint64) error {
 		pool := memory.NewGoAllocator()
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(r arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(r arrow.Record) error {
 			defer r.Release()
 			t.Log(r)
 			return nil
@@ -472,12 +473,12 @@ func Test_Table_InsertLowest(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(r arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(r arrow.Record) error {
 			defer r.Release()
 			t.Log(r)
 			return nil
@@ -574,12 +575,12 @@ func Test_Table_Concurrency(t *testing.T) {
 			err := table.View(func(tx uint64) error {
 				totalrows := int64(0)
 
-				as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+				as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 				if err != nil {
 					return err
 				}
 
-				err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+				err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 					totalrows += ar.NumRows()
 					defer ar.Release()
 
@@ -702,11 +703,11 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 		// Calculate the number of entries in database
 		totalrows := int64(0)
 		err = table.View(func(tx uint64) error {
-			as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+			as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 			if err != nil {
 				return err
 			}
-			return table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+			return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 				defer ar.Release()
 				totalrows += ar.NumRows()
 
@@ -798,11 +799,11 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		rows := int64(0)
-		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 			rows += ar.NumRows()
 			defer ar.Release()
 
@@ -819,11 +820,11 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	table.db.highWatermark.Store(3)
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		require.NoError(t, err)
 
 		rows := int64(0)
-		err = table.Iterator(ctx, table.db.highWatermark.Load(), pool, as, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, table.db.highWatermark.Load(), pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 			rows += ar.NumRows()
 			defer ar.Release()
 
@@ -1149,12 +1150,12 @@ func Test_Table_Filter(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		iterated := false
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		err = table.Iterator(ctx, tx, pool, as, nil, filterExpr, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, nil, nil, filterExpr, nil, func(ar arrow.Record) error {
 			defer ar.Release()
 
 			iterated = true
@@ -1256,12 +1257,12 @@ func Test_Table_InsertCancellation(t *testing.T) {
 			err := table.View(func(tx uint64) error {
 				totalrows := int64(0)
 
-				as, err := table.ArrowSchema(context.Background(), tx, pool, nil, nil, nil)
+				as, err := table.ArrowSchema(context.Background(), tx, pool, nil, nil, nil, nil)
 				if err != nil {
 					return err
 				}
 
-				err = table.Iterator(context.Background(), tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+				err = table.Iterator(context.Background(), tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 					totalrows += ar.NumRows()
 					defer ar.Release()
 
@@ -1332,12 +1333,12 @@ func Test_Table_CancelBasic(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		totalrows := int64(0)
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 			totalrows += ar.NumRows()
 			defer ar.Release()
 
@@ -1402,7 +1403,7 @@ func Test_Table_ArrowSchema(t *testing.T) {
 	// because transaction 1 is just the new block creation, therefore there
 	// would be no schema to read (schemas only materialize when data is
 	// inserted).
-	schema, err := table.ArrowSchema(ctx, 2, pool, nil, nil, nil)
+	schema, err := table.ArrowSchema(ctx, 2, pool, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.Len(t, schema.Fields(), 6)
@@ -1438,7 +1439,7 @@ func Test_Table_ArrowSchema(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			nil, nil, nil,
+			nil, nil, nil, nil,
 		)
 		require.NoError(t, err)
 
@@ -1477,10 +1478,10 @@ func Test_Table_ArrowSchema(t *testing.T) {
 			tx,
 			pool,
 			[]logicalplan.ColumnMatcher{
-				logicalplan.DynamicColumnMatcher{ColumnName: "labels"},
-				logicalplan.StaticColumnMatcher{ColumnName: "value"},
+				&logicalplan.DynamicColumn{ColumnName: "labels"},
+				&logicalplan.Column{ColumnName: "value"},
 			},
-			nil, nil,
+			nil, nil, nil,
 		)
 		require.NoError(t, err)
 
@@ -1568,12 +1569,12 @@ func Test_DoubleTable(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		pool := memory.NewGoAllocator()
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, func(ar arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
 			defer ar.Release()
 			require.Equal(t, value, ar.Column(1).(*array.Float64).Value(0))
 			return nil


### PR DESCRIPTION
1) [Optimize distinct queries with single value per rowgroup](https://github.com/polarsignals/frostdb/commit/ce1959ed7e64d06d240400dd256315b49a546090):
Gathering distinct values of (non optional) dictionary encoded columns
is a constant operation per rowgroup when the dictionary only has a
single value. Additionally distinct projections using binary expressions
such as `timestamp > 0` can be determined without loading the row if the
column index has sufficient data. For example when the index notes that
all timestamps are between 5 and 8, then all values for `timestamp > 0`
are true, and therefore true for any distinct values in the rowgroup.

2) [pqarrow: Optimize distinct where all but one column are single value](https://github.com/polarsignals/frostdb/commit/872f3fcffed60a17989f579203c7a617e576e168):
When all but one column have only a single value, then the whole
rowgroup does not have to be scanned as the possible combination of
distinct values are the non-single column values combined with all
single value columns.