### PR TITLE
Fixup granule filters

### DIFF
--- a/binaryscalarexpr.go
+++ b/binaryscalarexpr.go
@@ -42,8 +42,34 @@ func (v VirtualSparseColumnChunk) BloomFilter() parquet.BloomFilter { return nil
 // NumValues implements the parquet.ColumnChunk interface; It is intentionally unimplemented.
 func (v VirtualSparseColumnChunk) NumValues() int64 { return -1 }
 
-// ColumnIndex returns a column index for the VirtualSpareColumnChunk.
+// ColumnIndex returns a column index for the VirtualSparseColumnChunk.
 func (v VirtualSparseColumnChunk) ColumnIndex() parquet.ColumnIndex { return v.i }
+
+type VirtualSparseColumnIndex struct {
+	Min parquet.Value
+	Max parquet.Value
+}
+
+// NumPages implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) NumPages() int { return 1 }
+
+// NullCount implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) NullCount(int) int64 { return 0 }
+
+// NullPage implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) NullPage(int) bool { return false }
+
+// MinValue implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) MinValue(int) parquet.Value { return v.Min }
+
+// MaxValue implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) MaxValue(int) parquet.Value { return v.Max }
+
+// IsAscending implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) IsAscending() bool { return true }
+
+// IsDescending implements the parquet.ColumnIndex interface.
+func (v VirtualSparseColumnIndex) IsDescending() bool { return false }
 
 // ColumnChunks implements the Particulate interafce.
 func (p *ParquetFileParticulate) ColumnChunks() []parquet.ColumnChunk {

--- a/granule.go
+++ b/granule.go
@@ -333,7 +333,7 @@ func findMin(t parquet.Type, values []parquet.Value) *parquet.Value {
 	return find(-1, t, values)
 }
 
-// Schema implements the Particulate interface. It generates a parquet.Schema from the min/max fields of the Granule
+// Schema implements the Particulate interface. It generates a parquet.Schema from the min/max fields of the Granule.
 func (g *Granule) Schema() *parquet.Schema {
 	group := parquet.Group{}
 	g.metadata.maxlock.RLock()

--- a/granule.go
+++ b/granule.go
@@ -335,32 +335,45 @@ func findMin(t parquet.Type, values []parquet.Value) *parquet.Value {
 // Schema implements the Particulate interface. It generates a parquet.Schema from the min/max fields of the Granule
 func (g *Granule) Schema() *parquet.Schema {
 	group := parquet.Group{}
-	func() {
-		g.metadata.maxlock.RLock()
-		defer g.metadata.maxlock.RUnlock()
-		for name, v := range g.metadata.max {
-			switch v.Kind() {
-			case parquet.Int32:
-				group[name] = parquet.Int(32)
-			case parquet.Int64:
-				group[name] = parquet.Int(64)
-			case parquet.Float:
-				group[name] = parquet.Leaf(parquet.FloatType)
-			case parquet.Double:
-				group[name] = parquet.Leaf(parquet.DoubleType)
-			case parquet.ByteArray:
-				group[name] = parquet.String()
-			case parquet.FixedLenByteArray:
-				group[name] = parquet.Leaf(parquet.ByteArrayType)
-			default:
-				group[name] = parquet.Leaf(parquet.DoubleType)
-			}
+	g.metadata.maxlock.RLock()
+	defer g.metadata.maxlock.RUnlock()
+	for name, v := range g.metadata.max {
+		switch v.Kind() {
+		case parquet.Int32:
+			group[name] = parquet.Int(32)
+		case parquet.Int64:
+			group[name] = parquet.Int(64)
+		case parquet.Float:
+			group[name] = parquet.Leaf(parquet.FloatType)
+		case parquet.Double:
+			group[name] = parquet.Leaf(parquet.DoubleType)
+		case parquet.ByteArray:
+			group[name] = parquet.String()
+		case parquet.FixedLenByteArray:
+			group[name] = parquet.Leaf(parquet.ByteArrayType)
+		default:
+			group[name] = parquet.Leaf(parquet.DoubleType)
 		}
-	}()
+	}
 	return parquet.NewSchema("granule", group)
 }
 
 // ColumnChunks implements the Particulate interface.
 func (g *Granule) ColumnChunks() []parquet.ColumnChunk {
-	return nil // TODO THOR
+	var chunks []parquet.ColumnChunk
+	g.metadata.maxlock.RLock()
+	defer g.metadata.maxlock.RUnlock()
+	g.metadata.minlock.RLock()
+	defer g.metadata.minlock.RUnlock()
+
+	for name, maxVal := range g.metadata.max {
+		chunks = append(chunks, VirtualSparseColumnChunk{
+			i: VirtualSparseColumnIndex{
+				Min: *g.metadata.min[name],
+				Max: *maxVal,
+			},
+		})
+	}
+
+	return chunks
 }

--- a/granule.go
+++ b/granule.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"unsafe"
 
@@ -366,11 +367,17 @@ func (g *Granule) ColumnChunks() []parquet.ColumnChunk {
 	g.metadata.minlock.RLock()
 	defer g.metadata.minlock.RUnlock()
 
-	for name, maxVal := range g.metadata.max {
+	names := []string{}
+	for name := range g.metadata.max {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
 		chunks = append(chunks, VirtualSparseColumnChunk{
 			i: VirtualSparseColumnIndex{
 				Min: *g.metadata.min[name],
-				Max: *maxVal,
+				Max: *g.metadata.max[name],
 			},
 		})
 	}

--- a/granule.go
+++ b/granule.go
@@ -332,12 +332,35 @@ func findMin(t parquet.Type, values []parquet.Value) *parquet.Value {
 	return find(-1, t, values)
 }
 
-// Schema implements the Particulate interface
+// Schema implements the Particulate interface. It generates a parquet.Schema from the min/max fields of the Granule
 func (g *Granule) Schema() *parquet.Schema {
-	return nil // TODO THOR
+	group := parquet.Group{}
+	func() {
+		g.metadata.maxlock.RLock()
+		defer g.metadata.maxlock.RUnlock()
+		for name, v := range g.metadata.max {
+			switch v.Kind() {
+			case parquet.Int32:
+				group[name] = parquet.Int(32)
+			case parquet.Int64:
+				group[name] = parquet.Int(64)
+			case parquet.Float:
+				group[name] = parquet.Leaf(parquet.FloatType)
+			case parquet.Double:
+				group[name] = parquet.Leaf(parquet.DoubleType)
+			case parquet.ByteArray:
+				group[name] = parquet.String()
+			case parquet.FixedLenByteArray:
+				group[name] = parquet.Leaf(parquet.ByteArrayType)
+			default:
+				group[name] = parquet.Leaf(parquet.DoubleType)
+			}
+		}
+	}()
+	return parquet.NewSchema("granule", group)
 }
 
-// ColumnChunks implements the Particulate interface
+// ColumnChunks implements the Particulate interface.
 func (g *Granule) ColumnChunks() []parquet.ColumnChunk {
 	return nil // TODO THOR
 }

--- a/granule.go
+++ b/granule.go
@@ -331,3 +331,13 @@ func findMax(t parquet.Type, values []parquet.Value) *parquet.Value {
 func findMin(t parquet.Type, values []parquet.Value) *parquet.Value {
 	return find(-1, t, values)
 }
+
+// Schema implements the Particulate interface
+func (g *Granule) Schema() *parquet.Schema {
+	return nil // TODO THOR
+}
+
+// ColumnChunks implements the Particulate interface
+func (g *Granule) ColumnChunks() []parquet.ColumnChunk {
+	return nil // TODO THOR
+}

--- a/table.go
+++ b/table.go
@@ -879,7 +879,6 @@ func (t *TableBlock) splitGranule(granule *Granule) {
 func (t *TableBlock) RowGroupIterator(
 	ctx context.Context,
 	tx uint64,
-	filterExpr logicalplan.Expr,
 	filter TrueNegativeFilter,
 	iterator func(rg dynparquet.DynamicRowGroup) bool,
 ) error {
@@ -1140,7 +1139,7 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 	rowGroups := []dynparquet.DynamicRowGroup{}
 
 	// Collect all the row groups just to determine the dynamic cols
-	err := t.RowGroupIterator(ctx, math.MaxUint64, nil, &AlwaysTrueFilter{}, func(rg dynparquet.DynamicRowGroup) bool {
+	err := t.RowGroupIterator(ctx, math.MaxUint64, &AlwaysTrueFilter{}, func(rg dynparquet.DynamicRowGroup) bool {
 		rowGroups = append(rowGroups, rg)
 		return true
 	})
@@ -1269,7 +1268,7 @@ func (t *Table) collectRowGroups(ctx context.Context, tx uint64, filterExpr logi
 	memoryBlocks, lastBlockTimestamp := t.memoryBlocks()
 	for _, block := range memoryBlocks {
 		span.AddEvent("memoryBlock")
-		if err := block.RowGroupIterator(ctx, tx, filterExpr, filter, iteratorFunc); err != nil {
+		if err := block.RowGroupIterator(ctx, tx, filter, iteratorFunc); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Removes the `filterGranule` function and instead leverages the Particulate work from https://github.com/polarsignals/frostdb/pull/170.

This allows us to use the filter on the Granule itself instead of having a custom function for it.