### PR TITLE
pqarrow/frostdb: accumulate results in Iterator

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -271,6 +271,10 @@ func Test_DB_WithStorage(t *testing.T) {
 		dynparquet.NewSampleSchema(),
 	)
 
+	// TODO(asubiotto): These buckets are not deleted from disk, resulting in
+	// test failures if run multiple times. There seems to be an attempt below
+	// to delete them, but it doesn't have an effect. What's the magic
+	// incantation?
 	bucket, err := filesystem.NewBucket(".")
 	require.NoError(t, err)
 

--- a/pqarrow/convert/convert.go
+++ b/pqarrow/convert/convert.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/apache/arrow/go/v8/arrow"
-	"github.com/apache/arrow/go/v8/arrow/array"
 	"github.com/segmentio/parquet-go"
 
 	"github.com/polarsignals/frostdb/pqarrow/writer"
@@ -34,33 +33,46 @@ func ParquetNodeToType(n parquet.Node) (arrow.DataType, error) {
 
 // ParquetNodeToTypeWithWriterFunc converts a parquet node to an arrow type and a function to
 // create a value writer.
-func ParquetNodeToTypeWithWriterFunc(n parquet.Node) (arrow.DataType, func(b array.Builder, numValues int) writer.ValueWriter, error) {
+func ParquetNodeToTypeWithWriterFunc(n parquet.Node) (arrow.DataType, writer.NewWriterFunc, error) {
 	t := n.Type()
 	lt := t.LogicalType()
 
-	switch {
-	case lt != nil:
+	resultType, resultWriter, err := func() (arrow.DataType, writer.NewWriterFunc, error) {
 		switch {
-		case lt.UTF8 != nil:
-			return &arrow.BinaryType{}, writer.NewBinaryValueWriter, nil
-		case lt.Integer != nil:
-			switch lt.Integer.BitWidth {
-			case 64:
-				if lt.Integer.IsSigned {
-					return &arrow.Int64Type{}, writer.NewInt64ValueWriter, nil
+		case lt != nil:
+			switch {
+			case lt.UTF8 != nil:
+				return &arrow.BinaryType{}, writer.NewBinaryValueWriter, nil
+			case lt.Integer != nil:
+				switch lt.Integer.BitWidth {
+				case 64:
+					if lt.Integer.IsSigned {
+						return &arrow.Int64Type{}, writer.NewInt64ValueWriter, nil
+					}
+					return &arrow.Uint64Type{}, writer.NewUint64ValueWriter, nil
+				default:
+					return nil, nil, errors.New("unsupported int bit width")
 				}
-				return &arrow.Uint64Type{}, writer.NewUint64ValueWriter, nil
 			default:
-				return nil, nil, errors.New("unsupported int bit width")
+				return nil, nil, errors.New("unsupported logical type: " + n.Type().String())
 			}
+		case t.String() == "group": // NOTE: this needs to be perfomed before t.Kind() because t.Kind() will panic when called on a group
+			return nil, nil, errors.New("unsupported type: " + n.Type().String())
+		case t.Kind() == parquet.Double:
+			return &arrow.Float64Type{}, writer.NewFloat64ValueWriter, nil
 		default:
-			return nil, nil, errors.New("unsupported logical type: " + n.Type().String())
+			return nil, nil, errors.New("unsupported type: " + n.Type().String())
 		}
-	case t.String() == "group": // NOTE: this needs to be perfomed before t.Kind() because t.Kind() will panic when called on a group
-		return nil, nil, errors.New("unsupported type: " + n.Type().String())
-	case t.Kind() == parquet.Double:
-		return &arrow.Float64Type{}, writer.NewFloat64ValueWriter, nil
-	default:
-		return nil, nil, errors.New("unsupported type: " + n.Type().String())
+	}()
+	if err != nil {
+		return nil, nil, err
 	}
+
+	if n.Repeated() {
+		// TODO(asubiotto): We should use arrow.ListOfNonNullable if
+		// n.Optional(). The problem is that it doesn't seem like the arrow
+		// builder stores the nullability (NewArray always uses ListOf).
+		return arrow.ListOf(resultType), writer.NewListValueWriter(resultWriter), nil
+	}
+	return resultType, resultWriter, nil
 }

--- a/pqarrow/writer/writer.go
+++ b/pqarrow/writer/writer.go
@@ -19,6 +19,8 @@ type binaryValueWriter struct {
 	firstWrite bool
 }
 
+type NewWriterFunc func(b array.Builder, numValues int) ValueWriter
+
 func NewBinaryValueWriter(b array.Builder, numValues int) ValueWriter {
 	return &binaryValueWriter{
 		b:          b.(*array.BinaryBuilder),


### PR DESCRIPTION
Previously, in some cases, the Table.Iterator method would push Records with a
single row one at a time to the next operator. This would happen especially in
cases where a distinct optimization is executed and a single value is written
per parquet page. This commit changes the scan process to write scan results to
a provided RecordBuilder in order to buffer results up to a specified
builderBufferSize (default=1024) and take advantage of processing these results
in tight loops downstream.

The results are especially noticeable in QueryTypes, which takes advantage of
the aforementioned distinct optimizations:

```
name          old time/op    new time/op    delta
QueryTypes-8     169ms ±11%      68ms ±13%  -59.43%  (p=0.000 n=10+9)
QueryMerge-8    27.0ms ±34%    23.4ms ±12%     ~     (p=0.095 n=10+9)
QueryRange-8    13.8ms ±15%    13.3ms ± 9%     ~     (p=0.356 n=9+10)

name          old alloc/op   new alloc/op   delta
QueryTypes-8     443MB ± 0%      88MB ± 0%  -80.21%  (p=0.000 n=10+9)
QueryMerge-8    39.9MB ± 0%    39.9MB ± 0%     ~     (p=0.497 n=10+9)
QueryRange-8    18.6MB ± 0%    18.6MB ± 0%   -0.05%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
QueryTypes-8     1.13M ± 0%     0.52M ± 0%  -53.55%  (p=0.000 n=10+9)
QueryMerge-8      104k ± 0%      104k ± 0%   -0.10%  (p=0.000 n=10+9)
QueryRange-8     6.61k ± 0%     6.49k ± 0%   -1.69%  (p=0.000 n=8+10)
```