### PR TITLE
Fix panic after error

### DIFF
--- a/db.go
+++ b/db.go
@@ -283,7 +283,7 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 
 			return nil
 		}); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("bucket iter on database open: %w", err)
 		}
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -2,6 +2,7 @@ package frostdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -897,7 +898,7 @@ func Test_DB_OpenError(t *testing.T) {
 	db, err := c.DB(context.Background(), "test")
 	require.Error(t, err)
 	require.Nil(t, db)
-	require.Equal(t, tempErr, err)
+	require.True(t, errors.Is(err, tempErr))
 
 	db, err = c.DB(context.Background(), "test")
 	require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -783,7 +783,7 @@ func Test_DB_Filter_Block(t *testing.T) {
 	}
 }
 
-// ErrorBucket is an objstore.Bucket implementation that supports error injection
+// ErrorBucket is an objstore.Bucket implementation that supports error injection.
 type ErrorBucket struct {
 	iter             func(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error
 	get              func(ctx context.Context, name string) (io.ReadCloser, error)


### PR DESCRIPTION
Don't register metrics until opening of the database is complete to avoid duplicate registration panic after an error has occurred.