### PR TITLE
update parquet-go: modify nilPage Data method to return encoding.Values

### DIFF
--- a/dynparquet/nil_chunk.go
+++ b/dynparquet/nil_chunk.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/segmentio/parquet-go"
+	"github.com/segmentio/parquet-go/encoding"
 )
 
 // NilColumnChunk is a column chunk that contains a single page with all null
@@ -228,7 +229,7 @@ func (p *nilPage) Slice(i, j int64) parquet.BufferedPage {
 // Data is unimplemented, since the page is virtual and does not need to be
 // written in its current usage in this package. If that changes this method
 // needs to be implemented. Implements the parquet.BufferedPage interface.
-func (p *nilPage) Data() []byte {
+func (p *nilPage) Data() encoding.Values {
 	panic("not implemented")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.12.2
-	github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf
+	github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220715165016-ce338803bc1e
 	github.com/tidwall/wal v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/segmentio/parquet-go v0.0.0-20220713215308-e2be471e1d7b h1:Ejstj1ited
 github.com/segmentio/parquet-go v0.0.0-20220713215308-e2be471e1d7b/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf h1:5yLngjz3nAomA1BbuHoRdPaCSsmy2RP2n+KF2Ew+VUs=
 github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
+github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This PR adapts FrostDB to the changes introduced in https://github.com/segmentio/parquet-go/pull/289