### PR TITLE
query/physicalplan: Add Diagram to draw physicalplan into traces

### DIFF
--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
+	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
@@ -149,6 +150,21 @@ func NewHashAggregate(
 
 func (a *HashAggregate) SetNext(next PhysicalPlan) {
 	a.next = next
+}
+
+func (a *HashAggregate) Draw() *Diagram {
+	var child *Diagram
+	if a.next != nil {
+		child = a.next.Draw()
+	}
+
+	var groupings []string
+	for _, grouping := range a.groupByColumnMatchers {
+		groupings = append(groupings, grouping.Name())
+	}
+
+	details := fmt.Sprintf("HashAggregate (%s by %s)", a.columnToAggregate.Name(), strings.Join(groupings, ","))
+	return &Diagram{Details: details, Child: child}
 }
 
 // Go translation of boost's hash_combine function. Read here why these values

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -2,7 +2,9 @@ package physicalplan
 
 import (
 	"context"
+	"fmt"
 	"hash/maphash"
+	"strings"
 	"sync"
 
 	"github.com/apache/arrow/go/v8/arrow"
@@ -23,6 +25,20 @@ type Distinction struct {
 
 	mtx  *sync.RWMutex
 	seen map[uint64]struct{}
+}
+
+func (d *Distinction) Draw() *Diagram {
+	var child *Diagram
+	if d.next != nil {
+		child = d.next.Draw()
+	}
+
+	var columns []string
+	for _, c := range d.columns {
+		columns = append(columns, c.Name())
+	}
+
+	return &Diagram{Details: fmt.Sprintf("Distinction (%s)", strings.Join(columns, ",")), Child: child}
 }
 
 func Distinct(pool memory.Allocator, tracer trace.Tracer, columns []logicalplan.Expr) *Distinction {

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -3,6 +3,7 @@ package physicalplan
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/RoaringBitmap/roaring"
@@ -20,6 +21,15 @@ type PredicateFilter struct {
 	tracer     trace.Tracer
 	filterExpr BooleanExpression
 	next       PhysicalPlan
+}
+
+func (f *PredicateFilter) Draw() *Diagram {
+	var child *Diagram
+	if f.next != nil {
+		child = f.next.Draw()
+	}
+	details := fmt.Sprintf("PredicateFilter (%s)", f.filterExpr.String())
+	return &Diagram{Details: details, Child: child}
 }
 
 type Bitmap = roaring.Bitmap

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -3,9 +3,11 @@ package physicalplan
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/polarsignals/frostdb/dynparquet"
@@ -15,10 +17,12 @@ import (
 type PhysicalPlan interface {
 	Callback(ctx context.Context, r arrow.Record) error
 	SetNext(next PhysicalPlan)
+	Draw() *Diagram
 }
 
 type ScanPhysicalPlan interface {
 	Execute(ctx context.Context, pool memory.Allocator) error
+	Draw() *Diagram
 }
 
 type PrePlanVisitorFunc func(plan *logicalplan.LogicalPlan) bool
@@ -46,6 +50,15 @@ type OutputPlan struct {
 	scan     ScanPhysicalPlan
 }
 
+func (e *OutputPlan) Draw() *Diagram {
+	// Doesn't change anything anymore as it's the root of the plan.
+	return &Diagram{}
+}
+
+func (e *OutputPlan) DrawString() string {
+	return e.scan.Draw().String()
+}
+
 func (e *OutputPlan) Callback(ctx context.Context, r arrow.Record) error {
 	return e.callback(ctx, r)
 }
@@ -70,6 +83,15 @@ type TableScan struct {
 	options  *logicalplan.TableScan
 	next     PhysicalPlan
 	finisher func(ctx context.Context) error
+}
+
+func (s *TableScan) Draw() *Diagram {
+	var child *Diagram
+	if s.next != nil {
+		child = s.next.Draw()
+	}
+	details := fmt.Sprintf("TableScan")
+	return &Diagram{Details: details, Child: child}
 }
 
 func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
@@ -119,6 +141,14 @@ type SchemaScan struct {
 	options  *logicalplan.SchemaScan
 	next     PhysicalPlan
 	finisher func(ctx context.Context) error
+}
+
+func (s *SchemaScan) Draw() *Diagram {
+	var child *Diagram
+	if s.next != nil {
+		child = s.next.Draw()
+	}
+	return &Diagram{Details: "SchemaScan", Child: child}
 }
 
 func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
@@ -202,6 +232,23 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 	}))
 
 	outputPlan.SetNextCallback(prev.Callback)
+	span.SetAttributes(attribute.String("plan", outputPlan.scan.Draw().String()))
 
 	return outputPlan, err
+}
+
+type Diagram struct {
+	Details string
+	Child   *Diagram
+}
+
+func (d *Diagram) String() string {
+	if d.Child == nil {
+		return d.Details
+	}
+	child := d.Child.String()
+	if child == "" {
+		return d.Details
+	}
+	return d.Details + " - " + child
 }

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -3,6 +3,7 @@ package physicalplan
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
@@ -13,12 +14,17 @@ import (
 )
 
 type columnProjection interface {
+	Name() string
 	Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error)
 }
 
 type aliasProjection struct {
 	expr *logicalplan.AliasExpr
 	name string
+}
+
+func (a aliasProjection) Name() string {
+	return a.name
 }
 
 func (a aliasProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error) {
@@ -34,6 +40,10 @@ func (a aliasProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow
 
 type binaryExprProjection struct {
 	boolExpr BooleanExpression
+}
+
+func (b binaryExprProjection) Name() string {
+	return b.boolExpr.String()
 }
 
 func (b binaryExprProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error) {
@@ -79,6 +89,10 @@ type plainProjection struct {
 	expr *logicalplan.Column
 }
 
+func (p plainProjection) Name() string {
+	return p.expr.ColumnName
+}
+
 func (p plainProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error) {
 	for i, field := range ar.Schema().Fields() {
 		if p.expr.MatchColumn(field.Name) {
@@ -91,6 +105,10 @@ func (p plainProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow
 
 type dynamicProjection struct {
 	expr *logicalplan.DynamicColumn
+}
+
+func (p dynamicProjection) Name() string {
+	return p.expr.ColumnName
 }
 
 func (p dynamicProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error) {
@@ -197,4 +215,18 @@ func (p *Projection) Callback(ctx context.Context, r arrow.Record) error {
 
 func (p *Projection) SetNext(next PhysicalPlan) {
 	p.next = next
+}
+
+func (p *Projection) Draw() *Diagram {
+	var child *Diagram
+	if p.next != nil {
+		child = p.next.Draw()
+	}
+
+	var columns []string
+	for _, p := range p.colProjections {
+		columns = append(columns, p.Name())
+	}
+	details := fmt.Sprintf("Projection (%s)", strings.Join(columns, ","))
+	return &Diagram{Details: details, Child: child}
 }


### PR DESCRIPTION
This will add an attribute/log to the `PhysicalPlan/Build` span among the lines of:
```
TableScan - Projection (name,sample_type,sample_unit,period_type,period_unit,duration > 0) - Distinction (name,sample_type,sample_unit,period_type,period_unit,duration > 0)
```
```
TableScan - PredicateFilter ((name == goroutine AND (sample_type == goroutine AND (sample_unit == count AND (period_type == goroutine AND (period_unit == count AND (duration == 0 AND (timestamp > 1661951985385 AND timestamp < 1661952885385)))))))) - HashAggregate (value by labels,timestamp)
```