### PR TITLE
Filter blocks based on min/max values against query expr

### DIFF
--- a/binaryscalarexpr.go
+++ b/binaryscalarexpr.go
@@ -4,21 +4,82 @@ import (
 	"errors"
 
 	"github.com/segmentio/parquet-go"
+	"github.com/segmentio/parquet-go/format"
 
-	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
+
+// ParquetFileParticulate extends parquet.File with Particulate functions
+type ParquetFileParticulate struct {
+	*parquet.File
+}
+
+// Schema implements the Particulate interafce
+func (p *ParquetFileParticulate) Schema() *parquet.Schema {
+	return p.File.Schema()
+}
+
+// VirtualSparseColumnChunk is a virtualization of a sparse ColumnChunk
+type VirtualSparseColumnChunk struct {
+	i parquet.ColumnIndex
+}
+
+// Type implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) Type() parquet.Type { return nil }
+
+// Column implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) Column() int { return -1 }
+
+// Pages implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) Pages() parquet.Pages { return nil }
+
+// OffsetIndex implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) OffsetIndex() parquet.OffsetIndex { return nil }
+
+// BloomFilter implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) BloomFilter() parquet.BloomFilter { return nil }
+
+// NumValues implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+func (v VirtualSparseColumnChunk) NumValues() int64 { return -1 }
+
+// ColumnIndex returns a column index for the VirtualSpareColumnChunk
+func (v VirtualSparseColumnChunk) ColumnIndex() parquet.ColumnIndex { return v.i }
+
+// ColumnChunks implements the Particulate interafce
+func (p *ParquetFileParticulate) ColumnChunks() []parquet.ColumnChunk {
+	var chunks []parquet.ColumnChunk
+	for i := range p.ColumnIndexes() {
+		switch *p.Metadata().Schema[i+1].Type {
+		case format.Int32:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.Int32, &p.ColumnIndexes()[i])})
+		case format.Int64:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.Int64, &p.ColumnIndexes()[i])})
+		case format.Float:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.Float, &p.ColumnIndexes()[i])})
+		case format.Double:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.Double, &p.ColumnIndexes()[i])})
+		case format.ByteArray:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.ByteArray, &p.ColumnIndexes()[i])})
+		case format.FixedLenByteArray:
+			chunks = append(chunks, VirtualSparseColumnChunk{parquet.NewColumnIndex(parquet.FixedLenByteArray, &p.ColumnIndexes()[i])})
+		default:
+			panic("unimplemented format type")
+		}
+	}
+
+	return chunks
+}
 
 type ColumnRef struct {
 	ColumnName string
 }
 
-func (c *ColumnRef) Column(rg dynparquet.DynamicRowGroup) (parquet.ColumnChunk, bool, error) {
-	columnIndex := findColumnIndex(rg.Schema(), c.ColumnName)
+func (c *ColumnRef) Column(p Particulate) (parquet.ColumnChunk, bool, error) {
+	columnIndex := findColumnIndex(p.Schema(), c.ColumnName)
 	var columnChunk parquet.ColumnChunk
 	// columnChunk can be nil if the column is not present in the row group.
 	if columnIndex != -1 {
-		columnChunk = rg.ColumnChunks()[columnIndex]
+		columnChunk = p.ColumnChunks()[columnIndex]
 	}
 
 	return columnChunk, columnIndex != -1, nil
@@ -39,8 +100,8 @@ type BinaryScalarExpr struct {
 	Right parquet.Value
 }
 
-func (e BinaryScalarExpr) Eval(rg dynparquet.DynamicRowGroup) (bool, error) {
-	leftData, exists, err := e.Left.Column(rg)
+func (e BinaryScalarExpr) Eval(p Particulate) (bool, error) {
+	leftData, exists, err := e.Left.Column(p)
 	if err != nil {
 		return false, err
 	}
@@ -71,9 +132,8 @@ func BinaryScalarOperation(left parquet.ColumnChunk, right parquet.Value, operat
 	case logicalplan.OpEq:
 		bloomFilter := left.BloomFilter()
 		if bloomFilter == nil {
-			// If there is no bloom filter then we cannot make a statement about a
-			// true negative so the rowgroup has to be a candidate.
-			return true, nil
+			// If there is no bloom filter then we cannot make a statement about true negative, instead check the min max values of the column chunk
+			return compare(right, Max(left)) <= 0 || compare(right, Min(left)) >= -1, nil
 		}
 
 		ok, err := bloomFilter.Check(right)
@@ -85,6 +145,61 @@ func BinaryScalarOperation(left parquet.ColumnChunk, right parquet.Value, operat
 			// negatives, we know this column chunk does not contain the value.
 			return false, nil
 		}
+
+		return true, nil
+	case logicalplan.OpLtEq:
+		return compare(Min(left), right) <= 0, nil
+	case logicalplan.OpLt:
+		return compare(Min(left), right) < 0, nil
+	case logicalplan.OpGt:
+		return compare(Max(left), right) > 0, nil
+	case logicalplan.OpGtEq:
+		return compare(Max(left), right) >= 0, nil
+	default:
+		return true, nil
 	}
-	return true, nil
+}
+
+// Min returns the minimum value found in the column chunk across all pages
+func Min(chunk parquet.ColumnChunk) parquet.Value {
+	columnIndex := chunk.ColumnIndex()
+	min := columnIndex.MinValue(0)
+	for i := 1; i < columnIndex.NumPages(); i++ {
+		if v := columnIndex.MinValue(i); compare(min, v) == 1 {
+			min = v
+		}
+	}
+
+	return min
+}
+
+// Max returns the maximum value found in the column chunk across all pages
+func Max(chunk parquet.ColumnChunk) parquet.Value {
+	columnIndex := chunk.ColumnIndex()
+	max := columnIndex.MaxValue(0)
+	for i := 1; i < columnIndex.NumPages(); i++ {
+		if v := columnIndex.MaxValue(i); compare(max, v) == -1 {
+			max = v
+		}
+	}
+
+	return max
+}
+
+// compares two parquet values. 0 if they are equal, -1 if v1 < v2, 1 if v1 > v2.
+func compare(v1, v2 parquet.Value) int {
+	switch v1.Kind() {
+	case parquet.Int32:
+		return parquet.Int32Type.Compare(v1, v2)
+	case parquet.Int64:
+		return parquet.Int64Type.Compare(v1, v2)
+	case parquet.Float:
+		return parquet.FloatType.Compare(v1, v2)
+	case parquet.Double:
+		return parquet.DoubleType.Compare(v1, v2)
+	case parquet.ByteArray, parquet.FixedLenByteArray:
+		return parquet.ByteArrayType.Compare(v1, v2)
+	default:
+		panic("unsupported value comparison")
+	}
 }

--- a/binaryscalarexpr.go
+++ b/binaryscalarexpr.go
@@ -9,43 +9,43 @@ import (
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
-// ParquetFileParticulate extends parquet.File with Particulate functions
+// ParquetFileParticulate extends parquet.File with Particulate functions.
 type ParquetFileParticulate struct {
 	*parquet.File
 }
 
-// Schema implements the Particulate interafce
+// Schema implements the Particulate interafce.
 func (p *ParquetFileParticulate) Schema() *parquet.Schema {
 	return p.File.Schema()
 }
 
-// VirtualSparseColumnChunk is a virtualization of a sparse ColumnChunk
+// VirtualSparseColumnChunk is a virtualization of a sparse ColumnChunk.
 type VirtualSparseColumnChunk struct {
 	i parquet.ColumnIndex
 }
 
-// Type implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// Type implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) Type() parquet.Type { return nil }
 
-// Column implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// Column implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) Column() int { return -1 }
 
-// Pages implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// Pages implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) Pages() parquet.Pages { return nil }
 
-// OffsetIndex implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// OffsetIndex implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) OffsetIndex() parquet.OffsetIndex { return nil }
 
-// BloomFilter implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// BloomFilter implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) BloomFilter() parquet.BloomFilter { return nil }
 
-// NumValues implements the parquet.ColumnChunk interface; It is intentionally unimplemented
+// NumValues implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) NumValues() int64 { return -1 }
 
-// ColumnIndex returns a column index for the VirtualSpareColumnChunk
+// ColumnIndex returns a column index for the VirtualSpareColumnChunk.
 func (v VirtualSparseColumnChunk) ColumnIndex() parquet.ColumnIndex { return v.i }
 
-// ColumnChunks implements the Particulate interafce
+// ColumnChunks implements the Particulate interafce.
 func (p *ParquetFileParticulate) ColumnChunks() []parquet.ColumnChunk {
 	var chunks []parquet.ColumnChunk
 	for i := range p.ColumnIndexes() {
@@ -160,7 +160,7 @@ func BinaryScalarOperation(left parquet.ColumnChunk, right parquet.Value, operat
 	}
 }
 
-// Min returns the minimum value found in the column chunk across all pages
+// Min returns the minimum value found in the column chunk across all pages.
 func Min(chunk parquet.ColumnChunk) parquet.Value {
 	columnIndex := chunk.ColumnIndex()
 	min := columnIndex.MinValue(0)
@@ -173,7 +173,7 @@ func Min(chunk parquet.ColumnChunk) parquet.Value {
 	return min
 }
 
-// Max returns the maximum value found in the column chunk across all pages
+// Max returns the maximum value found in the column chunk across all pages.
 func Max(chunk parquet.ColumnChunk) parquet.Value {
 	columnIndex := chunk.ColumnIndex()
 	max := columnIndex.MaxValue(0)

--- a/filter.go
+++ b/filter.go
@@ -20,6 +20,9 @@ func (f PreExprVisitorFunc) PostVisit(expr logicalplan.Expr) bool {
 	return false
 }
 
+// Particulate is an abstraction of something that can be filtered.
+// A parquet.RowGroup is a particulate that is able to be filtered, and wrapping a parquet.File with
+// ParquetFileParticulate allows a file to be filtered.
 type Particulate interface {
 	Schema() *parquet.Schema
 	ColumnChunks() []parquet.ColumnChunk

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -25,6 +25,15 @@ type LogicalPlan struct {
 	Aggregation *Aggregation
 }
 
+// IterOptions are a set of options for the TableReader Iterators
+// TODO: should we instead use the option pattern? Is that possible with the way the Iterator functions work?
+type IterOptions struct {
+	PhysicalProjection []Expr
+	Projection         []Expr
+	Filter             Expr
+	DistinctColumns    []Expr
+}
+
 func (plan *LogicalPlan) String() string {
 	return plan.string(0)
 }
@@ -106,30 +115,21 @@ type TableReader interface {
 		tx uint64,
 		pool memory.Allocator,
 		schema *arrow.Schema,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr,
-		distinctColumns []Expr,
+		options IterOptions,
 		callback func(ctx context.Context, r arrow.Record) error,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr,
-		distinctColumns []Expr,
+		options IterOptions,
 		callback func(ctx context.Context, r arrow.Record) error,
 	) error
 	ArrowSchema(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		physicalProjection []Expr,
-		projection []Expr,
-		filter Expr, // TODO: We probably don't need this
-		distinctColumns []Expr,
+		options IterOptions,
 	) (*arrow.Schema, error)
 	Schema() *dynparquet.Schema
 }

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -28,10 +28,7 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts IterOptions,
 	callback func(ctx context.Context, r arrow.Record) error,
 ) error {
 	return nil
@@ -41,10 +38,7 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts IterOptions,
 	callback func(ctx context.Context, r arrow.Record) error,
 ) error {
 	return nil
@@ -54,10 +48,7 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []Expr,
-	projection []Expr,
-	filter Expr,
-	distinctColumns []Expr,
+	iterOpts IterOptions,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -112,10 +112,12 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
+			logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+			},
 		)
 		if err != nil {
 			return err
@@ -126,10 +128,12 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			tx,
 			pool,
 			schema,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
+			logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+			},
 			s.next.Callback,
 		)
 	})
@@ -164,10 +168,12 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			s.options.PhysicalProjection,
-			s.options.Projection,
-			s.options.Filter,
-			s.options.Distinct,
+			logicalplan.IterOptions{
+				PhysicalProjection: s.options.PhysicalProjection,
+				Projection:         s.options.Projection,
+				Filter:             s.options.Filter,
+				DistinctColumns:    s.options.Distinct,
+			},
 			s.next.Callback,
 		)
 	})

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -30,10 +30,7 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts logicalplan.IterOptions,
 	callback func(ctx context.Context, r arrow.Record) error,
 ) error {
 	return nil
@@ -43,10 +40,7 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts logicalplan.IterOptions,
 	callback func(ctx context.Context, r arrow.Record) error,
 ) error {
 	return nil
@@ -56,10 +50,7 @@ func (m *mockTableReader) ArrowSchema(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	physicalProjection []logicalplan.Expr,
-	projection []logicalplan.Expr,
-	filter logicalplan.Expr,
-	distinctColumns []logicalplan.Expr,
+	iterOpts logicalplan.IterOptions,
 ) (*arrow.Schema, error) {
 	return nil, nil
 }


### PR DESCRIPTION
In place of my previous PR with query hints.

This no longer has query hints, it instead using the query expr against the min/max values in a block from the parquet file metadata to determine if the block may contain data that satisfies the query.

This appeared to have the same effect as my previous PR but performs this in a more generic way as requested. 