### PR TITLE
Unbuffered storage

### DIFF
--- a/table.go
+++ b/table.go
@@ -1144,7 +1144,7 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 
 	// Iterate over all the row groups, and write them to storage
 	count := 0
-	maxRows := 8096
+	maxRows := 8192
 	j := 0
 	for i, rg := range rowGroups {
 		count += int(rg.NumRows())

--- a/table.go
+++ b/table.go
@@ -1169,7 +1169,7 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 	return nil
 }
 
-// writeRows writes a set of dynamic row groups to a writer
+// writeRows writes a set of dynamic row groups to a writer.
 func (t *TableBlock) writeRows(w *dynparquet.PooledWriter, count int, rowGroups []dynparquet.DynamicRowGroup) error {
 	merged, err := t.table.config.schema.MergeDynamicRowGroups(rowGroups)
 	if err != nil {


### PR DESCRIPTION
This addresses the memory spikes seen in #156 

Instead of accumulating the block in a memory buffer we write it directly to objstore using the io.Pipe.
In addition instead of performing `readRows` on all merged rowgroups which allocates a large buffer of memory to do so, we instead only merged subslices of the rowgroups.

Can see in the screenshot there's no longer a spike in memory as we write to storage
![image](https://user-images.githubusercontent.com/8681572/184701582-defb4c6b-8181-4a22-8493-586246915e1e.png)
