### PR TITLE
logicalplan: add max aggregate function

### DIFF
--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -388,12 +388,15 @@ type AggFunc uint32
 const (
 	AggFuncUnknown AggFunc = iota
 	AggFuncSum
+	AggFuncMax
 )
 
 func (f AggFunc) String() string {
 	switch f {
 	case AggFuncSum:
 		return "sum"
+	case AggFuncMax:
+		return "max"
 	default:
 		panic("unknown aggregation function")
 	}
@@ -402,6 +405,13 @@ func (f AggFunc) String() string {
 func Sum(expr Expr) *AggregationFunction {
 	return &AggregationFunction{
 		Func: AggFuncSum,
+		Expr: expr,
+	}
+}
+
+func Max(expr Expr) *AggregationFunction {
+	return &AggregationFunction{
+		Func: AggFuncMax,
 		Expr: expr,
 	}
 }

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -199,10 +199,18 @@ func ValidateAggregationExpr(plan *LogicalPlan) *ExprValidationError {
 	// check that the column type can be aggregated by the function type
 	columnType := column.StorageLayout.Type()
 	aggFuncExpr := aggFuncFinder.result.(*AggregationFunction)
-	if aggFuncExpr.Func == AggFuncSum && columnType.LogicalType().UTF8 != nil {
-		return &ExprValidationError{
-			message: "cannot sum text column",
-			expr:    plan.Aggregation.AggExpr,
+	if columnType.LogicalType().UTF8 != nil {
+		switch aggFuncExpr.Func {
+		case AggFuncSum:
+			return &ExprValidationError{
+				message: "cannot sum text column",
+				expr:    plan.Aggregation.AggExpr,
+			}
+		case AggFuncMax:
+			return &ExprValidationError{
+				message: "cannot max text column",
+				expr:    plan.Aggregation.AggExpr,
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit adds an aggregate function to find the maximum value of an int64
column. This will be specifically useful to find the latest timestamp to query
over a range in a historical dataset in benchmarks.