### PR TITLE
query/physicalplan: PhysicalPlans are passed rather than just function callbacks

### DIFF
--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -17,7 +17,7 @@ import (
 type Distinction struct {
 	pool     memory.Allocator
 	tracer   trace.Tracer
-	next     func(ctx context.Context, r arrow.Record) error
+	next     PhysicalPlan
 	columns  []logicalplan.Expr
 	hashSeed maphash.Seed
 
@@ -37,8 +37,8 @@ func Distinct(pool memory.Allocator, tracer trace.Tracer, columns []logicalplan.
 	}
 }
 
-func (d *Distinction) SetNextCallback(callback func(ctx context.Context, r arrow.Record) error) {
-	d.next = callback
+func (d *Distinction) SetNext(plan PhysicalPlan) {
+	d.next = plan
 }
 
 func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
@@ -128,7 +128,7 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 		rows,
 	)
 
-	err := d.next(ctx, distinctRecord)
+	err := d.next.Callback(ctx, distinctRecord)
 	distinctRecord.Release()
 	return err
 }

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -140,7 +140,7 @@ type Projection struct {
 
 	colProjections []columnProjection
 
-	next func(ctx context.Context, r arrow.Record) error
+	next PhysicalPlan
 }
 
 func Project(mem memory.Allocator, tracer trace.Tracer, exprs []logicalplan.Expr) (*Projection, error) {
@@ -192,9 +192,9 @@ func (p *Projection) Callback(ctx context.Context, r arrow.Record) error {
 		resArrays,
 		rows,
 	)
-	return p.next(ctx, ar)
+	return p.next.Callback(ctx, ar)
 }
 
-func (p *Projection) SetNextCallback(next func(ctx context.Context, r arrow.Record) error) {
+func (p *Projection) SetNext(next PhysicalPlan) {
 	p.next = next
 }


### PR DESCRIPTION
Adding the `Finish(context.Context) error` callbacks next.