### PR TITLE
Timestamp hints

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -220,7 +220,7 @@ func TestDBWithWAL(t *testing.T) {
 
 	pool := memory.NewGoAllocator()
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
@@ -230,9 +230,6 @@ func TestDBWithWAL(t *testing.T) {
 			tx,
 			pool,
 			as,
-			nil,
-			nil,
-			nil,
 			nil,
 			func(ar arrow.Record) error {
 				t.Log(ar)

--- a/db_test.go
+++ b/db_test.go
@@ -935,7 +935,7 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			filterExpr:  logicalplan.Col("timestamp").GtEq(logicalplan.Literal(now.Add(-1 * time.Minute).UnixMilli())),
 			projections: []logicalplan.Expr{logicalplan.DynCol("labels")},
 			rows:        3,
-			cols:        5,
+			cols:        2,
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					logger,
@@ -1040,7 +1040,6 @@ func Test_DB_Block_Optimization(t *testing.T) {
 				query = query.Distinct(test.distinct...)
 			}
 			err = query.Execute(context.Background(), func(ar arrow.Record) error {
-				fmt.Println(ar)
 				require.Equal(t, test.rows, ar.NumRows())
 				require.Equal(t, test.cols, ar.NumCols())
 				return nil

--- a/query/engine.go
+++ b/query/engine.go
@@ -38,7 +38,7 @@ func ColAsTimestamp(columnName string) func(*LocalEngine) {
 func NewEngine(
 	pool memory.Allocator,
 	tableProvider logicalplan.TableProvider,
-	hints ...Hint,
+	hints ...Hint, // TODO THOR rename this to optimizer instead
 ) *LocalEngine {
 	return &LocalEngine{
 		pool:          pool,

--- a/query/engine.go
+++ b/query/engine.go
@@ -40,10 +40,16 @@ func NewEngine(
 	tableProvider logicalplan.TableProvider,
 	hints ...Hint, // TODO THOR rename this to optimizer instead
 ) *LocalEngine {
-	return &LocalEngine{
+	e := &LocalEngine{
 		pool:          pool,
 		tableProvider: tableProvider,
 	}
+
+	for _, hint := range hints {
+		hint(e)
+	}
+
+	return e
 }
 
 type LocalQueryBuilder struct {

--- a/query/engine.go
+++ b/query/engine.go
@@ -25,10 +25,10 @@ type LocalEngine struct {
 	optimizations []logicalplan.Optimizer
 }
 
-// Hint is a suggestion to be made to the query engine about how it might optimize the query
+// Hint is a suggestion to be made to the query engine about how it might optimize the query.
 type Hint func(*LocalEngine)
 
-// ColAsTimestamp is a query engine hint that informs the engine which column to use as a timestamp during historical queries
+// ColAsTimestamp is a query engine hint that informs the engine which column to use as a timestamp during historical queries.
 func ColAsTimestamp(columnName string) func(*LocalEngine) {
 	return func(l *LocalEngine) {
 		l.optimizations = append(l.optimizations, logicalplan.TimestampColumnOptimization(columnName))

--- a/query/engine.go
+++ b/query/engine.go
@@ -21,11 +21,24 @@ type Builder interface {
 type LocalEngine struct {
 	pool          memory.Allocator
 	tableProvider logicalplan.TableProvider
+
+	timestampColHint string
+}
+
+// Hint is a suggestion to be made to the query engine about how it might more effectively query
+type Hint func(*LocalEngine)
+
+// ColAsTimestamp is a query engine hint that informs the engine which column to use as a timestamp during historical queries
+func ColAsTimestamp(columnName string) func(*LocalEngine) {
+	return func(l *LocalEngine) {
+		l.timestampColHint = columnName
+	}
 }
 
 func NewEngine(
 	pool memory.Allocator,
 	tableProvider logicalplan.TableProvider,
+	hints ...Hint,
 ) *LocalEngine {
 	return &LocalEngine{
 		pool:          pool,
@@ -41,14 +54,14 @@ type LocalQueryBuilder struct {
 func (e *LocalEngine) ScanTable(name string) Builder {
 	return LocalQueryBuilder{
 		pool:        e.pool,
-		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name),
+		planBuilder: (&logicalplan.Builder{}).Scan(e.tableProvider, name, logicalplan.TableScanColAsTimestamp(e.timestampColHint)),
 	}
 }
 
 func (e *LocalEngine) ScanSchema(name string) Builder {
 	return LocalQueryBuilder{
 		pool:        e.pool,
-		planBuilder: (&logicalplan.Builder{}).ScanSchema(e.tableProvider, name),
+		planBuilder: (&logicalplan.Builder{}).ScanSchema(e.tableProvider, name, logicalplan.SchemaScanColAsTimestamp(e.timestampColHint)),
 	}
 }
 

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -12,13 +12,21 @@ type Builder struct {
 func (b Builder) Scan(
 	provider TableProvider,
 	tableName string,
+	hints ...TableScanHint,
 ) Builder {
+
+	scan := &TableScan{
+		TableProvider: provider,
+		TableName:     tableName,
+	}
+
+	for _, hint := range hints {
+		hint(scan)
+	}
+
 	return Builder{
 		plan: &LogicalPlan{
-			TableScan: &TableScan{
-				TableProvider: provider,
-				TableName:     tableName,
-			},
+			TableScan: scan,
 		},
 	}
 }
@@ -26,13 +34,21 @@ func (b Builder) Scan(
 func (b Builder) ScanSchema(
 	provider TableProvider,
 	tableName string,
+	hints ...SchemaScanHint,
 ) Builder {
+
+	scan := &SchemaScan{
+		TableProvider: provider,
+		TableName:     tableName,
+	}
+
+	for _, hint := range hints {
+		hint(scan)
+	}
+
 	return Builder{
 		plan: &LogicalPlan{
-			SchemaScan: &SchemaScan{
-				TableProvider: provider,
-				TableName:     tableName,
-			},
+			SchemaScan: scan,
 		},
 	}
 }

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -12,21 +12,13 @@ type Builder struct {
 func (b Builder) Scan(
 	provider TableProvider,
 	tableName string,
-	hints ...TableScanHint,
 ) Builder {
-
-	scan := &TableScan{
-		TableProvider: provider,
-		TableName:     tableName,
-	}
-
-	for _, hint := range hints {
-		hint(scan)
-	}
-
 	return Builder{
 		plan: &LogicalPlan{
-			TableScan: scan,
+			TableScan: &TableScan{
+				TableProvider: provider,
+				TableName:     tableName,
+			},
 		},
 	}
 }
@@ -34,21 +26,13 @@ func (b Builder) Scan(
 func (b Builder) ScanSchema(
 	provider TableProvider,
 	tableName string,
-	hints ...SchemaScanHint,
 ) Builder {
-
-	scan := &SchemaScan{
-		TableProvider: provider,
-		TableName:     tableName,
-	}
-
-	for _, hint := range hints {
-		hint(scan)
-	}
-
 	return Builder{
 		plan: &LogicalPlan{
-			SchemaScan: scan,
+			SchemaScan: &SchemaScan{
+				TableProvider: provider,
+				TableName:     tableName,
+			},
 		},
 	}
 }

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -141,14 +141,6 @@ type TableProvider interface {
 	GetTable(name string) TableReader
 }
 
-type TableScanHint func(*TableScan)
-
-func TableScanColAsTimestamp(col string) func(*TableScan) {
-	return func(t *TableScan) {
-		t.ColAsTimestamp = col
-	}
-}
-
 type TableScan struct {
 	TableProvider TableProvider
 	TableName     string
@@ -177,14 +169,6 @@ func (scan *TableScan) String() string {
 		" Projection: " + fmt.Sprint(scan.Projection) +
 		" Filter: " + fmt.Sprint(scan.Filter) +
 		" Distinct: " + fmt.Sprint(scan.Distinct)
-}
-
-type SchemaScanHint func(*SchemaScan)
-
-func SchemaScanColAsTimestamp(col string) func(*SchemaScan) {
-	return func(t *SchemaScan) {
-		t.ColAsTimestamp = col
-	}
 }
 
 type SchemaScan struct {

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -27,6 +27,16 @@ type LogicalPlan struct {
 	Aggregation *Aggregation
 }
 
+// IterOptions are a set of options for the TableReader Iterators
+// TODO: should we instead use the option pattern? Is that possible with the way the Iterator functions work?
+type IterOptions struct {
+	PhysicalProjection []Expr
+	Projection         []Expr
+	Filter             Expr
+	DistinctColumns    []Expr
+	TimestampCol       string
+}
+
 func (plan *LogicalPlan) String() string {
 	return plan.string(0)
 }
@@ -108,33 +118,21 @@ type TableReader interface {
 		tx uint64,
 		pool memory.Allocator,
 		schema *arrow.Schema,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr,
-		distinctColumns []Expr,
-		timestampCol string,
+		options *IterOptions,
 		callback func(r arrow.Record) error,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr,
-		distinctColumns []Expr,
-		timestampCol string,
+		options *IterOptions,
 		callback func(r arrow.Record) error,
 	) error
 	ArrowSchema(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr, // TODO: We probably don't need this
-		distinctColumns []Expr,
-		timestampCol string,
+		options *IterOptions,
 	) (*arrow.Schema, error)
 	Schema() *dynparquet.Schema
 }

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -28,10 +28,7 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts *IterOptions,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -41,10 +38,7 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts *IterOptions,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -54,10 +48,7 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts *IterOptions,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -233,3 +233,23 @@ func (p *DistinctPushDown) optimize(plan *LogicalPlan, distinctColumns []Expr) {
 		p.optimize(plan.Input, distinctColumns)
 	}
 }
+
+// TimestampColumnOptimization will set the name of the column that represents timestamps in the table
+type TimestampColumnOptimization string
+
+// Optimize will perform the timestamp column optimization
+func (t TimestampColumnOptimization) Optimize(plan *LogicalPlan) *LogicalPlan {
+	t.optimize(plan)
+	return plan
+}
+
+func (t TimestampColumnOptimization) optimize(plan *LogicalPlan) {
+	switch {
+	case plan.SchemaScan != nil:
+		plan.SchemaScan.ColAsTimestamp = string(t)
+	case plan.TableScan != nil:
+		plan.TableScan.ColAsTimestamp = string(t)
+	case plan.Input != nil:
+		t.optimize(plan.Input)
+	}
+}

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -234,10 +234,10 @@ func (p *DistinctPushDown) optimize(plan *LogicalPlan, distinctColumns []Expr) {
 	}
 }
 
-// TimestampColumnOptimization will set the name of the column that represents timestamps in the table
+// TimestampColumnOptimization will set the name of the column that represents timestamps in the table.
 type TimestampColumnOptimization string
 
-// Optimize will perform the timestamp column optimization
+// Optimize will perform the timestamp column optimization.
 func (t TimestampColumnOptimization) Optimize(plan *LogicalPlan) *LogicalPlan {
 	t.optimize(plan)
 	return plan

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -79,6 +79,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
+			s.options.ColAsTimestamp,
 		)
 		if err != nil {
 			return err
@@ -93,6 +94,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
+			s.options.ColAsTimestamp,
 			s.next.Callback,
 		)
 	})
@@ -123,6 +125,7 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			s.options.Projection,
 			s.options.Filter,
 			s.options.Distinct,
+			s.options.ColAsTimestamp,
 			s.next.Callback,
 		)
 	})

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -75,11 +75,13 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
-			s.options.ColAsTimestamp,
+			&logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+				TimestampCol:       s.options.ColAsTimestamp,
+			},
 		)
 		if err != nil {
 			return err
@@ -90,11 +92,13 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			tx,
 			pool,
 			schema,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
-			s.options.ColAsTimestamp,
+			&logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+				TimestampCol:       s.options.ColAsTimestamp,
+			},
 			s.next.Callback,
 		)
 	})
@@ -121,11 +125,13 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
-			s.options.ColAsTimestamp,
+			&logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+				TimestampCol:       s.options.ColAsTimestamp,
+			},
 			s.next.Callback,
 		)
 	})

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -29,10 +29,7 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts *logicalplan.IterOptions,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -42,10 +39,7 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts *logicalplan.IterOptions,
 	callback func(r arrow.Record) error,
 ) error {
 	return nil
@@ -55,10 +49,7 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts *logicalplan.IterOptions,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }

--- a/store.go
+++ b/store.go
@@ -78,6 +78,7 @@ func (b *BlockFilter) LastBlockTimestamp(lastBlockTimestamp uint64) *BlockFilter
 
 // TODO
 func (b *BlockFilter) TimestampFilter(timestampCol string, filter logicalplan.Expr) *BlockFilter {
+	fmt.Println("TimestampFilter: ", timestampCol, filter)
 	if timestampCol == "" {
 		return b
 	}
@@ -110,6 +111,8 @@ func (t *Table) IterateBucketBlocks(ctx context.Context, logger log.Logger, bloc
 			return err
 		}
 
+		// TODO THOR NOTE: we can't accurately perform a filter on just a ulid since it doesn't give us a range, it only tells us
+		// the ulid is the beginning of the block, and so the attributes modified at is the ending of the block. So we can know the time range using that
 		if blockFilter.Filter(blockUlid) {
 			return nil
 		}

--- a/store.go
+++ b/store.go
@@ -180,7 +180,6 @@ func (b *BucketReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 
 // compareTimestamp returns true if the block contains timestamps covered in expr
 func compareTimestamp(col string, start, end uint64, expr logicalplan.Expr) (bool, error) {
-	fmt.Println("compareTimestamp: ", col)
 	if expr == nil {
 		return false, nil
 	}
@@ -257,15 +256,12 @@ func compareTimestamp(col string, start, end uint64, expr logicalplan.Expr) (boo
 
 			return end >= v, nil
 		case logicalplan.OpEq:
-			fmt.Println("compareTimestamp OpEq")
-
 			v, err := parseExpr(e)
 			if err != nil {
 				return false, err
 			}
 
 			return v >= start && v <= end, nil
-
 		case logicalplan.OpAnd:
 			left, err := compareTimestamp(col, start, end, e.Left)
 			if err != nil {

--- a/table.go
+++ b/table.go
@@ -1401,7 +1401,9 @@ func (t *Table) collectRowGroups(ctx context.Context, tx uint64, filterExpr logi
 		}
 	}
 
-	if err := t.IterateBucketBlocks(ctx, t.logger, filter, iteratorFunc, lastReadBlockTimestamp); err != nil {
+	blockFilter := (&BlockFilter{}).
+		LastBlockTimestamp(lastReadBlockTimestamp)
+	if err := t.IterateBucketBlocks(ctx, t.logger, blockFilter, filter, iteratorFunc); err != nil {
 		return nil, err
 	}
 

--- a/table_test.go
+++ b/table_test.go
@@ -169,7 +169,7 @@ func TestTable(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
@@ -179,9 +179,6 @@ func TestTable(t *testing.T) {
 			tx,
 			pool,
 			as,
-			nil,
-			nil,
-			nil,
 			nil,
 			func(ar arrow.Record) error {
 				t.Log(ar)
@@ -317,12 +314,12 @@ func Test_Table_GranuleSplit(t *testing.T) {
 
 	err = table.View(func(tx uint64) error {
 		pool := memory.NewGoAllocator()
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(r arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, func(r arrow.Record) error {
 			defer r.Release()
 			t.Log(r)
 			return nil
@@ -469,12 +466,12 @@ func Test_Table_InsertLowest(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(r arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, func(r arrow.Record) error {
 			defer r.Release()
 			t.Log(r)
 			return nil
@@ -571,12 +568,12 @@ func Test_Table_Concurrency(t *testing.T) {
 			err := table.View(func(tx uint64) error {
 				totalrows := int64(0)
 
-				as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+				as, err := table.ArrowSchema(ctx, tx, pool, nil)
 				if err != nil {
 					return err
 				}
 
-				err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+				err = table.Iterator(ctx, tx, pool, as, nil, func(ar arrow.Record) error {
 					totalrows += ar.NumRows()
 					defer ar.Release()
 
@@ -699,11 +696,11 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 		// Calculate the number of entries in database
 		totalrows := int64(0)
 		err = table.View(func(tx uint64) error {
-			as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+			as, err := table.ArrowSchema(ctx, tx, pool, nil)
 			if err != nil {
 				return err
 			}
-			return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+			return table.Iterator(ctx, tx, pool, as, nil, func(ar arrow.Record) error {
 				defer ar.Release()
 				totalrows += ar.NumRows()
 
@@ -795,11 +792,11 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	pool := memory.NewGoAllocator()
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		require.NoError(t, err)
 
 		rows := int64(0)
-		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, nil, func(ar arrow.Record) error {
 			rows += ar.NumRows()
 			defer ar.Release()
 
@@ -816,11 +813,11 @@ func Test_Table_ReadIsolation(t *testing.T) {
 	table.db.highWatermark.Store(3)
 
 	err = table.View(func(tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		require.NoError(t, err)
 
 		rows := int64(0)
-		err = table.Iterator(ctx, table.db.highWatermark.Load(), pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, table.db.highWatermark.Load(), pool, as, nil, func(ar arrow.Record) error {
 			rows += ar.NumRows()
 			defer ar.Release()
 
@@ -1146,12 +1143,12 @@ func Test_Table_Filter(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		iterated := false
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
 
-		err = table.Iterator(ctx, tx, pool, as, nil, nil, filterExpr, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, &logicalplan.IterOptions{Filter: filterExpr}, func(ar arrow.Record) error {
 			defer ar.Release()
 
 			iterated = true
@@ -1220,7 +1217,7 @@ func Test_Table_Bloomfilter(t *testing.T) {
 
 	iterations := 0
 	err := table.View(func(tx uint64) error {
-		err := table.Iterator(context.Background(), tx, memory.NewGoAllocator(), nil, nil, nil, logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4")), nil, func(ar arrow.Record) error {
+		err := table.Iterator(context.Background(), tx, memory.NewGoAllocator(), nil, &logicalplan.IterOptions{Filter: logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4"))}, func(ar arrow.Record) error {
 			defer ar.Release()
 			iterations++
 			return nil
@@ -1320,12 +1317,12 @@ func Test_Table_InsertCancellation(t *testing.T) {
 			err := table.View(func(tx uint64) error {
 				totalrows := int64(0)
 
-				as, err := table.ArrowSchema(context.Background(), tx, pool, nil, nil, nil, nil)
+				as, err := table.ArrowSchema(context.Background(), tx, pool, nil)
 				if err != nil {
 					return err
 				}
 
-				err = table.Iterator(context.Background(), tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+				err = table.Iterator(context.Background(), tx, pool, as, nil, func(ar arrow.Record) error {
 					totalrows += ar.NumRows()
 					defer ar.Release()
 
@@ -1396,12 +1393,12 @@ func Test_Table_CancelBasic(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		totalrows := int64(0)
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
 
-		err = table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+		err = table.Iterator(ctx, tx, pool, as, nil, func(ar arrow.Record) error {
 			totalrows += ar.NumRows()
 			defer ar.Release()
 
@@ -1466,7 +1463,7 @@ func Test_Table_ArrowSchema(t *testing.T) {
 	// because transaction 1 is just the new block creation, therefore there
 	// would be no schema to read (schemas only materialize when data is
 	// inserted).
-	schema, err := table.ArrowSchema(ctx, 2, pool, nil, nil, nil, nil)
+	schema, err := table.ArrowSchema(ctx, 2, pool, nil)
 	require.NoError(t, err)
 
 	require.Len(t, schema.Fields(), 6)
@@ -1498,12 +1495,7 @@ func Test_Table_ArrowSchema(t *testing.T) {
 	// Read two schemas for two different queries within the same transaction.
 
 	err = table.View(func(tx uint64) error {
-		schema, err := table.ArrowSchema(
-			ctx,
-			tx,
-			pool,
-			nil, nil, nil, nil,
-		)
+		schema, err := table.ArrowSchema(ctx, tx, pool, nil)
 		require.NoError(t, err)
 
 		require.Len(t, schema.Fields(), 7)
@@ -1540,11 +1532,12 @@ func Test_Table_ArrowSchema(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			[]logicalplan.Expr{
-				&logicalplan.DynamicColumn{ColumnName: "labels"},
-				&logicalplan.Column{ColumnName: "value"},
+			&logicalplan.IterOptions{
+				PhysicalProjection: []logicalplan.Expr{
+					&logicalplan.DynamicColumn{ColumnName: "labels"},
+					&logicalplan.Column{ColumnName: "value"},
+				},
 			},
-			nil, nil, nil,
 		)
 		require.NoError(t, err)
 
@@ -1632,12 +1625,12 @@ func Test_DoubleTable(t *testing.T) {
 	err = table.View(func(tx uint64) error {
 		pool := memory.NewGoAllocator()
 
-		as, err := table.ArrowSchema(ctx, tx, pool, nil, nil, nil, nil)
+		as, err := table.ArrowSchema(ctx, tx, pool, nil)
 		if err != nil {
 			return err
 		}
 
-		return table.Iterator(ctx, tx, pool, as, nil, nil, nil, nil, func(ar arrow.Record) error {
+		return table.Iterator(ctx, tx, pool, as, nil, func(ar arrow.Record) error {
 			defer ar.Release()
 			require.Equal(t, value, ar.Column(1).(*array.Float64).Value(0))
 			return nil


### PR DESCRIPTION
This adds a new concept called `Hints` to the query engine. Hints are an optional setting you can provide to the query engine for it to potentially make optimizations to it's queries. 

This adds a single hint called `ColAsTimestamp` that informs the query engine that a specific column is being used as a timestamp. This hint is then used as an optimization when performing historic queries of blocks. If a query is provided that filters on that timestamp column, it shall use that expr against the blocks ulid timestamp to determine if the block could contain any timestamps that satisfy that portion of the query, if not it'll skip that block entirely.

This is useful for queries that are being performed over say the last ~15m but have historic blocks much older than that. Instead of reading those blocks the query engine can skip over all of them and only access blocks that were written in the last 15m. This is most notable when build with Parca that has had persistence enabled.