### PR TITLE
query/physicalplan: Add finish callback to PhysicalPlan interface

### DIFF
--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -41,6 +41,10 @@ func (d *Distinction) SetNext(plan PhysicalPlan) {
 	d.next = plan
 }
 
+func (d *Distinction) Finish(ctx context.Context) error {
+	return d.next.Finish(ctx)
+}
+
 func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 	// Generates high volume of spans. Comment out if needed during development.
 	// ctx, span := d.tracer.Start(ctx, "Distinction/Callback")

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -234,6 +234,10 @@ func (f *PredicateFilter) Callback(ctx context.Context, r arrow.Record) error {
 	return f.next.Callback(ctx, filtered)
 }
 
+func (f *PredicateFilter) Finish(ctx context.Context) error {
+	return f.next.Finish(ctx)
+}
+
 func filter(pool memory.Allocator, filterExpr BooleanExpression, ar arrow.Record) (arrow.Record, bool, error) {
 	bitmap, err := filterExpr.Eval(ar)
 	if err != nil {

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -195,6 +195,10 @@ func (p *Projection) Callback(ctx context.Context, r arrow.Record) error {
 	return p.next.Callback(ctx, ar)
 }
 
+func (p *Projection) Finish(ctx context.Context) error {
+	return p.next.Finish(ctx)
+}
+
 func (p *Projection) SetNext(next PhysicalPlan) {
 	p.next = next
 }


### PR DESCRIPTION
As it has been done by @albertlockett, move the `Finish` callback to the PhysicalPlan interface.
