### PR TITLE
query: Introduce array of callbacks to be called concurrently

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -225,10 +225,12 @@ func TestDBWithWAL(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			func(ctx context.Context, ar arrow.Record) error {
-				t.Log(ar)
-				defer ar.Release()
-				return nil
+			[]func(ctx context.Context, ar arrow.Record) error{
+				func(ctx context.Context, ar arrow.Record) error {
+					t.Log(ar)
+					defer ar.Release()
+					return nil
+				},
 			},
 		)
 	})

--- a/db_test.go
+++ b/db_test.go
@@ -225,7 +225,7 @@ func TestDBWithWAL(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, ar arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, ar arrow.Record) error {
 					t.Log(ar)
 					defer ar.Release()

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf h1:5yLngjz3nAomA1BbuHoRdPaCSsmy2RP2n+KF2Ew+VUs=
-github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
 github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/query/engine.go
+++ b/query/engine.go
@@ -139,5 +139,5 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(ctx contex
 		return err
 	}
 
-	return phyPlan.Execute(ctx, b.pool, callback)
+	return phyPlan.Execute(ctx, b.pool)
 }

--- a/query/engine.go
+++ b/query/engine.go
@@ -133,6 +133,7 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(ctx contex
 		b.tracer,
 		logicalPlan.InputSchema(),
 		logicalPlan,
+		callback,
 	)
 	if err != nil {
 		return err

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -11,6 +11,9 @@ import (
 	"github.com/polarsignals/frostdb/dynparquet"
 )
 
+// Callback receives an arrow.Record for further processing.
+type Callback func(ctx context.Context, r arrow.Record) error
+
 // LogicalPlan is a logical representation of a query. Each LogicalPlan is a
 // sub-tree of the query. It is built recursively.
 type LogicalPlan struct {
@@ -116,14 +119,14 @@ type TableReader interface {
 		pool memory.Allocator,
 		schema *arrow.Schema,
 		options IterOptions,
-		callbacks []func(ctx context.Context, r arrow.Record) error,
+		callbacks []Callback,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
 		options IterOptions,
-		callback []func(ctx context.Context, r arrow.Record) error,
+		callback []Callback,
 	) error
 	ArrowSchema(
 		ctx context.Context,

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -116,14 +116,14 @@ type TableReader interface {
 		pool memory.Allocator,
 		schema *arrow.Schema,
 		options IterOptions,
-		callback func(ctx context.Context, r arrow.Record) error,
+		callbacks []func(ctx context.Context, r arrow.Record) error,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
 		options IterOptions,
-		callback func(ctx context.Context, r arrow.Record) error,
+		callback []func(ctx context.Context, r arrow.Record) error,
 	) error
 	ArrowSchema(
 		ctx context.Context,

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -28,8 +28,8 @@ func (m *mockTableReader) Iterator(
 	tx uint64,
 	pool memory.Allocator,
 	schema *arrow.Schema,
-	iterOpts IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	options IterOptions,
+	callbacks []Callback,
 ) error {
 	return nil
 }
@@ -38,8 +38,8 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	options IterOptions,
+	callback []Callback,
 ) error {
 	return nil
 }

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -392,7 +392,7 @@ func appendValue(b array.Builder, arr arrow.Array, i int) error {
 }
 
 func (a *HashAggregate) Finish(ctx context.Context) error {
-	for _, callback := range a.callbacks {
+	for i := range a.callbacks {
 		ctx, span := a.tracer.Start(ctx, "HashAggregate/Finish")
 		defer span.End()
 
@@ -428,7 +428,7 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 		aggregateField := arrow.Field{Name: a.resultColumnName, Type: aggregateArray.DataType()}
 		cols := append(groupByArrays, aggregateArray)
 
-		return callback(ctx, array.NewRecord(
+		return a.next.Callbacks()[i](ctx, array.NewRecord(
 			arrow.NewSchema(append(groupByFields, aggregateField), nil),
 			cols,
 			int64(numRows),

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -117,7 +117,7 @@ type HashAggregate struct {
 	hashSeed              maphash.Seed
 
 	next      PhysicalPlan
-	callbacks []func(ctx context.Context, r arrow.Record) error
+	callbacks []logicalplan.Callback
 
 	// Buffers that are reused across callback calls.
 	groupByFields      []arrow.Field
@@ -125,7 +125,7 @@ type HashAggregate struct {
 	groupByArrays      []arrow.Array
 }
 
-func (a *HashAggregate) Callbacks() []func(ctx context.Context, r arrow.Record) error {
+func (a *HashAggregate) Callbacks() []logicalplan.Callback {
 	return a.callbacks
 }
 
@@ -241,7 +241,7 @@ func hashInt64Array(arr *array.Int64) []uint64 {
 func (a *HashAggregate) SetNext(next PhysicalPlan) {
 	a.next = next
 
-	a.callbacks = make([]func(context.Context, arrow.Record) error, 0, len(next.Callbacks()))
+	a.callbacks = make([]logicalplan.Callback, 0, len(next.Callbacks()))
 	for range next.Callbacks() {
 		a.callbacks = append(a.callbacks, func(ctx context.Context, r arrow.Record) error {
 			// Generates high volume of spans. Comment out if needed during development.

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -23,7 +23,7 @@ type Distinction struct {
 	hashSeed maphash.Seed
 
 	next      PhysicalPlan
-	callbacks []func(ctx context.Context, r arrow.Record) error
+	callbacks []logicalplan.Callback
 
 	mtx  *sync.RWMutex
 	seen map[uint64]struct{}
@@ -41,7 +41,7 @@ func Distinct(pool memory.Allocator, tracer trace.Tracer, columns []logicalplan.
 	}
 }
 
-func (d *Distinction) Callbacks() []func(ctx context.Context, r arrow.Record) error {
+func (d *Distinction) Callbacks() []logicalplan.Callback {
 	return d.callbacks
 }
 
@@ -52,7 +52,7 @@ func (d *Distinction) Finish(ctx context.Context) error {
 func (d *Distinction) SetNext(plan PhysicalPlan) {
 	d.next = plan
 
-	d.callbacks = make([]func(context.Context, arrow.Record) error, 0, len(plan.Callbacks()))
+	d.callbacks = make([]logicalplan.Callback, 0, len(plan.Callbacks()))
 	for _, callback := range plan.Callbacks() {
 		d.callbacks = append(d.callbacks, func(ctx context.Context, r arrow.Record) error {
 			// Generates high volume of spans. Comment out if needed during development.

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -19,26 +19,14 @@ import (
 type Distinction struct {
 	pool     memory.Allocator
 	tracer   trace.Tracer
-	next     PhysicalPlan
 	columns  []logicalplan.Expr
 	hashSeed maphash.Seed
 
+	next      PhysicalPlan
+	callbacks []func(ctx context.Context, r arrow.Record) error
+
 	mtx  *sync.RWMutex
 	seen map[uint64]struct{}
-}
-
-func (d *Distinction) Draw() *Diagram {
-	var child *Diagram
-	if d.next != nil {
-		child = d.next.Draw()
-	}
-
-	var columns []string
-	for _, c := range d.columns {
-		columns = append(columns, c.Name())
-	}
-
-	return &Diagram{Details: fmt.Sprintf("Distinction (%s)", strings.Join(columns, ",")), Child: child}
 }
 
 func Distinct(pool memory.Allocator, tracer trace.Tracer, columns []logicalplan.Expr) *Distinction {
@@ -53,102 +41,123 @@ func Distinct(pool memory.Allocator, tracer trace.Tracer, columns []logicalplan.
 	}
 }
 
-func (d *Distinction) SetNext(plan PhysicalPlan) {
-	d.next = plan
+func (d *Distinction) Callbacks() []func(ctx context.Context, r arrow.Record) error {
+	return d.callbacks
 }
 
 func (d *Distinction) Finish(ctx context.Context) error {
 	return d.next.Finish(ctx)
 }
 
-func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
-	// Generates high volume of spans. Comment out if needed during development.
-	// ctx, span := d.tracer.Start(ctx, "Distinction/Callback")
-	// defer span.End()
+func (d *Distinction) SetNext(plan PhysicalPlan) {
+	d.next = plan
 
-	distinctFields := make([]arrow.Field, 0, 10)
-	distinctFieldHashes := make([]uint64, 0, 10)
-	distinctArrays := make([]arrow.Array, 0, 10)
+	d.callbacks = make([]func(context.Context, arrow.Record) error, 0, len(plan.Callbacks()))
+	for _, callback := range plan.Callbacks() {
+		d.callbacks = append(d.callbacks, func(ctx context.Context, r arrow.Record) error {
+			// Generates high volume of spans. Comment out if needed during development.
+			// ctx, span := d.tracer.Start(ctx, "Distinction/Callback")
+			// defer span.End()
 
-	for i, field := range r.Schema().Fields() {
-		for _, col := range d.columns {
-			if col.MatchColumn(field.Name) {
-				distinctFields = append(distinctFields, field)
-				distinctFieldHashes = append(distinctFieldHashes, scalar.Hash(d.hashSeed, scalar.NewStringScalar(field.Name)))
-				distinctArrays = append(distinctArrays, r.Column(i))
-			}
-		}
-	}
+			distinctFields := make([]arrow.Field, 0, 10)
+			distinctFieldHashes := make([]uint64, 0, 10)
+			distinctArrays := make([]arrow.Array, 0, 10)
 
-	resBuilders := make([]array.Builder, 0, len(distinctArrays))
-	for _, arr := range distinctArrays {
-		resBuilders = append(resBuilders, array.NewBuilder(d.pool, arr.DataType()))
-	}
-	rows := int64(0)
-
-	numRows := int(r.NumRows())
-
-	colHashes := make([][]uint64, len(distinctFields))
-	for i, arr := range distinctArrays {
-		colHashes[i] = hashArray(arr)
-	}
-
-	for i := 0; i < numRows; i++ {
-		hash := uint64(0)
-		for j := range colHashes {
-			if colHashes[j][i] == 0 {
-				continue
+			for i, field := range r.Schema().Fields() {
+				for _, col := range d.columns {
+					if col.MatchColumn(field.Name) {
+						distinctFields = append(distinctFields, field)
+						distinctFieldHashes = append(distinctFieldHashes, scalar.Hash(d.hashSeed, scalar.NewStringScalar(field.Name)))
+						distinctArrays = append(distinctArrays, r.Column(i))
+					}
+				}
 			}
 
-			hash = hashCombine(
-				hash,
-				hashCombine(
-					distinctFieldHashes[j],
-					colHashes[j][i],
-				),
+			resBuilders := make([]array.Builder, 0, len(distinctArrays))
+			for _, arr := range distinctArrays {
+				resBuilders = append(resBuilders, array.NewBuilder(d.pool, arr.DataType()))
+			}
+			rows := int64(0)
+
+			numRows := int(r.NumRows())
+
+			colHashes := make([][]uint64, len(distinctFields))
+			for i, arr := range distinctArrays {
+				colHashes[i] = hashArray(arr)
+			}
+
+			for i := 0; i < numRows; i++ {
+				hash := uint64(0)
+				for j := range colHashes {
+					if colHashes[j][i] == 0 {
+						continue
+					}
+
+					hash = hashCombine(
+						hash,
+						hashCombine(
+							distinctFieldHashes[j],
+							colHashes[j][i],
+						),
+					)
+				}
+
+				d.mtx.RLock()
+				if _, ok := d.seen[hash]; ok {
+					d.mtx.RUnlock()
+					continue
+				}
+				d.mtx.RUnlock()
+
+				for j, arr := range distinctArrays {
+					err := appendValue(resBuilders[j], arr, i)
+					if err != nil {
+						return err
+					}
+				}
+
+				rows++
+				d.mtx.Lock()
+				d.seen[hash] = struct{}{}
+				d.mtx.Unlock()
+			}
+
+			if rows == 0 {
+				// No need to call anything further down the chain, no new values were
+				// seen so we can skip.
+				return nil
+			}
+
+			resArrays := make([]arrow.Array, 0, len(resBuilders))
+			for _, builder := range resBuilders {
+				resArrays = append(resArrays, builder.NewArray())
+			}
+
+			schema := arrow.NewSchema(distinctFields, nil)
+
+			distinctRecord := array.NewRecord(
+				schema,
+				resArrays,
+				rows,
 			)
-		}
 
-		d.mtx.RLock()
-		if _, ok := d.seen[hash]; ok {
-			d.mtx.RUnlock()
-			continue
-		}
-		d.mtx.RUnlock()
+			err := callback(ctx, distinctRecord)
+			distinctRecord.Release()
+			return err
+		})
+	}
+}
 
-		for j, arr := range distinctArrays {
-			err := appendValue(resBuilders[j], arr, i)
-			if err != nil {
-				return err
-			}
-		}
-
-		rows++
-		d.mtx.Lock()
-		d.seen[hash] = struct{}{}
-		d.mtx.Unlock()
+func (d *Distinction) Draw() *Diagram {
+	var child *Diagram
+	if d.next != nil {
+		child = d.next.Draw()
 	}
 
-	if rows == 0 {
-		// No need to call anything further down the chain, no new values were
-		// seen so we can skip.
-		return nil
+	var columns []string
+	for _, c := range d.columns {
+		columns = append(columns, c.Name())
 	}
 
-	resArrays := make([]arrow.Array, 0, len(resBuilders))
-	for _, builder := range resBuilders {
-		resArrays = append(resArrays, builder.NewArray())
-	}
-
-	schema := arrow.NewSchema(distinctFields, nil)
-
-	distinctRecord := array.NewRecord(
-		schema,
-		resArrays,
-		rows,
-	)
-
-	err := d.next.Callback(ctx, distinctRecord)
-	distinctRecord.Release()
-	return err
+	return &Diagram{Details: fmt.Sprintf("Distinction(%d) (%s)", len(d.callbacks), strings.Join(columns, ",")), Child: child}
 }

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -22,7 +22,7 @@ type PredicateFilter struct {
 	filterExpr BooleanExpression
 
 	next      PhysicalPlan
-	callbacks []func(ctx context.Context, r arrow.Record) error
+	callbacks []logicalplan.Callback
 }
 
 func (f *PredicateFilter) Draw() *Diagram {
@@ -225,14 +225,14 @@ func newFilter(pool memory.Allocator, tracer trace.Tracer, filterExpr BooleanExp
 	}
 }
 
-func (f *PredicateFilter) Callbacks() []func(ctx context.Context, r arrow.Record) error {
+func (f *PredicateFilter) Callbacks() []logicalplan.Callback {
 	return f.callbacks
 }
 
 func (f *PredicateFilter) SetNext(next PhysicalPlan) {
 	f.next = next
 
-	f.callbacks = make([]func(ctx context.Context, r arrow.Record) error, 0, len(next.Callbacks()))
+	f.callbacks = make([]logicalplan.Callback, 0, len(next.Callbacks()))
 	for _, callback := range next.Callbacks() {
 		f.callbacks = append(f.callbacks, func(ctx context.Context, r arrow.Record) error {
 			// Generates high volume of spans. Comment out if needed during development.

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
@@ -15,8 +14,8 @@ import (
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
-// TODO: Be smarter about the wanted concurrency
-var concurrencyHardcoded = runtime.NumCPU()
+// TODO: Make this smarter and concurrent
+var concurrencyHardcoded = 1
 
 type PhysicalPlan interface {
 	Callbacks() []logicalplan.Callback
@@ -78,7 +77,7 @@ func (e *OutputPlan) SetNext(next PhysicalPlan) {
 	panic("bug in builder! output plan should not have a next plan!")
 }
 
-func (e *OutputPlan) Execute(ctx context.Context, pool memory.Allocator, _ func(ctx context.Context, r arrow.Record) error) error {
+func (e *OutputPlan) Execute(ctx context.Context, pool memory.Allocator) error {
 	return e.scan.Execute(ctx, pool)
 }
 

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -14,7 +14,7 @@ import (
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
-// TODO: Make this smarter and concurrent
+// TODO: Make this smarter and concurrent.
 var concurrencyHardcoded = 1
 
 type PhysicalPlan interface {

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -31,7 +31,7 @@ func (m *mockTableReader) Iterator(
 	pool memory.Allocator,
 	schema *arrow.Schema,
 	iterOpts logicalplan.IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callbacks []logicalplan.Callback,
 ) error {
 	return nil
 }
@@ -41,7 +41,7 @@ func (m *mockTableReader) SchemaIterator(
 	tx uint64,
 	pool memory.Allocator,
 	iterOpts logicalplan.IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callback []logicalplan.Callback,
 ) error {
 	return nil
 }

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -91,6 +91,7 @@ func TestBuildPhysicalPlan(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		dynparquet.NewSampleSchema(),
 		p,
+		func(ctx context.Context, record arrow.Record) error { return nil },
 	)
 	require.NoError(t, err)
 }

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -159,7 +159,7 @@ type Projection struct {
 	colProjections []columnProjection
 
 	next      PhysicalPlan
-	callbacks []func(context.Context, arrow.Record) error
+	callbacks []logicalplan.Callback
 }
 
 func Project(mem memory.Allocator, tracer trace.Tracer, exprs []logicalplan.Expr) (*Projection, error) {
@@ -180,7 +180,7 @@ func Project(mem memory.Allocator, tracer trace.Tracer, exprs []logicalplan.Expr
 	return p, nil
 }
 
-func (p *Projection) Callbacks() []func(ctx context.Context, r arrow.Record) error {
+func (p *Projection) Callbacks() []logicalplan.Callback {
 	return p.callbacks
 }
 
@@ -191,7 +191,7 @@ func (p *Projection) Finish(ctx context.Context) error {
 func (p *Projection) SetNext(next PhysicalPlan) {
 	p.next = next
 
-	p.callbacks = make([]func(context.Context, arrow.Record) error, 0, len(next.Callbacks()))
+	p.callbacks = make([]logicalplan.Callback, 0, len(next.Callbacks()))
 	for _, callback := range next.Callbacks() {
 		p.callbacks = append(p.callbacks, func(ctx context.Context, r arrow.Record) error {
 			// Generates high volume of spans. Comment out if needed during development.

--- a/table.go
+++ b/table.go
@@ -442,7 +442,7 @@ func (t *Table) Iterator(
 	pool memory.Allocator,
 	schema *arrow.Schema,
 	iterOpts logicalplan.IterOptions,
-	iterators []func(ctx context.Context, r arrow.Record) error,
+	iterators []logicalplan.Callback,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "Table/Iterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))
@@ -512,7 +512,7 @@ func (t *Table) SchemaIterator(
 	tx uint64,
 	pool memory.Allocator,
 	iterOpts logicalplan.IterOptions,
-	iterators []func(ctx context.Context, r arrow.Record) error,
+	iterators []logicalplan.Callback,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "Table/SchemaIterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))

--- a/table_test.go
+++ b/table_test.go
@@ -176,7 +176,7 @@ func TestTable(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					t.Log(r)
 					defer r.Release()
@@ -323,7 +323,7 @@ func Test_Table_GranuleSplit(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					defer r.Release()
 					t.Log(r)
@@ -483,7 +483,7 @@ func Test_Table_InsertLowest(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					defer r.Release()
 					t.Log(r)
@@ -594,7 +594,7 @@ func Test_Table_Concurrency(t *testing.T) {
 					pool,
 					as,
 					logicalplan.IterOptions{},
-					[]func(ctx context.Context, r arrow.Record) error{
+					[]logicalplan.Callback{
 						func(ctx context.Context, r arrow.Record) error {
 							totalrows += r.NumRows()
 							defer r.Release()
@@ -727,7 +727,7 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 				pool,
 				as,
 				logicalplan.IterOptions{},
-				[]func(ctx context.Context, r arrow.Record) error{
+				[]logicalplan.Callback{
 					func(ctx context.Context, r arrow.Record) error {
 						defer r.Release()
 						totalrows += r.NumRows()
@@ -832,7 +832,7 @@ func Test_Table_ReadIsolation(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					rows += r.NumRows()
 					defer r.Release()
@@ -862,7 +862,7 @@ func Test_Table_ReadIsolation(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					rows += r.NumRows()
 					defer r.Release()
@@ -1207,7 +1207,7 @@ func Test_Table_Filter(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{Filter: filterExpr},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					defer r.Release()
 
@@ -1285,7 +1285,7 @@ func Test_Table_Bloomfilter(t *testing.T) {
 			memory.NewGoAllocator(),
 			nil,
 			logicalplan.IterOptions{Filter: logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4"))},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					defer r.Release()
 					iterations++
@@ -1399,7 +1399,7 @@ func Test_Table_InsertCancellation(t *testing.T) {
 					pool,
 					as,
 					logicalplan.IterOptions{},
-					[]func(ctx context.Context, r arrow.Record) error{
+					[]logicalplan.Callback{
 						func(ctx context.Context, r arrow.Record) error {
 							totalrows += r.NumRows()
 							defer r.Release()
@@ -1484,7 +1484,7 @@ func Test_Table_CancelBasic(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					totalrows += r.NumRows()
 					defer r.Release()
@@ -1725,7 +1725,7 @@ func Test_DoubleTable(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			[]func(ctx context.Context, r arrow.Record) error{
+			[]logicalplan.Callback{
 				func(ctx context.Context, r arrow.Record) error {
 					defer r.Release()
 					require.Equal(t, value, r.Column(1).(*array.Float64).Value(0))


### PR DESCRIPTION
For now, we only ever call the first callback, since not all operators of the PhysicalPlan are concurrency-safe yet.

Overall the plan is already concurrency ready as per our "draw" output that only works based on the amount of callbacks. 
```
TableScan(24x) - Projection(24x) (labels.label1) - Distinction(24x) (labels.label1)
```

An easier-to-understand version of this idea is available in #184 