### PR TITLE
*: update parquet-go to include goroutine leak fix

### DIFF
--- a/dynparquet/nil_chunk.go
+++ b/dynparquet/nil_chunk.go
@@ -198,21 +198,21 @@ func (p *nilValueReader) ReadValues(values []parquet.Value) (int, error) {
 
 // DefinitionLevels returns the definition levels of the page. Since the page
 // contains only null values, all of them are 0. Implements the
-// parquet.BufferedPage interface.
+// parquet.Page interface.
 func (p *nilPage) DefinitionLevels() []byte {
 	return nil
 }
 
 // RepetitionLevels returns the definition levels of the page. Since the page
 // contains only null values, all of them are 0. Implements the
-// parquet.BufferedPage interface.
+// parquet.Page interface.
 func (p *nilPage) RepetitionLevels() []byte {
 	return nil
 }
 
 // Data is unimplemented, since the page is virtual and does not need to be
 // written in its current usage in this package. If that changes this method
-// needs to be implemented. Implements the parquet.BufferedPage interface.
+// needs to be implemented. Implements the parquet.Page interface.
 func (p *nilPage) Data() encoding.Values {
 	panic("not implemented")
 }
@@ -224,7 +224,7 @@ func (p *nilPage) Slice(i, j int64) parquet.Page {
 	}
 }
 
-// Clone creates a copy of the nilPage. Implements the parquet.BufferedPage
+// Clone creates a copy of the nilPage. Implements the parquet.Page
 // interface.
 func (p *nilPage) Clone() parquet.Page {
 	return &nilPage{

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -546,6 +546,7 @@ func (b *Buffer) Clone() (*Buffer, error) {
 	)
 
 	rows := b.buffer.Rows()
+	defer rows.Close()
 	for {
 		rowBuf := make([]parquet.Row, 64)
 		n, err := rows.ReadRows(rowBuf)
@@ -653,6 +654,7 @@ func (s *Schema) SerializeBuffer(buffer *Buffer) ([]byte, error) {
 	//}
 
 	rows := buffer.Rows()
+	defer rows.Close()
 	rowBuf := rowBufPool.Get().([]parquet.Row)
 	defer rowBufPool.Put(rowBuf[:cap(rowBuf)])
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.12.2
-	github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638
+	github.com/segmentio/parquet-go v0.0.0-20220914222423-67dbe8d21ca5
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220715165016-ce338803bc1e
 	github.com/tidwall/wal v1.1.7
@@ -34,7 +34,7 @@ require (
 	github.com/efficientgo/tools/core v0.0.0-20220225185207-fe763185946b // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/goccy/go-json v0.7.10 // indirect
-	github.com/klauspost/compress v1.15.5 // indirect
+	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.1/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.14.2/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.5 h1:qyCLMz2JCrKADihKOh9FxnW3houKeNsp2h5OEz0QSEA=
-github.com/klauspost/compress v1.15.5/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -416,8 +416,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638 h1:aPE6pwnk8m+LxPmJdqd9XCyStmp2QWGjVUkwP4MPq/U=
-github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638/go.mod h1:PxYdAI6cGd+s1j4hZDQbz3VFgobF5fDA0weLeNWKTE4=
+github.com/segmentio/parquet-go v0.0.0-20220914222423-67dbe8d21ca5 h1:8vdaMkRW5IbWW454S4//xBlIDgTPFWlgjVuaOBH4tQk=
+github.com/segmentio/parquet-go v0.0.0-20220914222423-67dbe8d21ca5/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/table.go
+++ b/table.go
@@ -1027,6 +1027,7 @@ func (t *TableBlock) splitRowsByGranule(buf *dynparquet.SerializedBuffer) (map[*
 
 	// TODO: we might be able to do ascend less than or ascend greater than here?
 	rows := buf.DynamicRows()
+	defer rows.Close()
 	var prev *Granule
 	exhaustedAllRows := false
 
@@ -1216,6 +1217,7 @@ func (t *TableBlock) writeRows(w *dynparquet.PooledWriter, count int, rowGroups 
 	}
 
 	rows := merged.Rows()
+	defer rows.Close()
 	for {
 		rowsBuf := make([]parquet.Row, count)
 		n, err := rows.ReadRows(rowsBuf)


### PR DESCRIPTION
This should alleviate our CI flakes where too many goroutines are alive at one
time.

There is also a fix pulled in for buffering bloom filter reads.