### PR TITLE
Create array of PhysicalPlans to prepare for concurrency

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -221,11 +221,11 @@ func TestDBWithWAL(t *testing.T) {
 			pool,
 			as,
 			logicalplan.IterOptions{},
-			func(ctx context.Context, ar arrow.Record) error {
+			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				t.Log(ar)
 				defer ar.Release()
 				return nil
-			},
+			}},
 		)
 	})
 	require.NoError(t, err)

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -25,6 +25,10 @@ type LogicalPlan struct {
 	Aggregation *Aggregation
 }
 
+// Callback is a function that is called throughout a chain of operators
+// modifying the underlying data.
+type Callback func(ctx context.Context, r arrow.Record) error
+
 // IterOptions are a set of options for the TableReader Iterators
 // TODO: should we instead use the option pattern? Is that possible with the way the Iterator functions work?
 type IterOptions struct {
@@ -116,14 +120,14 @@ type TableReader interface {
 		pool memory.Allocator,
 		schema *arrow.Schema,
 		options IterOptions,
-		callback func(ctx context.Context, r arrow.Record) error,
+		callbacks []Callback,
 	) error
 	SchemaIterator(
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
 		options IterOptions,
-		callback func(ctx context.Context, r arrow.Record) error,
+		callbacks []Callback,
 	) error
 	ArrowSchema(
 		ctx context.Context,

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -29,7 +29,7 @@ func (m *mockTableReader) Iterator(
 	pool memory.Allocator,
 	schema *arrow.Schema,
 	iterOpts IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callbacks []Callback,
 ) error {
 	return nil
 }
@@ -39,7 +39,7 @@ func (m *mockTableReader) SchemaIterator(
 	tx uint64,
 	pool memory.Allocator,
 	iterOpts IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callbacks []Callback,
 ) error {
 	return nil
 }

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -31,7 +31,7 @@ func (m *mockTableReader) Iterator(
 	pool memory.Allocator,
 	schema *arrow.Schema,
 	iterOpts logicalplan.IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callbacks []logicalplan.Callback,
 ) error {
 	return nil
 }
@@ -41,7 +41,7 @@ func (m *mockTableReader) SchemaIterator(
 	tx uint64,
 	pool memory.Allocator,
 	iterOpts logicalplan.IterOptions,
-	callback func(ctx context.Context, r arrow.Record) error,
+	callbacks []logicalplan.Callback,
 ) error {
 	return nil
 }

--- a/table.go
+++ b/table.go
@@ -474,7 +474,7 @@ func (t *Table) Iterator(
 	pool memory.Allocator,
 	schema *arrow.Schema,
 	iterOpts logicalplan.IterOptions,
-	iterator func(ctx context.Context, r arrow.Record) error,
+	callbacks []logicalplan.Callback,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "Table/Iterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))
@@ -486,6 +486,8 @@ func (t *Table) Iterator(
 	if err != nil {
 		return err
 	}
+
+	callback := callbacks[0]
 
 	// Previously we sorted all row groups into a single row group here,
 	// but it turns out that none of the downstream uses actually rely on
@@ -535,7 +537,7 @@ func (t *Table) Iterator(
 			if recordBuilderExceedsNumRows(builder, builderBufferSize) {
 				r := builder.NewRecord()
 				prepareForFlush(r, rg.Schema())
-				if err := iterator(ctx, r); err != nil {
+				if err := callback(ctx, r); err != nil {
 					return err
 				}
 				r.Release()
@@ -547,7 +549,7 @@ func (t *Table) Iterator(
 		// Flush the builder.
 		r := builder.NewRecord()
 		prepareForFlush(r, rowGroups[0].Schema())
-		if err := iterator(ctx, r); err != nil {
+		if err := callback(ctx, r); err != nil {
 			return err
 		}
 		r.Release()
@@ -563,13 +565,15 @@ func (t *Table) SchemaIterator(
 	tx uint64,
 	pool memory.Allocator,
 	iterOpts logicalplan.IterOptions,
-	iterator func(ctx context.Context, r arrow.Record) error,
+	callbacks []logicalplan.Callback,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "Table/SchemaIterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))
 	span.SetAttributes(attribute.Int("projections", len(iterOpts.Projection)))
 	span.SetAttributes(attribute.Int("distinct", len(iterOpts.DistinctColumns)))
 	defer span.End()
+
+	callback := callbacks[0]
 
 	rowGroups, err := t.collectRowGroups(ctx, tx, iterOpts.Filter)
 	if err != nil {
@@ -598,7 +602,7 @@ func (t *Table) SchemaIterator(
 			b.Field(0).(*array.StringBuilder).AppendValues(fieldNames, nil)
 
 			record := b.NewRecord()
-			err = iterator(ctx, record)
+			err = callback(ctx, record)
 			record.Release()
 			b.Release()
 			if err != nil {

--- a/table.go
+++ b/table.go
@@ -487,6 +487,7 @@ func (t *Table) Iterator(
 		return err
 	}
 
+	// This is a compatibility call until we have concurrency.
 	callback := callbacks[0]
 
 	// Previously we sorted all row groups into a single row group here,
@@ -573,6 +574,7 @@ func (t *Table) SchemaIterator(
 	span.SetAttributes(attribute.Int("distinct", len(iterOpts.DistinctColumns)))
 	defer span.End()
 
+	// This is a compatibility call until we have concurrency.
 	callback := callbacks[0]
 
 	rowGroups, err := t.collectRowGroups(ctx, tx, iterOpts.Filter)


### PR DESCRIPTION
All slices only have 1 entry which means no concurrency.

The Diagrams are currently broken, but I'll update them afterward. 
I think it makes sense to build a tree for those and use some sort of ASCI lib to print the tree. 