### PR TITLE
pqarrow: avoid creating dictionary on distinct fast path

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -377,22 +377,7 @@ func writeColumnToArray(
 		}
 
 		if !readPages {
-			valBytes := globalMinValue.Bytes()
-			// TODO(asubiotto): columnType should be sufficient for this code.
-			// However, due to
-			// https://github.com/segmentio/parquet-go/issues/312,
-			// some tests panic when using a parquet.Buffer as a data source,
-			// so we use the explicitly passed in type here.
-			dict := t.NewDictionary(
-				columnChunk.Column(),
-				1,
-				t.NewValues(valBytes, []uint32{0, uint32(len(valBytes))}),
-			)
-			for pageIdx := 0; pageIdx < columnIndex.NumPages(); pageIdx++ {
-				if err := w.WritePage(dict.Page()); err != nil {
-					return fmt.Errorf("write dictionary page: %w", err)
-				}
-			}
+			w.Write([]parquet.Value{globalMinValue})
 			return nil
 		}
 	}


### PR DESCRIPTION
On the distinct fast path, we were previously creating a dictionary from the
index value and then writing that dictionary's page for each page in a column
chunk.

This commit skips this unnecessary step and writes the single index value
directly to the writer. The code already checks that the index value is the
same across all pages, so only needs to be written once to the underlying
writer. This gives us a nice reduction in allocations, although it was mostly
an oversight on my part:

```
name          old time/op    new time/op    delta
QueryTypes-8    42.5ms ±10%    40.7ms ± 6%     ~     (p=0.571 n=5+3)

name          old alloc/op   new alloc/op   delta
QueryTypes-8    80.6MB ± 0%    79.1MB ± 0%   -1.85%  (p=0.036 n=5+3)

name          old allocs/op  new allocs/op  delta
QueryTypes-8      447k ± 0%      383k ± 0%  -14.25%  (p=0.000 n=5+3)
```