### PR TITLE
Fix remote downloads

### DIFF
--- a/dynparquet/nil_chunk.go
+++ b/dynparquet/nil_chunk.go
@@ -196,13 +196,6 @@ func (p *nilValueReader) ReadValues(values []parquet.Value) (int, error) {
 	return i, nil
 }
 
-// Buffer returns the nilPage as a parquet.BufferedPage, since the page is
-// entirely a virtual construct, it is already considered buffered and just
-// returns itself. Implements the parquet.Page interface.
-func (p *nilPage) Buffer() parquet.BufferedPage {
-	return p
-}
-
 // DefinitionLevels returns the definition levels of the page. Since the page
 // contains only null values, all of them are 0. Implements the
 // parquet.BufferedPage interface.
@@ -217,15 +210,6 @@ func (p *nilPage) RepetitionLevels() []byte {
 	return nil
 }
 
-// Slice returns the nilPage with the subset of values represented by the range
-// between i and j. Implements the parquet.BufferedPage interface.
-func (p *nilPage) Slice(i, j int64) parquet.BufferedPage {
-	return &nilPage{
-		numValues:   int(j - i),
-		columnIndex: p.columnIndex,
-	}
-}
-
 // Data is unimplemented, since the page is virtual and does not need to be
 // written in its current usage in this package. If that changes this method
 // needs to be implemented. Implements the parquet.BufferedPage interface.
@@ -233,9 +217,16 @@ func (p *nilPage) Data() encoding.Values {
 	panic("not implemented")
 }
 
+func (p *nilPage) Slice(i, j int64) parquet.Page {
+	return &nilPage{
+		numValues:   p.numValues,
+		columnIndex: p.columnIndex,
+	}
+}
+
 // Clone creates a copy of the nilPage. Implements the parquet.BufferedPage
 // interface.
-func (p *nilPage) Clone() parquet.BufferedPage {
+func (p *nilPage) Clone() parquet.Page {
 	return &nilPage{
 		numValues:   p.numValues,
 		columnIndex: p.columnIndex,

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus/client_golang v1.12.2
-	github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d
+	github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638
 	github.com/stretchr/testify v1.7.1
 	github.com/thanos-io/objstore v0.0.0-20220715165016-ce338803bc1e
 	github.com/tidwall/wal v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -416,10 +416,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf h1:5yLngjz3nAomA1BbuHoRdPaCSsmy2RP2n+KF2Ew+VUs=
-github.com/segmentio/parquet-go v0.0.0-20220725200142-047e5979dfcf/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d h1:IxYmTiYCMaR3B0fjD9igXDr1AE5M8KRFbhEhEJ1WYx4=
-github.com/segmentio/parquet-go v0.0.0-20220802221544-d84ed320251d/go.mod h1:BuMbRhCCg3gFchup9zucJaUjQ4m6RxX+iVci37CoMPQ=
+github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638 h1:aPE6pwnk8m+LxPmJdqd9XCyStmp2QWGjVUkwP4MPq/U=
+github.com/segmentio/parquet-go v0.0.0-20220902005228-5bd5f6114638/go.mod h1:PxYdAI6cGd+s1j4hZDQbz3VFgobF5fDA0weLeNWKTE4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -20,17 +20,17 @@ type FileReaderAt struct {
 	ctx  context.Context
 }
 
-// BucketReaderAt implements the Bucket interface
+// BucketReaderAt implements the Bucket interface.
 type BucketReaderAt struct {
 	objstore.Bucket
 }
 
-// NewBucketReaderAt returns a new Bucket
+// NewBucketReaderAt returns a new Bucket.
 func NewBucketReaderAt(bucket objstore.Bucket) *BucketReaderAt {
 	return &BucketReaderAt{Bucket: bucket}
 }
 
-// GetReaderAt returns a io.ReaderAt for the given filename
+// GetReaderAt returns a io.ReaderAt for the given filename.
 func (b *BucketReaderAt) GetReaderAt(ctx context.Context, name string) (io.ReaderAt, error) {
 	return &FileReaderAt{
 		Bucket: b.Bucket,

--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -1,0 +1,62 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/thanos-io/objstore"
+)
+
+// Bucket is an objstore.Bucket that also supports reading files via a ReaderAt interface.
+type Bucket interface {
+	objstore.Bucket
+	GetReaderAt(ctx context.Context, name string) (io.ReaderAt, error)
+}
+
+// FileReaderAt is a wrapper around a objstore.Bucket that implements the ReaderAt interface.
+type FileReaderAt struct {
+	objstore.Bucket
+	name string
+	ctx  context.Context
+}
+
+// BucketReaderAt implements the Bucket interface
+type BucketReaderAt struct {
+	objstore.Bucket
+}
+
+// NewBucketReaderAt returns a new Bucket
+func NewBucketReaderAt(bucket objstore.Bucket) *BucketReaderAt {
+	return &BucketReaderAt{Bucket: bucket}
+}
+
+// GetReaderAt returns a io.ReaderAt for the given filename
+func (b *BucketReaderAt) GetReaderAt(ctx context.Context, name string) (io.ReaderAt, error) {
+	return &FileReaderAt{
+		Bucket: b.Bucket,
+		name:   name,
+		ctx:    ctx,
+	}, nil
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (b *FileReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	rc, err := b.GetRange(b.ctx, b.name, off, int64(len(p)))
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		err = rc.Close()
+	}()
+
+	total := 0
+	for total < len(p) { // Read does not guarantee the buffer will be full, but ReadAt does
+		n, err = rc.Read(p[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}

--- a/store.go
+++ b/store.go
@@ -118,7 +118,7 @@ func (t *Table) IterateBucketBlocks(ctx context.Context, logger log.Logger, last
 }
 
 func openFile(ctx context.Context, r io.ReaderAt, size int64, tracer trace.Tracer) (*parquet.File, error) {
-	ctx, span := tracer.Start(ctx, "Table/IterateBucketBlocks/Iter/OpenFile")
+	_, span := tracer.Start(ctx, "Table/IterateBucketBlocks/Iter/OpenFile")
 	defer span.End()
 	file, err := parquet.OpenFile(
 		r,


### PR DESCRIPTION
The `io.Reader` interface does not guarantee that a Read will return the full requested set of bytes, but may instead return a subset of the request with no error. This was causing some problems with remote storage backends. 

This extends the `objstore.Bucket` interface with one that includes a `GetReaderAt` function that allows bucket implementations to read the remote parquet files.   

It also bumps the `parquet-go` version in frostDB to the latest that allows us to set read buffers size when opening parquet files to avoid many small reads. 