### PR TITLE
*: Add support for `Or` expressions

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -157,6 +157,44 @@ func TestFilter(t *testing.T) {
 			filterExpr: logicalplan.Col("labels.label1").RegexMatch("values."),
 			rows:       0,
 		},
+		"== string or == string": {
+			filterExpr: logicalplan.Or(
+				logicalplan.Col("labels.label1").Eq(logicalplan.Literal("value1")),
+				logicalplan.Col("labels.label1").Eq(logicalplan.Literal("value2")),
+			),
+			cols: 6,
+			rows: 2,
+		},
+		"regexp or == missing column": {
+			filterExpr: logicalplan.Or(
+				logicalplan.Col("labels.label1").RegexMatch("value."),
+				logicalplan.Col("labels.label5").Eq(logicalplan.Literal("")),
+			),
+			cols: 7,
+			rows: 3,
+		},
+		"regexp and (== string or == string)": {
+			filterExpr: logicalplan.And(
+				logicalplan.Col("labels.label3").RegexMatch("value."),
+				logicalplan.Or(
+					logicalplan.Col("labels.label1").Eq(logicalplan.Literal("value1")),
+					logicalplan.Col("labels.label1").Eq(logicalplan.Literal("value2")),
+				),
+			),
+			cols: 6,
+			rows: 1,
+		},
+		"== string or (regexp and == string)": {
+			filterExpr: logicalplan.Or(
+				logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4")),
+				logicalplan.And(
+					logicalplan.Col("labels.label2").RegexMatch("value."),
+					logicalplan.Col("labels.label1").Eq(logicalplan.Literal("value2")),
+				),
+			),
+			cols: 7,
+			rows: 2,
+		},
 	}
 
 	engine := query.NewEngine(

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -24,6 +24,7 @@ const (
 	OpRegexMatch
 	OpRegexNotMatch
 	OpAnd
+	OpOr
 )
 
 func (o Op) String() string {
@@ -46,6 +47,8 @@ func (o Op) String() string {
 		return "!~"
 	case OpAnd:
 		return "&&"
+	case OpOr:
+		return "||"
 	default:
 		panic("unknown operator")
 	}
@@ -240,6 +243,39 @@ func and(exprs []Expr) Expr {
 		Left:  nonNilExprs[0],
 		Op:    OpAnd,
 		Right: and(nonNilExprs[1:]),
+	}
+}
+
+func Or(exprs ...Expr) Expr {
+	return or(exprs)
+}
+
+func or(exprs []Expr) Expr {
+	nonNilExprs := make([]Expr, 0, len(exprs))
+	for _, expr := range exprs {
+		if expr != nil {
+			nonNilExprs = append(nonNilExprs, expr)
+		}
+	}
+
+	if len(nonNilExprs) == 0 {
+		return nil
+	}
+	if len(nonNilExprs) == 1 {
+		return nonNilExprs[0]
+	}
+	if len(nonNilExprs) == 2 {
+		return &BinaryExpr{
+			Left:  nonNilExprs[0],
+			Op:    OpOr,
+			Right: nonNilExprs[1],
+		}
+	}
+
+	return &BinaryExpr{
+		Left:  nonNilExprs[0],
+		Op:    OpOr,
+		Right: or(nonNilExprs[1:]),
 	}
 }
 

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -218,32 +218,7 @@ func And(exprs ...Expr) Expr {
 }
 
 func and(exprs []Expr) Expr {
-	nonNilExprs := make([]Expr, 0, len(exprs))
-	for _, expr := range exprs {
-		if expr != nil {
-			nonNilExprs = append(nonNilExprs, expr)
-		}
-	}
-
-	if len(nonNilExprs) == 0 {
-		return nil
-	}
-	if len(nonNilExprs) == 1 {
-		return nonNilExprs[0]
-	}
-	if len(nonNilExprs) == 2 {
-		return &BinaryExpr{
-			Left:  nonNilExprs[0],
-			Op:    OpAnd,
-			Right: nonNilExprs[1],
-		}
-	}
-
-	return &BinaryExpr{
-		Left:  nonNilExprs[0],
-		Op:    OpAnd,
-		Right: and(nonNilExprs[1:]),
-	}
+	return computeBinaryExpr(exprs, OpAnd)
 }
 
 func Or(exprs ...Expr) Expr {
@@ -251,6 +226,10 @@ func Or(exprs ...Expr) Expr {
 }
 
 func or(exprs []Expr) Expr {
+	return computeBinaryExpr(exprs, OpOr)
+}
+
+func computeBinaryExpr(exprs []Expr, op Op) Expr {
 	nonNilExprs := make([]Expr, 0, len(exprs))
 	for _, expr := range exprs {
 		if expr != nil {
@@ -267,15 +246,15 @@ func or(exprs []Expr) Expr {
 	if len(nonNilExprs) == 2 {
 		return &BinaryExpr{
 			Left:  nonNilExprs[0],
-			Op:    OpOr,
+			Op:    op,
 			Right: nonNilExprs[1],
 		}
 	}
 
 	return &BinaryExpr{
 		Left:  nonNilExprs[0],
-		Op:    OpOr,
-		Right: or(nonNilExprs[1:]),
+		Op:    op,
+		Right: computeBinaryExpr(nonNilExprs[1:], op),
 	}
 }
 

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -251,7 +251,7 @@ func ValidateFilterExpr(plan *LogicalPlan, e Expr) *ExprValidationError {
 
 // ValidateFilterBinaryExpr validates the filter's binary expression.
 func ValidateFilterBinaryExpr(plan *LogicalPlan, expr *BinaryExpr) *ExprValidationError {
-	if expr.Op == OpAnd {
+	if expr.Op == OpAnd || expr.Op == OpOr {
 		return ValidateFilterAndBinaryExpr(plan, expr)
 	}
 


### PR DESCRIPTION
This change adds support for `Or` expressions, make changes to:
- `logicalplan`
- `physicalplan`

Also modifies the example to demonstrate it.

TODO:
- [x] Add test coverage

Fixes #146 