### PR TITLE
Fix writer partition

### DIFF
--- a/granule.go
+++ b/granule.go
@@ -73,7 +73,7 @@ func (g *Granule) addPart(p *Part, r *dynparquet.DynamicRow) (uint64, error) {
 	}
 	node := g.parts.Prepend(p)
 
-	newSize := g.metadata.size.Add(uint64(p.Buf.ParquetFile().NumRows()))
+	newSize := g.metadata.size.Add(uint64(p.Buf.ParquetFile().Size()))
 
 	for {
 		least := g.metadata.least.Load()

--- a/store.go
+++ b/store.go
@@ -83,15 +83,6 @@ func (t *Table) IterateBucketBlocks(
 			return err
 		}
 
-		// Check if the block can be filtered out
-		mayContainUsefulData, err := filter.Eval(&ParquetFileParticulate{File: file})
-		if err != nil {
-			return err
-		}
-		if !mayContainUsefulData { // skip the block entirely
-			return nil
-		}
-
 		// Get a reader from the file bytes
 		buf, err := dynparquet.NewSerializedBuffer(file)
 		if err != nil {

--- a/table.go
+++ b/table.go
@@ -58,8 +58,18 @@ type TableConfig struct {
 	rowGroupSize int
 }
 
+type TableOption func(*TableConfig) error
+
+func WithRowGroupSize(numRows int) TableOption {
+	return func(config *TableConfig) error {
+		config.rowGroupSize = numRows
+		return nil
+	}
+}
+
 func NewTableConfig(
 	schema *dynparquet.Schema,
+	options ...TableOption,
 ) *TableConfig {
 	return &TableConfig{
 		schema: schema,

--- a/table_test.go
+++ b/table_test.go
@@ -1438,3 +1438,75 @@ func Test_DoubleTable(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func Test_Table_GranuleCompaction(t *testing.T) {
+	table := basicTable(t)
+	table.config.rowGroupSize = 2 // override row group size setting
+
+	samples := dynparquet.Samples{{
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 1,
+		Value:     1,
+	}, {
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+			{Name: "label3", Value: "value3"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 2,
+		Value:     2,
+	}, {
+		Labels: []dynparquet.Label{
+			{Name: "label1", Value: "value1"},
+			{Name: "label2", Value: "value2"},
+			{Name: "label4", Value: "value4"},
+		},
+		Stacktrace: []uuid.UUID{
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+		},
+		Timestamp: 3,
+		Value:     3,
+	}}
+
+	ctx := context.Background()
+	tx, err := table.Write(ctx, samples[0], samples[1], samples[2])
+	require.NoError(t, err)
+
+	// Wait for the writes to have been marked as completed
+	table.db.Wait(tx)
+
+	// Expect only a single granule to have been created
+	require.Equal(t, 1, table.active.Index().Len())
+
+	// Force compaction on the granule
+	g := (table.active.Index().Min()).(*Granule)
+	table.active.wg.Add(1)
+	table.active.compact(g)
+
+	// Expect the granule to have been compacted into a single granule
+	require.Equal(t, 1, table.active.Index().Len())
+
+	// Expect the granule to contain a single part with multiple row groups
+	g = (table.active.Index().Min()).(*Granule)
+	parts := 0
+	g.parts.Iterate(func(p *Part) bool {
+		parts++
+		require.Equal(t, 2, p.Buf.NumRowGroups())
+		return true
+	})
+
+	// There should only be a single part that contains multiple row groups
+	require.Equal(t, 1, parts)
+}


### PR DESCRIPTION
Introduces a table level option of `WithRowGroupSize` which informs the writer when to `Flush()` the buffer and write out a RowGroup. 

It uses this setting both during granule compaction, as well as block persistence. 