### PR TITLE
table: Write api to make FrostDB easier to use

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1155,6 +1155,7 @@ func Test_DB_TableWrite_DynamicSchema(t *testing.T) {
 			Labels: []dynparquet.Label{
 				{Name: "label1", Value: "value1"},
 				{Name: "label2", Value: "value2"},
+				{Name: "label3", Value: "value3"},
 			},
 			Stacktrace: []uuid.UUID{
 				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
@@ -1178,10 +1179,8 @@ func Test_DB_TableWrite_DynamicSchema(t *testing.T) {
 		},
 	}
 
-	for _, s := range samples {
-		_, err = table.Write(ctx, s)
-		require.NoError(t, err)
-	}
+	_, err = table.Write(ctx, samples[0], samples[1], samples[2])
+	require.NoError(t, err)
 
 	engine := query.NewEngine(
 		memory.NewGoAllocator(),
@@ -1190,7 +1189,7 @@ func Test_DB_TableWrite_DynamicSchema(t *testing.T) {
 
 	err = engine.ScanTable("test").Execute(ctx, func(ctx context.Context, ar arrow.Record) error {
 		require.Equal(t, int64(3), ar.NumRows())
-		require.Equal(t, int64(6), ar.NumCols())
+		require.Equal(t, int64(7), ar.NumCols())
 		return nil
 	})
 	require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -1047,3 +1047,151 @@ func Test_DB_Block_Optimization(t *testing.T) {
 		})
 	}
 }
+
+func Test_DB_TableWrite_FlatSchema(t *testing.T) {
+	ctx := context.Background()
+	flatDefinition := &schemapb.Schema{
+		Name: "test",
+		Columns: []*schemapb.Column{{
+			Name: "example_type",
+			StorageLayout: &schemapb.StorageLayout{
+				Type:     schemapb.StorageLayout_TYPE_STRING,
+				Encoding: schemapb.StorageLayout_ENCODING_RLE_DICTIONARY,
+			},
+			Dynamic: false,
+		}, {
+			Name: "timestamp",
+			StorageLayout: &schemapb.StorageLayout{
+				Type: schemapb.StorageLayout_TYPE_INT64,
+			},
+			Dynamic: false,
+		}, {
+			Name: "value",
+			StorageLayout: &schemapb.StorageLayout{
+				Type: schemapb.StorageLayout_TYPE_INT64,
+			},
+			Dynamic: false,
+		}},
+		SortingColumns: []*schemapb.SortingColumn{{
+			Name:      "example_type",
+			Direction: schemapb.SortingColumn_DIRECTION_ASCENDING,
+		}, {
+			Name:      "timestamp",
+			Direction: schemapb.SortingColumn_DIRECTION_ASCENDING,
+		}},
+	}
+	schema, err := dynparquet.SchemaFromDefinition(flatDefinition)
+	require.NoError(t, err)
+	config := NewTableConfig(schema)
+
+	c, err := New(WithLogger(newTestLogger(t)))
+	require.NoError(t, err)
+
+	db, err := c.DB(ctx, "flatschema")
+	require.NoError(t, err)
+
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	s := struct {
+		ExampleType string
+		Timestamp   int64
+		Value       int64
+	}{
+		ExampleType: "hello-world",
+		Timestamp:   7,
+		Value:       8,
+	}
+
+	_, err = table.Write(ctx, s)
+	require.NoError(t, err)
+
+	engine := query.NewEngine(
+		memory.NewGoAllocator(),
+		db.TableProvider(),
+	)
+
+	err = engine.ScanTable("test").Execute(ctx, func(ctx context.Context, ar arrow.Record) error {
+		require.Equal(t, int64(1), ar.NumRows())
+		require.Equal(t, int64(3), ar.NumCols())
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func Test_DB_TableWrite_DynamicSchema(t *testing.T) {
+	ctx := context.Background()
+	config := NewTableConfig(
+		dynparquet.NewSampleSchema(),
+	)
+
+	c, err := New(WithLogger(newTestLogger(t)))
+	require.NoError(t, err)
+
+	db, err := c.DB(ctx, "sampleschema")
+	require.NoError(t, err)
+
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	now := time.Now()
+	ts := now.UnixMilli()
+	samples := dynparquet.Samples{
+		{
+			ExampleType: "test",
+			Labels: []dynparquet.Label{
+				{Name: "label1", Value: "value1"},
+				{Name: "label2", Value: "value2"},
+			},
+			Stacktrace: []uuid.UUID{
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			},
+			Timestamp: ts,
+			Value:     1,
+		},
+		{
+			ExampleType: "test",
+			Labels: []dynparquet.Label{
+				{Name: "label1", Value: "value1"},
+				{Name: "label2", Value: "value2"},
+			},
+			Stacktrace: []uuid.UUID{
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			},
+			Timestamp: ts,
+			Value:     2,
+		},
+		{
+			ExampleType: "test",
+			Labels: []dynparquet.Label{
+				{Name: "label1", Value: "value1"},
+				{Name: "label2", Value: "value2"},
+			},
+			Stacktrace: []uuid.UUID{
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+			},
+			Timestamp: ts,
+			Value:     3,
+		},
+	}
+
+	for _, s := range samples {
+		_, err = table.Write(ctx, s)
+		require.NoError(t, err)
+	}
+
+	engine := query.NewEngine(
+		memory.NewGoAllocator(),
+		db.TableProvider(),
+	)
+
+	err = engine.ScanTable("test").Execute(ctx, func(ctx context.Context, ar arrow.Record) error {
+		require.Equal(t, int64(3), ar.NumRows())
+		require.Equal(t, int64(6), ar.NumCols())
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -92,14 +92,14 @@ func (s Sample) ToParquetRow(labelNames []string) parquet.Row {
 			i++
 		}
 	}
-	row = append(row, parquet.ValueOf(extractLocationIDs(s.Stacktrace)).Level(0, 0, nameNumber+1))
+	row = append(row, parquet.ValueOf(ExtractLocationIDs(s.Stacktrace)).Level(0, 0, nameNumber+1))
 	row = append(row, parquet.ValueOf(s.Timestamp).Level(0, 0, nameNumber+2))
 	row = append(row, parquet.ValueOf(s.Value).Level(0, 0, nameNumber+3))
 
 	return row
 }
 
-func extractLocationIDs(locs []uuid.UUID) []byte {
+func ExtractLocationIDs(locs []uuid.UUID) []byte {
 	b := make([]byte, len(locs)*16) // UUID are 16 bytes thus multiply by 16
 	index := 0
 	for i := len(locs) - 1; i >= 0; i-- {

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -53,7 +53,7 @@ func main() {
 	thor := Simple{
 		Names: FirstLast{
 			FirstName: "Thor",
-			Surname:   "",
+			Surname:   "Hansen",
 		},
 		Value: 99,
 	}

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -74,7 +74,7 @@ func main() {
 			Surname    string
 		}{
 			FirstName:  "Matthias",
-			MiddleName: "Oliver",
+			MiddleName: "Oliver Rainer",
 			Surname:    "Loibl",
 		},
 		Value: 101,

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
-	"github.com/segmentio/parquet-go"
 
 	"github.com/polarsignals/frostdb"
 	"github.com/polarsignals/frostdb/dynparquet"
@@ -33,45 +32,61 @@ func main() {
 		frostdb.NewTableConfig(schema),
 	)
 
+	type FirstLast struct {
+		FirstName string
+		Surname   string
+	}
+
+	type Simple struct {
+		Names FirstLast
+		Value int64
+	}
 	// Create values to insert into the database these first rows havel dynamic label names of 'firstname' and 'surname'
-	buf, _ := schema.NewBuffer(map[string][]string{
-		"names": {"firstname", "surname"},
-	})
+	frederic := Simple{
+		Names: FirstLast{
+			FirstName: "Frederic",
+			Surname:   "Brancz",
+		},
+		Value: 100,
+	}
 
-	// firstname:Frederic surname:Brancz 100
-	_, _ = buf.WriteRows([]parquet.Row{{
-		parquet.ValueOf("Frederic").Level(0, 1, 0),
-		parquet.ValueOf("Brancz").Level(0, 1, 1),
-		parquet.ValueOf(100).Level(0, 0, 2),
-	}})
-
-	// firstname:Thor surname:Hansen 10
-	_, _ = buf.WriteRows([]parquet.Row{{
-		parquet.ValueOf("Thor").Level(0, 1, 0),
-		parquet.ValueOf("Hansen").Level(0, 1, 1),
-		parquet.ValueOf(10).Level(0, 0, 2),
-	}})
-	_, _ = table.InsertBuffer(context.Background(), buf)
+	thor := Simple{
+		Names: FirstLast{
+			FirstName: "Thor",
+			Surname:   "",
+		},
+		Value: 99,
+	}
+	_, _ = table.Write(context.Background(), frederic, thor)
 
 	// Now we can insert rows that have middle names into our dynamic column
-	buf, _ = schema.NewBuffer(map[string][]string{
-		"names": {"firstname", "middlename", "surname"},
-	})
-	// firstname:Matthias middlename:Oliver surname:Loibl 1
-	_, _ = buf.WriteRows([]parquet.Row{{
-		parquet.ValueOf("Matthias").Level(0, 1, 0),
-		parquet.ValueOf("Oliver").Level(0, 1, 1),
-		parquet.ValueOf("Loibl").Level(0, 1, 2),
-		parquet.ValueOf(1).Level(0, 0, 3),
-	}})
-	_, _ = table.InsertBuffer(context.Background(), buf)
+	matthias := struct {
+		Names struct {
+			FirstName  string
+			MiddleName string
+			Surname    string
+		}
+		Value int64
+	}{
+		Names: struct {
+			FirstName  string
+			MiddleName string
+			Surname    string
+		}{
+			FirstName:  "Matthias",
+			MiddleName: "Oliver",
+			Surname:    "Loibl",
+		},
+		Value: 101,
+	}
+	_, _ = table.Write(context.Background(), matthias)
 
 	// Create a new query engine to retrieve data and print the results
 	engine := query.NewEngine(memory.DefaultAllocator, database.TableProvider())
 	_ = engine.ScanTable("simple_table").
 		Project(logicalplan.DynCol("names")). // We don't know all dynamic columns at query time, but we want all of them to be returned.
 		Filter(
-			logicalplan.Col("names.firstname").Eq(logicalplan.Literal("Frederic")),
+			logicalplan.Col("names.first_name").Eq(logicalplan.Literal("Frederic")),
 		).Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
 		fmt.Println(r)
 		return nil

--- a/table.go
+++ b/table.go
@@ -363,7 +363,7 @@ func (t *Table) Sync() {
 }
 
 // Write objects into the table.
-func (t *Table) Write(ctx context.Context, vals ...interface{}) (uint64, error) {
+func (t *Table) Write(ctx context.Context, vals ...any) (uint64, error) {
 	b, err := ValuesToBuffer(t.Schema(), vals...)
 	if err != nil {
 		return 0, err
@@ -383,11 +383,11 @@ func ToSnakeCase(str string) string {
 	return strings.ToLower(snake)
 }
 
-func ValuesToBuffer(schema *dynparquet.Schema, vals ...interface{}) (*dynparquet.Buffer, error) {
+func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer, error) {
 	dynamicColumns := map[string][]string{}
 	rows := make([]parquet.Row, 0, len(vals))
 
-	findColumn := func(val reflect.Value, col string, v interface{}) interface{} {
+	findColumn := func(val reflect.Value, col string, v any) any {
 		for i := 0; i < val.NumField(); i++ {
 			if ToSnakeCase(val.Type().Field(i).Name) == col {
 				return val.Field(i).Interface()


### PR DESCRIPTION
This adds a layer on top of the `Insert` API to increase accessibility of the API. The new API function is `Write(context.Context, ...any)` where a user may write a normal Go struct and FrostDB will handle converting it into a parquet buffer.

I had taken a first pass at this some time ago in https://github.com/polarsignals/frostdb/pull/67/files but finally got around to cleaning that up and making it even more ergonomic.

While I'm certain this does not cover every type of struct that someone may want to write, it covers the use cases that exist in FrostDB today, and can be expanded overtime to support more fields as required. 