### PR TITLE
Granule by size

### DIFF
--- a/db.go
+++ b/db.go
@@ -34,6 +34,7 @@ type ColumnStore struct {
 	logger               log.Logger
 	tracer               trace.Tracer
 	granuleSize          int
+	granuleSizeBytes     int64
 	activeMemorySize     int64
 	storagePath          string
 	bucket               objstore.Bucket
@@ -59,7 +60,8 @@ func New(
 		tracer:           trace.NewNoopTracerProvider().Tracer(""),
 		indexDegree:      2,
 		splitSize:        2,
-		granuleSize:      8192,
+		granuleSize:      8196,
+		granuleSizeBytes: 25 * 1024 * 1024,  // 25MB granule size before splitting
 		activeMemorySize: 512 * 1024 * 1024, // 512MB
 	}
 
@@ -93,6 +95,13 @@ func WithTracer(tracer trace.Tracer) Option {
 func WithRegistry(reg prometheus.Registerer) Option {
 	return func(s *ColumnStore) error {
 		s.reg = reg
+		return nil
+	}
+}
+
+func WithGranuleSizeBytes(bytes int64) Option {
+	return func(s *ColumnStore) error {
+		s.granuleSizeBytes = bytes
 		return nil
 	}
 }

--- a/db.go
+++ b/db.go
@@ -33,7 +33,6 @@ type ColumnStore struct {
 	reg                  prometheus.Registerer
 	logger               log.Logger
 	tracer               trace.Tracer
-	granuleSize          int
 	granuleSizeBytes     int64
 	activeMemorySize     int64
 	storagePath          string
@@ -60,7 +59,6 @@ func New(
 		tracer:           trace.NewNoopTracerProvider().Tracer(""),
 		indexDegree:      2,
 		splitSize:        2,
-		granuleSize:      8196,
 		granuleSizeBytes: 25 * 1024 * 1024,  // 25MB granule size before splitting
 		activeMemorySize: 512 * 1024 * 1024, // 512MB
 	}
@@ -102,13 +100,6 @@ func WithRegistry(reg prometheus.Registerer) Option {
 func WithGranuleSizeBytes(bytes int64) Option {
 	return func(s *ColumnStore) error {
 		s.granuleSizeBytes = bytes
-		return nil
-	}
-}
-
-func WithGranuleSize(size int) Option {
-	return func(s *ColumnStore) error {
-		s.granuleSize = size
 		return nil
 	}
 }

--- a/db.go
+++ b/db.go
@@ -59,7 +59,7 @@ func New(
 		tracer:           trace.NewNoopTracerProvider().Tracer(""),
 		indexDegree:      2,
 		splitSize:        2,
-		granuleSizeBytes: 25 * 1024 * 1024,  // 25MB granule size before splitting
+		granuleSizeBytes: 1 * 1024 * 1024,   // 1MB granule size before splitting
 		activeMemorySize: 512 * 1024 * 1024, // 512MB
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -44,7 +44,6 @@ func TestDBWithWALAndBucket(t *testing.T) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithGranuleSize(8096),
 		WithWAL(),
 		WithStoragePath(dir),
 		WithBucketStorage(bucket),
@@ -71,7 +70,6 @@ func TestDBWithWALAndBucket(t *testing.T) {
 
 	c, err = New(
 		WithLogger(logger),
-		WithGranuleSize(8096),
 		WithWAL(),
 		WithStoragePath(dir),
 		WithBucketStorage(bucket),
@@ -96,7 +94,6 @@ func TestDBWithWAL(t *testing.T) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithGranuleSize(8096),
 		WithWAL(),
 		WithStoragePath(dir),
 	)
@@ -199,7 +196,6 @@ func TestDBWithWAL(t *testing.T) {
 
 	c, err = New(
 		WithLogger(logger),
-		WithGranuleSize(8096),
 		WithWAL(),
 		WithStoragePath(dir),
 	)
@@ -240,7 +236,6 @@ func TestDBWithWAL(t *testing.T) {
 	// One granule with 3 parts
 	require.Equal(t, 1, table.active.Index().Len())
 	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).parts.total.Load())
-	require.Equal(t, uint64(5), table.active.Index().Min().(*Granule).metadata.card.Load())
 	require.Equal(t, parquet.Row{
 		parquet.ValueOf("test").Level(0, 0, 0),
 		parquet.ValueOf("value1").Level(0, 1, 1),

--- a/table.go
+++ b/table.go
@@ -835,9 +835,14 @@ func (t *TableBlock) compactGranule(granule *Granule) error {
 		return fmt.Errorf("new granule: %w", err)
 	}
 
-	granules, err := g.split(tx, t.table.db.columnStore.granuleSize/t.table.db.columnStore.splitSize)
-	if err != nil {
-		return fmt.Errorf("splitting granule: %w", err)
+	granules := []*Granule{g}
+	// only split the granule if it has exceeded the size
+	if serBuf.ParquetFile().Size() > t.table.db.columnStore.granuleSizeBytes {
+		granules, err = g.split(tx, t.table.db.columnStore.granuleSize/t.table.db.columnStore.splitSize)
+		if err != nil {
+			return fmt.Errorf("splitting granule: %w", err)
+		}
+
 	}
 
 	// add remaining parts onto new granules

--- a/table.go
+++ b/table.go
@@ -862,12 +862,6 @@ func (t *TableBlock) compactGranule(granule *Granule) error {
 		return fmt.Errorf("closing schema writer: %w", err)
 	}
 
-	/*
-		if n < t.table.db.columnStore.granuleSize { // It's possible to have a Granule marked for compaction but all the parts in it aren't completed tx's yet
-			return fmt.Errorf("not enough completed transactions")
-		}
-	*/
-
 	serBuf, err := dynparquet.ReaderFromBytes(b.Bytes())
 	if err != nil {
 		return fmt.Errorf("reader from bytes: %w", err)

--- a/table.go
+++ b/table.go
@@ -886,7 +886,6 @@ func (t *TableBlock) compactGranule(granule *Granule) error {
 		if err != nil {
 			return fmt.Errorf("splitting granule: %w", err)
 		}
-
 	}
 
 	// add remaining parts onto new granules
@@ -1051,8 +1050,7 @@ func (t *TableBlock) splitRowsByGranule(buf *dynparquet.SerializedBuffer) (map[*
 				if prev != nil {
 					_, ok := rowsByGranule[prev]
 					if !ok {
-						// TODO
-						rowsByGranule[prev] = map[int]struct{}{idx: struct{}{}}
+						rowsByGranule[prev] = map[int]struct{}{idx: {}}
 					} else {
 						rowsByGranule[prev][idx] = struct{}{}
 					}

--- a/table.go
+++ b/table.go
@@ -325,6 +325,7 @@ func (t *Table) RotateBlock(block *TableBlock) error {
 		return err
 	}
 	t.metrics.blockRotated.Inc()
+	t.metrics.numParts.Set(float64(0))
 
 	t.pendingBlocks[block] = struct{}{}
 	go t.writeBlock(block)

--- a/table_test.go
+++ b/table_test.go
@@ -1078,7 +1078,7 @@ func Test_Table_InsertCancellation(t *testing.T) {
 		"1024": {1024},
 	}
 
-	for name, _ := range tests {
+	for name := range tests {
 		t.Run(name, func(t *testing.T) {
 			table := basicTable(t)
 			ctx := context.Background()

--- a/table_test.go
+++ b/table_test.go
@@ -50,7 +50,7 @@ func newTestLogger(t TestLogHelper) log.Logger {
 	return logger
 }
 
-func basicTable(t *testing.T, granuleSize int) *Table {
+func basicTable(t *testing.T, options ...Option) *Table {
 	config := NewTableConfig(
 		dynparquet.NewSampleSchema(),
 	)
@@ -58,8 +58,7 @@ func basicTable(t *testing.T, granuleSize int) *Table {
 	logger := newTestLogger(t)
 
 	c, err := New(
-		WithLogger(logger),
-		WithGranuleSize(granuleSize),
+		append([]Option{WithLogger(logger)}, options...)...,
 	)
 	require.NoError(t, err)
 
@@ -72,7 +71,7 @@ func basicTable(t *testing.T, granuleSize int) *Table {
 }
 
 func TestTable(t *testing.T) {
-	table := basicTable(t, 2^12)
+	table := basicTable(t)
 
 	samples := dynparquet.Samples{{
 		ExampleType: "test",
@@ -191,7 +190,6 @@ func TestTable(t *testing.T) {
 	// One granule with 3 parts
 	require.Equal(t, 1, table.active.Index().Len())
 	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).parts.total.Load())
-	require.Equal(t, uint64(5), table.active.Index().Min().(*Granule).metadata.card.Load())
 	require.Equal(t, parquet.Row{
 		parquet.ValueOf("test").Level(0, 0, 0),
 		parquet.ValueOf("value1").Level(0, 1, 1),
@@ -206,7 +204,7 @@ func TestTable(t *testing.T) {
 }
 
 func Test_Table_GranuleSplit(t *testing.T) {
-	table := basicTable(t, 4)
+	table := basicTable(t, WithGranuleSizeBytes(40))
 
 	samples := dynparquet.Samples{{
 		Labels: []dynparquet.Label{
@@ -324,175 +322,22 @@ func Test_Table_GranuleSplit(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).metadata.card.Load())
-	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).metadata.card.Load())
-}
-
-/*
-This test is meant for the following case
-If the table index is as follows
-
-[10,11]
-
-	\
-	[12,13,14]
-
-And we try and insert [8,9], we expect them to be inserted into the top granule
-
-[8,9,10,11]
-
-	\
-	[12,13]
-*/
-func Test_Table_InsertLowest(t *testing.T) {
-	table := basicTable(t, 4)
-
-	samples := dynparquet.Samples{{
-		Labels: []dynparquet.Label{
-			{Name: "label13", Value: "value13"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}, {
-		Labels: []dynparquet.Label{
-			{Name: "label12", Value: "value12"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}, {
-		Labels: []dynparquet.Label{
-			{Name: "label11", Value: "value11"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}, {
-		Labels: []dynparquet.Label{
-			{Name: "label10", Value: "value10"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}}
-
-	buf, err := samples.ToBuffer(table.Schema())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-
-	// Since we are inserting 4 elements and the granule size is 4, the granule
-	// will immediately split.
-	_, err = table.InsertBuffer(ctx, buf)
-	require.NoError(t, err)
-
-	// Since a compaction happens async, it may abort if it runs before the transactions are completed. In that case; we'll manually compact the granule
-	table.Sync()
-	if table.active.Index().Len() == 1 {
-		table.active.wg.Add(1)
-		table.active.compact(table.active.Index().Min().(*Granule))
-		table.Sync()
-	}
-
-	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(2), table.active.Index().Min().(*Granule).metadata.card.Load()) // [13, 12]
-	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11, 10]
-
-	samples = dynparquet.Samples{{
-		Labels: []dynparquet.Label{
-			{Name: "label14", Value: "value14"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}}
-
-	buf, err = samples.ToBuffer(table.Schema())
-	require.NoError(t, err)
-
-	_, err = table.InsertBuffer(ctx, buf)
-	require.NoError(t, err)
-
-	// Wait for the index to be updated by the asynchronous granule split.
-	table.Sync()
-
-	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).metadata.card.Load()) // [14, 13, 12]
-	require.Equal(t, uint64(2), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11, 10]
-
-	// Insert a new column that is the lowest column yet; expect it to be added to the minimum column
-	samples = dynparquet.Samples{{
-		Labels: []dynparquet.Label{
-			{Name: "label1", Value: "value1"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 10,
-		Value:     10,
-	}}
-
-	buf, err = samples.ToBuffer(table.Schema())
-	require.NoError(t, err)
-
-	_, err = table.InsertBuffer(ctx, buf)
-	require.NoError(t, err)
-
-	// Wait for the index to be updated by the asynchronous granule split.
-	table.Sync()
-
-	pool := memory.NewGoAllocator()
-
-	err = table.View(ctx, func(ctx context.Context, tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, logicalplan.IterOptions{})
-		if err != nil {
-			return err
-		}
-
-		return table.Iterator(ctx, tx, pool, as, logicalplan.IterOptions{}, func(ctx context.Context, r arrow.Record) error {
-			defer r.Release()
-			t.Log(r)
-			return nil
-		})
-	})
-	require.NoError(t, err)
-
-	require.Equal(t, 2, table.active.Index().Len())
-	require.Equal(t, uint64(3), table.active.Index().Min().(*Granule).metadata.card.Load()) // [14,13,12]
-	require.Equal(t, uint64(3), table.active.Index().Max().(*Granule).metadata.card.Load()) // [11,10,1]
 }
 
 // This test issues concurrent writes to the database, and expects all of them to be recorded successfully.
 func Test_Table_Concurrency(t *testing.T) {
 	tests := map[string]struct {
-		granuleSize int
+		granuleSize int64
 	}{
-		"8192": {8192},
-		"4096": {4096},
-		"2048": {2048},
-		"1024": {1024},
+		"25MB": {25 * 1024 * 1024},
+		"15MB": {15 * 1024 * 1024},
+		"8MB":  {8 * 1024 * 1024},
+		"1MB":  {1024 * 1024},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			table := basicTable(t, test.granuleSize)
+			table := basicTable(t, WithGranuleSizeBytes(test.granuleSize))
 			defer os.RemoveAll("test")
 
 			generateRows := func(n int) *dynparquet.Buffer {
@@ -612,7 +457,6 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithGranuleSize(512),
 		WithWAL(),
 		WithStoragePath(dir),
 	)
@@ -709,7 +553,7 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 }
 
 func Test_Table_ReadIsolation(t *testing.T) {
-	table := basicTable(t, 2<<12)
+	table := basicTable(t)
 
 	samples := dynparquet.Samples{{
 		Labels: []dynparquet.Label{
@@ -1040,7 +884,7 @@ func Test_Table_NewTableValidSplitSize(t *testing.T) {
 }
 
 func Test_Table_Filter(t *testing.T) {
-	table := basicTable(t, 2^12)
+	table := basicTable(t)
 
 	samples := dynparquet.Samples{{
 		ExampleType: "test",
@@ -1161,7 +1005,7 @@ func Test_Table_Filter(t *testing.T) {
 }
 
 func Test_Table_Bloomfilter(t *testing.T) {
-	table := basicTable(t, 2^12)
+	table := basicTable(t)
 
 	samples := dynparquet.Samples{{
 		ExampleType: "test",
@@ -1234,9 +1078,9 @@ func Test_Table_InsertCancellation(t *testing.T) {
 		"1024": {1024},
 	}
 
-	for name, test := range tests {
+	for name, _ := range tests {
 		t.Run(name, func(t *testing.T) {
-			table := basicTable(t, test.granuleSize)
+			table := basicTable(t)
 			ctx := context.Background()
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
 			defer cancel()
@@ -1336,7 +1180,7 @@ func Test_Table_InsertCancellation(t *testing.T) {
 }
 
 func Test_Table_CancelBasic(t *testing.T) {
-	table := basicTable(t, 8192)
+	table := basicTable(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -1410,7 +1254,7 @@ func Test_Table_CancelBasic(t *testing.T) {
 }
 
 func Test_Table_ArrowSchema(t *testing.T) {
-	table := basicTable(t, 8192)
+	table := basicTable(t)
 
 	samples := dynparquet.Samples{{
 		ExampleType: "test",
@@ -1588,7 +1432,6 @@ func Test_DoubleTable(t *testing.T) {
 	logger := newTestLogger(t)
 	c, err := New(
 		WithLogger(logger),
-		WithGranuleSize(4096),
 		WithBucketStorage(bucket),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8681572/188913971-98caaa0b-ec8d-463f-a456-45f6b66ae12d.png)

This change is in lieu of https://github.com/polarsignals/frostdb/pull/179
While that change had a large amount of memory savings, it came at the cost of significantly decreased query performance due to having to open the parquet files every time. 

This change does two things:
1. Changes compaction:
granules are compacted based on their overall size in bytes from the parquet files they hold instead of raw number of rows. If however after a granule is compacted, its new size is less than that of the setting, it does not split the granule into two but instead replaces the previous granule with the new compacted one.
2. Uses a single writer during inserts instead of a writer per granule. 

```thor@thors-MacBook-Pro frostdb % benchstat before.txt 1mbgranule.txt
name                                          old time/op    new time/op    delta
QueryTypes-10                                   13.9ms ± 0%    18.4ms ± 0%   ~     (p=1.000 n=1+1)
QueryMerge-10                                    208ms ± 0%      19ms ± 0%   ~     (p=1.000 n=1+1)
QueryRange-10                                    206ms ± 0%      13ms ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_1000Rows_10Iters_10Writers-10      563ms ± 0%     597ms ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_1000Iters_1Writers-10      539ms ± 0%     160ms ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_100Iters_100Writers-10     68.6s ± 0%     70.7s ± 0%   ~     (p=1.000 n=1+1)

name                                          old alloc/op   new alloc/op   delta
QueryTypes-10                                   37.8MB ± 0%    26.3MB ± 0%   ~     (p=1.000 n=1+1)
QueryMerge-10                                    275MB ± 0%      54MB ± 0%   ~     (p=1.000 n=1+1)
QueryRange-10                                    260MB ± 0%      25MB ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_1000Rows_10Iters_10Writers-10     97.3MB ± 0%    55.3MB ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_1000Iters_1Writers-10      742MB ± 0%     208MB ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_100Iters_100Writers-10    2.90GB ± 0%    2.24GB ± 0%   ~     (p=1.000 n=1+1)

name                                          old allocs/op  new allocs/op  delta
QueryTypes-10                                     169k ± 0%      320k ± 0%   ~     (p=1.000 n=1+1)
QueryMerge-10                                    3.44M ± 0%     0.13M ± 0%   ~     (p=1.000 n=1+1)
QueryRange-10                                    3.38M ± 0%     0.07M ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_1000Rows_10Iters_10Writers-10       528k ± 0%      127k ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_1000Iters_1Writers-10      11.6M ± 0%      1.2M ± 0%   ~     (p=1.000 n=1+1)
_Table_Insert_100Rows_100Iters_100Writers-10     20.8M ± 0%     12.2M ± 0%   ~     (p=1.000 n=1+1)```