### PR TITLE
Use block schemas

### DIFF
--- a/db.go
+++ b/db.go
@@ -529,7 +529,6 @@ func (db *DB) Table(name string, config *TableConfig) (*Table, error) {
 		table.config = config
 		delete(db.roTables, name)
 	} else {
-
 		var err error
 		table, err = newTable(
 			db,

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -390,6 +390,14 @@ func (s *Schema) Columns() []ColumnDefinition {
 	return s.columns
 }
 
+func (s *Schema) ParquetSchema() *parquet.Schema {
+	g := parquet.Group{}
+	for _, col := range s.columns {
+		g[col.Name] = col.StorageLayout
+	}
+	return parquet.NewSchema(s.def.Name, g)
+}
+
 // parquetSchema returns the parquet schema for the dynamic schema with the
 // concrete dynamic column names given in the argument.
 func (s Schema) parquetSchema(

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -20,7 +20,6 @@ import (
 // ParquetRowGroupToArrowSchema converts a parquet row group to an arrow schema.
 func ParquetRowGroupToArrowSchema(
 	ctx context.Context,
-	schema *dynparquet.Schema,
 	rg parquet.RowGroup,
 	physicalProjections []logicalplan.Expr,
 	projections []logicalplan.Expr,
@@ -70,7 +69,7 @@ func ParquetRowGroupToArrowSchema(
 
 	for _, distinctExpr := range distinctColumns {
 		if distinctExpr.Computed() {
-			dataType, err := distinctExpr.DataType(schema)
+			dataType, err := distinctExpr.DataType(rg.Schema())
 			if err != nil {
 				return nil, err
 			}

--- a/pqarrow/arrow_test.go
+++ b/pqarrow/arrow_test.go
@@ -97,7 +97,7 @@ func TestMergeToArrow(t *testing.T) {
 	ctx := context.Background()
 	pool := memory.DefaultAllocator
 
-	as, err := ParquetRowGroupToArrowSchema(ctx, dynSchema, merge, nil, nil, nil, nil)
+	as, err := ParquetRowGroupToArrowSchema(ctx, merge, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, as.Fields(), 8)
 	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.BinaryType{}})
@@ -141,7 +141,7 @@ func BenchmarkParquetToArrow(b *testing.B) {
 	ctx := context.Background()
 	pool := memory.NewGoAllocator()
 
-	schema, err := ParquetRowGroupToArrowSchema(ctx, dynSchema, buf, nil, nil, nil, nil)
+	schema, err := ParquetRowGroupToArrowSchema(ctx, buf, nil, nil, nil, nil)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -270,7 +270,6 @@ func TestDistinctBinaryExprOptimization(t *testing.T) {
 	}
 	as, err := ParquetRowGroupToArrowSchema(
 		ctx,
-		dynSchema,
 		buf,
 		[]logicalplan.Expr{
 			logicalplan.Col("example_type"),
@@ -354,7 +353,6 @@ func TestDistinctBinaryExprOptimizationMixed(t *testing.T) {
 	}
 	as, err := ParquetRowGroupToArrowSchema(
 		ctx,
-		dynSchema,
 		buf,
 		[]logicalplan.Expr{
 			logicalplan.Col("example_type"),

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -2,8 +2,7 @@ package logicalplan
 
 import (
 	"github.com/apache/arrow/go/v8/arrow"
-
-	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/segmentio/parquet-go"
 )
 
 type Builder struct {
@@ -57,7 +56,7 @@ type Visitor interface {
 }
 
 type Expr interface {
-	DataType(*dynparquet.Schema) (arrow.DataType, error)
+	DataType(*parquet.Schema) (arrow.DataType, error)
 	Accept(Visitor) bool
 	Name() string
 

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -258,8 +258,10 @@ func DynCol(name string) *DynamicColumn {
 
 func (c *DynamicColumn) DataType(s *parquet.Schema) (arrow.DataType, error) {
 	for _, field := range s.Fields() {
-		if field.Name() == c.ColumnName {
-			return convert.ParquetNodeToType(field)
+		if names := strings.Split(field.Name(), "."); len(names) == 2 {
+			if names[0] == c.ColumnName {
+				return convert.ParquetNodeToType(field)
+			}
 		}
 	}
 

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/scalar"
+	"github.com/segmentio/parquet-go"
 
-	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/pqarrow/convert"
 )
 
@@ -76,7 +76,7 @@ func (e *BinaryExpr) Accept(visitor Visitor) bool {
 	return visitor.PostVisit(e)
 }
 
-func (e *BinaryExpr) DataType(_ *dynparquet.Schema) (arrow.DataType, error) {
+func (e *BinaryExpr) DataType(_ *parquet.Schema) (arrow.DataType, error) {
 	return &arrow.BooleanType{}, nil
 }
 
@@ -121,13 +121,14 @@ func (c *Column) Name() string {
 	return c.ColumnName
 }
 
-func (c *Column) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
-	colDef, found := s.ColumnByName(c.ColumnName)
-	if !found {
-		return nil, errors.New("column not found")
+func (c *Column) DataType(s *parquet.Schema) (arrow.DataType, error) {
+	for _, field := range s.Fields() {
+		if field.Name() == c.ColumnName {
+			return convert.ParquetNodeToType(field)
+		}
 	}
 
-	return convert.ParquetNodeToType(colDef.StorageLayout)
+	return nil, errors.New("column not found")
 }
 
 func (c *Column) Alias(alias string) AliasExpr {
@@ -255,13 +256,14 @@ func DynCol(name string) *DynamicColumn {
 	return &DynamicColumn{ColumnName: name}
 }
 
-func (c *DynamicColumn) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
-	colDef, found := s.ColumnByName(c.ColumnName)
-	if !found {
-		return nil, errors.New("column not found")
+func (c *DynamicColumn) DataType(s *parquet.Schema) (arrow.DataType, error) {
+	for _, field := range s.Fields() {
+		if field.Name() == c.ColumnName {
+			return convert.ParquetNodeToType(field)
+		}
 	}
 
-	return convert.ParquetNodeToType(colDef.StorageLayout)
+	return nil, errors.New("column not found")
 }
 
 func (c *DynamicColumn) ColumnsUsedExprs() []Expr {
@@ -302,7 +304,7 @@ func Literal(v interface{}) *LiteralExpr {
 	}
 }
 
-func (e *LiteralExpr) DataType(_ *dynparquet.Schema) (arrow.DataType, error) {
+func (e *LiteralExpr) DataType(_ *parquet.Schema) (arrow.DataType, error) {
 	return e.Value.DataType(), nil
 }
 
@@ -330,7 +332,7 @@ type AggregationFunction struct {
 	Expr Expr
 }
 
-func (f *AggregationFunction) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
+func (f *AggregationFunction) DataType(s *parquet.Schema) (arrow.DataType, error) {
 	return f.Expr.DataType(s)
 }
 
@@ -392,7 +394,7 @@ type AliasExpr struct {
 	Alias string
 }
 
-func (e *AliasExpr) DataType(s *dynparquet.Schema) (arrow.DataType, error) {
+func (e *AliasExpr) DataType(s *parquet.Schema) (arrow.DataType, error) {
 	return e.Expr.DataType(s)
 }
 

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -11,14 +11,14 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/apache/arrow/go/v8/arrow/scalar"
 	"github.com/dgryski/go-metro"
+	"github.com/segmentio/parquet-go"
 
-	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 func Aggregate(
 	pool memory.Allocator,
-	s *dynparquet.Schema,
+	s *parquet.Schema,
 	agg *logicalplan.Aggregation,
 ) (*HashAggregate, error) {
 	var (

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -164,15 +164,13 @@ func Build(pool memory.Allocator, s *dynparquet.Schema, plan *logicalplan.Logica
 			phyPlan = Distinct(pool, plan.Distinct.Exprs)
 		case plan.Filter != nil:
 			phyPlan, err = Filter(pool, plan.Filter.Expr)
-			/* TODO: how do we get this to be a parquet.Schema?
-			case plan.Aggregation != nil:
-				var agg *HashAggregate
-				agg, err = Aggregate(pool, s, plan.Aggregation)
-				phyPlan = agg
-				if agg != nil {
-					finisher = agg.Finish
-				}
-			*/
+		case plan.Aggregation != nil:
+			var agg *HashAggregate
+			agg, err = Aggregate(pool, s.ParquetSchema(), plan.Aggregation)
+			phyPlan = agg
+			if agg != nil {
+				finisher = agg.Finish
+			}
 		default:
 			panic("Unsupported plan")
 		}

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -164,13 +164,15 @@ func Build(pool memory.Allocator, s *dynparquet.Schema, plan *logicalplan.Logica
 			phyPlan = Distinct(pool, plan.Distinct.Exprs)
 		case plan.Filter != nil:
 			phyPlan, err = Filter(pool, plan.Filter.Expr)
-		case plan.Aggregation != nil:
-			var agg *HashAggregate
-			agg, err = Aggregate(pool, s, plan.Aggregation)
-			phyPlan = agg
-			if agg != nil {
-				finisher = agg.Finish
-			}
+			/* TODO: how do we get this to be a parquet.Schema?
+			case plan.Aggregation != nil:
+				var agg *HashAggregate
+				agg, err = Aggregate(pool, s, plan.Aggregation)
+				phyPlan = agg
+				if agg != nil {
+					finisher = agg.Finish
+				}
+			*/
 		default:
 			panic("Unsupported plan")
 		}

--- a/store.go
+++ b/store.go
@@ -40,7 +40,7 @@ func (t *Table) IterateBucketBlocks(ctx context.Context, logger log.Logger, filt
 			return err
 		}
 
-		if blockUlid.Time() >= lastBlockTimestamp {
+		if lastBlockTimestamp != 0 && blockUlid.Time() >= lastBlockTimestamp {
 			return nil
 		}
 

--- a/table.go
+++ b/table.go
@@ -454,7 +454,6 @@ func (t *Table) Iterator(
 			if schema == nil {
 				schema, err = pqarrow.ParquetRowGroupToArrowSchema(
 					ctx,
-					t.config.schema,
 					rg,
 					physicalProjections,
 					projections,
@@ -567,7 +566,6 @@ func (t *Table) ArrowSchema(
 		default:
 			schema, err := pqarrow.ParquetRowGroupToArrowSchema(
 				ctx,
-				t.config.schema,
 				rg,
 				physicalProjections,
 				projections,

--- a/table.go
+++ b/table.go
@@ -338,6 +338,9 @@ func (t *Table) ActiveWriteBlock() (*TableBlock, func()) {
 }
 
 func (t *Table) Schema() *dynparquet.Schema {
+	if t.config == nil {
+		return nil
+	}
 	return t.config.schema
 }
 
@@ -1323,6 +1326,10 @@ func tombstone(parts []*Part) {
 func (t *Table) memoryBlocks() ([]*TableBlock, uint64) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
+
+	if t.active == nil { // this is currently a read only table
+		return nil, 0
+	}
 
 	lastReadBlockTimestamp := t.active.ulid.Time()
 	memoryBlocks := []*TableBlock{t.active}


### PR DESCRIPTION
This obviates the need for the changes in #153 

- On `db.DB()` we'll now scan storage for table names, and open up read only tables for the discovered databases, allowing us to perform reads against those tables. 
- No longer use the table schema during queries, but instead use the row group schema
- on `db.Table()` if discovered we'll move a read only table into an active writable table 