### PR TITLE
pqarrow/builder: optimize Parquet to Arrow conversion

### DIFF
--- a/pqarrow/builder/listbuilder.go
+++ b/pqarrow/builder/listbuilder.go
@@ -1,0 +1,34 @@
+package builder
+
+import (
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+)
+
+// ListBuilder is a wrapper over an array.ListBuilder that uses an
+// ColumnBuilder as a values builder.
+type ListBuilder struct {
+	*array.ListBuilder
+	valueBuilder ColumnBuilder
+}
+
+// NewListBuilder creates a ListBuilder with the given element type.
+func NewListBuilder(mem memory.Allocator, etype arrow.DataType) *ListBuilder {
+	return &ListBuilder{
+		ListBuilder:  array.NewListBuilder(mem, etype),
+		valueBuilder: NewBuilder(mem, etype),
+	}
+}
+
+func (b *ListBuilder) ValueBuilder() ColumnBuilder {
+	return b.valueBuilder
+}
+
+func (b *ListBuilder) NewArray() arrow.Array {
+	listArr := b.ListBuilder.NewArray()
+	// Overwrite the arrow listbuilder's child data with the wrapped
+	// ColumnBuilder's data.
+	listArr.Data().Children()[0] = b.valueBuilder.NewArray().Data()
+	return listArr
+}

--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -1,0 +1,226 @@
+package builder
+
+import (
+	"reflect"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/bitutil"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/segmentio/parquet-go"
+)
+
+// ColumnBuilder is a subset of the array.Builder interface implemented by the
+// optimized builders in this file.
+type ColumnBuilder interface {
+	Retain()
+	Release()
+	Len() int
+	AppendNull()
+	Reserve(int)
+	NewArray() arrow.Array
+}
+
+// OptimizedBuilder is a set of FrostDB specific builder methods.
+type OptimizedBuilder interface {
+	ColumnBuilder
+	AppendNulls(int)
+	ResetToLength(int)
+	RepeatLastValue(int)
+}
+
+type builderBase struct {
+	dtype          arrow.DataType
+	refCount       int64
+	length         int
+	validityBitmap []byte
+}
+
+func (b *builderBase) reset() {
+	b.length = 0
+	b.validityBitmap = b.validityBitmap[:0]
+}
+
+func (b *builderBase) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+func (b *builderBase) releaseInternal() {
+	b.length = 0
+	b.validityBitmap = nil
+}
+
+func (b *builderBase) Release() {
+	atomic.AddInt64(&b.refCount, -1)
+	b.releaseInternal()
+}
+
+// Len returns the number of elements in the array builder.
+func (b *builderBase) Len() int {
+	return b.length
+}
+
+func (b *builderBase) Reserve(int) {}
+
+// AppendNulls appends n null values to the array being built. This is specific
+// to distinct optimizations in FrostDB.
+func (b *builderBase) AppendNulls(n int) {
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length+n)
+	bitutil.SetBitsTo(b.validityBitmap, int64(b.length), int64(n), false)
+	b.length += n
+}
+
+func resizeBitmap(bitmap []byte, valuesToRepresent int) []byte {
+	bytesNeeded := int(bitutil.BytesForBits(int64(valuesToRepresent)))
+	if cap(bitmap) < bytesNeeded {
+		existingBitmap := bitmap
+		bitmap = make([]byte, bitutil.NextPowerOf2(bytesNeeded))
+		copy(bitmap, existingBitmap)
+	}
+	return bitmap[:bytesNeeded]
+}
+
+var _ OptimizedBuilder = (*OptBinaryBuilder)(nil)
+
+// OptBinaryBuilder is an optimized array.BinaryBuilder.
+type OptBinaryBuilder struct {
+	builderBase
+
+	data []byte
+	// offsets are offsets into data. The ith value is
+	// data[offsets[i]:offsets[i+1]]. Note however, that during normal operation,
+	// len(data) is never appended to the slice until the next value is added,
+	// i.e. the last offset is never closed until the offsets slice is appended
+	// to or returned to the caller.
+	offsets []uint32
+}
+
+func NewOptBinaryBuilder(dtype arrow.BinaryDataType) *OptBinaryBuilder {
+	b := &OptBinaryBuilder{}
+	b.dtype = dtype
+	return b
+}
+
+// Release decreases the reference count by 1.
+// When the reference count goes to zero, the memory is freed.
+// Release may be called simultaneously from multiple goroutines.
+func (b *OptBinaryBuilder) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		b.data = nil
+		b.offsets = nil
+		b.releaseInternal()
+	}
+}
+
+// AppendNull adds a new null value to the array being built. This is slow,
+// don't use it.
+func (b *OptBinaryBuilder) AppendNull() {
+	b.builderBase.AppendNulls(1)
+}
+
+// AppendNulls appends n null values to the array being built. This is specific
+// to distinct optimizations in FrostDB.
+func (b *OptBinaryBuilder) AppendNulls(n int) {
+	for i := 0; i < n; i++ {
+		b.offsets = append(b.offsets, uint32(len(b.data)))
+	}
+	b.builderBase.AppendNulls(n)
+}
+
+// NewArray creates a new array from the memory buffers used
+// by the builder and resets the Builder so it can be used to build
+// a new array.
+func (b *OptBinaryBuilder) NewArray() arrow.Array {
+	b.offsets = append(b.offsets, uint32(len(b.data)))
+	var offsetsAsBytes []byte
+
+	fromHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b.offsets))
+	toHeader := (*reflect.SliceHeader)(unsafe.Pointer(&offsetsAsBytes))
+	toHeader.Data = fromHeader.Data
+	toHeader.Len = fromHeader.Len * arrow.Uint32SizeBytes
+	toHeader.Cap = fromHeader.Cap * arrow.Uint32SizeBytes
+
+	data := array.NewData(
+		b.dtype,
+		b.length,
+		[]*memory.Buffer{
+			memory.NewBufferBytes(b.validityBitmap),
+			memory.NewBufferBytes(offsetsAsBytes),
+			memory.NewBufferBytes(b.data),
+		},
+		nil,
+		b.length-bitutil.CountSetBits(b.validityBitmap, 0, b.length),
+		0,
+	)
+	b.reset()
+	b.offsets = b.offsets[:0]
+	b.data = b.data[:0]
+	return array.NewBinaryData(data)
+}
+
+// AppendData appends a flat slice of bytes to the builder, with an accompanying
+// slice of offsets. This data is considered to be non-null.
+func (b *OptBinaryBuilder) AppendData(data []byte, offsets []uint32) {
+	// Trim the last offset since we want this last range to be "open".
+	offsets = offsets[:len(offsets)-1]
+
+	offsetConversion := uint32(len(b.data))
+	b.data = append(b.data, data...)
+	startOffset := len(b.offsets)
+	b.offsets = append(b.offsets, offsets...)
+	for curOffset := startOffset; curOffset < len(b.offsets); curOffset++ {
+		b.offsets[curOffset] += offsetConversion
+	}
+
+	b.length += len(offsets)
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
+	bitutil.SetBitsTo(b.validityBitmap, int64(startOffset), int64(len(offsets)), true)
+}
+
+// AppendParquetValues appends the given parquet values to the builder. The
+// values may be null, but if it is known upfront that none of the values are
+// null, AppendData offers a more efficient way of appending values.
+func (b *OptBinaryBuilder) AppendParquetValues(values []parquet.Value) {
+	for i := range values {
+		b.offsets = append(b.offsets, uint32(len(b.data)))
+		b.data = append(b.data, values[i].ByteArray()...)
+	}
+
+	oldLength := b.length
+	b.length += len(values)
+
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
+	for i := range values {
+		bitutil.SetBitTo(b.validityBitmap, oldLength+i, !values[i].IsNull())
+	}
+}
+
+// RepeatLastValue is specific to distinct optimizations in FrostDB.
+func (b *OptBinaryBuilder) RepeatLastValue(n int) {
+	if bitutil.BitIsNotSet(b.validityBitmap, b.length-1) {
+		// Last value is null.
+		b.AppendNulls(n)
+		return
+	}
+
+	lastValue := b.data[b.offsets[len(b.offsets)-1]:]
+	for i := 0; i < n; i++ {
+		b.offsets = append(b.offsets, uint32(len(b.data)))
+		b.data = append(b.data, lastValue...)
+	}
+	b.length += n
+}
+
+// ResetToLength is specific to distinct optimizations in FrostDB.
+func (b *OptBinaryBuilder) ResetToLength(n int) {
+	if n == b.length {
+		return
+	}
+
+	b.length = n
+	b.data = b.data[:b.offsets[n]]
+	b.offsets = b.offsets[:n]
+	b.validityBitmap = resizeBitmap(b.validityBitmap, n)
+}

--- a/pqarrow/builder/recordbuilder.go
+++ b/pqarrow/builder/recordbuilder.go
@@ -1,0 +1,96 @@
+package builder
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+)
+
+// The code in this file is based heavily on Apache arrow's array.RecordBuilder,
+// with some modifications to use our own optimized record builders. Ideally, we
+// would eventually merge this upstream.
+
+// RecordBuilder eases the process of building a Record, iteratively, from
+// a known Schema.
+type RecordBuilder struct {
+	refCount int64
+	mem      memory.Allocator
+	schema   *arrow.Schema
+	fields   []array.Builder
+}
+
+// NewRecordBuilder returns a builder, using the provided memory allocator and a schema.
+func NewRecordBuilder(mem memory.Allocator, schema *arrow.Schema) *RecordBuilder {
+	b := &RecordBuilder{
+		refCount: 1,
+		mem:      mem,
+		schema:   schema,
+		fields:   make([]array.Builder, len(schema.Fields())),
+	}
+
+	for i, f := range schema.Fields() {
+		b.fields[i] = array.NewBuilder(b.mem, f.Type)
+	}
+
+	return b
+}
+
+// Retain increases the reference count by 1.
+// Retain may be called simultaneously from multiple goroutines.
+func (b *RecordBuilder) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+// Release decreases the reference count by 1.
+func (b *RecordBuilder) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		for _, f := range b.fields {
+			f.Release()
+		}
+		b.fields = nil
+	}
+}
+
+func (b *RecordBuilder) Schema() *arrow.Schema     { return b.schema }
+func (b *RecordBuilder) Fields() []array.Builder   { return b.fields }
+func (b *RecordBuilder) Field(i int) array.Builder { return b.fields[i] }
+
+func (b *RecordBuilder) Reserve(size int) {
+	for _, f := range b.fields {
+		f.Reserve(size)
+	}
+}
+
+// NewRecord creates a new record from the memory buffers and resets the
+// RecordBuilder so it can be used to build a new record.
+//
+// The returned Record must be Release()'d after use.
+//
+// NewRecord panics if the fields' builder do not have the same length.
+func (b *RecordBuilder) NewRecord() array.Record {
+	cols := make([]arrow.Array, len(b.fields))
+	rows := int64(0)
+
+	defer func(cols []arrow.Array) {
+		for _, col := range cols {
+			if col == nil {
+				continue
+			}
+			col.Release()
+		}
+	}(cols)
+
+	for i, f := range b.fields {
+		cols[i] = f.NewArray()
+		irow := int64(cols[i].Len())
+		if i > 0 && irow != rows {
+			panic(fmt.Errorf("arrow/array: field %d has %d rows. want=%d", i, irow, rows))
+		}
+		rows = irow
+	}
+
+	return array.NewRecord(b.schema, cols, rows)
+}

--- a/pqarrow/convert/convert.go
+++ b/pqarrow/convert/convert.go
@@ -33,6 +33,7 @@ func ParquetNodeToType(n parquet.Node) (arrow.DataType, error) {
 
 // ParquetNodeToTypeWithWriterFunc converts a parquet node to an arrow type and a function to
 // create a value writer.
+// TODO(asubiotto): The dependency on the writer package needs to be untangled.
 func ParquetNodeToTypeWithWriterFunc(n parquet.Node) (arrow.DataType, writer.NewWriterFunc, error) {
 	t := n.Type()
 	lt := t.LogicalType()

--- a/pqarrow/writer/writer.go
+++ b/pqarrow/writer/writer.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow/array"
 	"github.com/segmentio/parquet-go"
+
+	"github.com/polarsignals/frostdb/pqarrow/builder"
 )
 
 type ValueWriter interface {
@@ -14,88 +16,43 @@ type ValueWriter interface {
 }
 
 type binaryValueWriter struct {
-	b          *array.BinaryBuilder
-	numValues  int
-	firstWrite bool
-	// scratch is a helper struct to help with reusing memory.
+	b       *builder.OptBinaryBuilder
 	scratch struct {
-		values   [][]byte
-		validity []bool
+		values []parquet.Value
 	}
 }
 
-type NewWriterFunc func(b array.Builder, numValues int) ValueWriter
+type NewWriterFunc func(b builder.ColumnBuilder, numValues int) ValueWriter
 
-func NewBinaryValueWriter(b array.Builder, numValues int) ValueWriter {
+func NewBinaryValueWriter(b builder.ColumnBuilder, numValues int) ValueWriter {
 	return &binaryValueWriter{
-		b:          b.(*array.BinaryBuilder),
-		numValues:  numValues,
-		firstWrite: true,
+		b: b.(*builder.OptBinaryBuilder),
 	}
 }
 
 func (w *binaryValueWriter) Write(values []parquet.Value) {
-	if w.firstWrite {
-		w.firstWrite = false
-
-		// Depending on the nullability of the column this could be optimized
-		// further by reading strings directly and adding all of them at once
-		// to the array builder.
-		w.scratch.values = make([][]byte, len(values))
-		w.scratch.validity = make([]bool, len(values))
-		largest := 0
-		for i, v := range values {
-			if !v.IsNull() {
-				w.scratch.values[i] = v.ByteArray()
-				if len(w.scratch.values[i]) > largest {
-					largest = len(w.scratch.values[i])
-				}
-				w.scratch.validity[i] = true
-			}
-		}
-		w.b.ReserveData(w.numValues * largest)
-
-		w.b.AppendValues(w.scratch.values, w.scratch.validity)
-	} else {
-		// Depending on the nullability of the column this could be optimized
-		// further by reading strings directly and adding all of them at once
-		// to the array builder.
-		n := len(values)
-		if n > cap(w.scratch.values) {
-			w.scratch.values = make([][]byte, n)
-			w.scratch.validity = make([]bool, n)
-		} else {
-			w.scratch.values = w.scratch.values[:n]
-			w.scratch.validity = w.scratch.validity[:n]
-		}
-		for i, v := range values {
-			if !v.IsNull() {
-				w.scratch.values[i] = v.ByteArray()
-				w.scratch.validity[i] = true
-			} else {
-				// Since we're reusing memory, it's safer to zero out the index.
-				w.scratch.values[i] = nil
-				w.scratch.validity[i] = false
-			}
-		}
-
-		w.b.AppendValues(w.scratch.values, w.scratch.validity)
-	}
+	w.b.AppendParquetValues(values)
 }
 
-// TODO: implement fast path of writing the whole page directly.
 func (w *binaryValueWriter) WritePage(p parquet.Page) error {
-	reader := p.Values()
-
-	values := make([]parquet.Value, p.NumValues())
-	_, err := reader.ReadValues(values)
-	// We're reading all values in the page so we always expect an io.EOF.
-	if err != nil && err != io.EOF {
-		return fmt.Errorf("read values: %w", err)
+	if p.NumNulls() != 0 {
+		reader := p.Values()
+		if cap(w.scratch.values) < int(p.NumValues()) {
+			w.scratch.values = make([]parquet.Value, p.NumValues())
+		}
+		w.scratch.values = w.scratch.values[:p.NumValues()]
+		_, err := reader.ReadValues(w.scratch.values)
+		// We're reading all values in the page so we always expect an io.EOF.
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("read values: %w", err)
+		}
+		w.Write(w.scratch.values)
+		return nil
 	}
 
-	w.Write(values)
-
+	// No nulls in page.
+	values := p.Data()
+	w.b.AppendData(values.ByteArray())
 	return nil
 }
 
@@ -104,7 +61,7 @@ type int64ValueWriter struct {
 	buf []int64
 }
 
-func NewInt64ValueWriter(b array.Builder, numValues int) ValueWriter {
+func NewInt64ValueWriter(b builder.ColumnBuilder, numValues int) ValueWriter {
 	res := &int64ValueWriter{
 		b: b.(*array.Int64Builder),
 	}
@@ -165,7 +122,7 @@ type uint64ValueWriter struct {
 	b *array.Uint64Builder
 }
 
-func NewUint64ValueWriter(b array.Builder, numValues int) ValueWriter {
+func NewUint64ValueWriter(b builder.ColumnBuilder, numValues int) ValueWriter {
 	res := &uint64ValueWriter{
 		b: b.(*array.Uint64Builder),
 	}
@@ -207,8 +164,8 @@ type repeatedValueWriter struct {
 	values ValueWriter
 }
 
-func NewListValueWriter(newValueWriter func(b array.Builder, numValues int) ValueWriter) func(b array.Builder, numValues int) ValueWriter {
-	return func(b array.Builder, numValues int) ValueWriter {
+func NewListValueWriter(newValueWriter func(b builder.ColumnBuilder, numValues int) ValueWriter) func(b builder.ColumnBuilder, numValues int) ValueWriter {
+	return func(b builder.ColumnBuilder, numValues int) ValueWriter {
 		builder := b.(*array.ListBuilder)
 
 		return &repeatedValueWriter{
@@ -251,7 +208,7 @@ type float64ValueWriter struct {
 	buf []float64
 }
 
-func NewFloat64ValueWriter(b array.Builder, numValues int) ValueWriter {
+func NewFloat64ValueWriter(b builder.ColumnBuilder, numValues int) ValueWriter {
 	res := &float64ValueWriter{
 		b: b.(*array.Float64Builder),
 	}


### PR DESCRIPTION
This PR adds the concept of optimized builders to FrostDB. These are array.Builders that can build arrow arrays more efficiently than the default builders by only copying when necessary. This is especially important when handling data like variable-sized strings, where we'd go through the following process:
- Read parquet strings stored in flat format, create a two-dimensional slice of values representing these.
- Append values to an arrow builder, which reads each string and converts it back to flat format.

With the new builder, we can immediately just copy the flat data + offsets and cast them to an arrow array when necessary. The improvements are noticeable especially in QueryRange:
```
name          old time/op    new time/op    delta
QueryTypes-8    3.84ms ± 3%    3.79ms ± 3%     ~     (p=0.151 n=5+5)
QueryMerge-8    12.9ms ± 2%    12.8ms ± 6%     ~     (p=0.548 n=5+5)
QueryRange-8    5.23ms ± 6%    4.49ms ± 2%  -14.26%  (p=0.016 n=4+5)

name          old alloc/op   new alloc/op   delta
QueryTypes-8    5.92MB ± 0%    5.69MB ± 0%   -3.90%  (p=0.008 n=5+5)
QueryMerge-8    90.9MB ± 0%    81.9MB ± 0%   -9.90%  (p=0.008 n=5+5)
QueryRange-8    28.8MB ± 0%    23.7MB ± 0%  -17.81%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
QueryTypes-8     97.6k ± 0%     93.4k ± 0%   -4.31%  (p=0.008 n=5+5)
QueryMerge-8      303k ± 0%      301k ± 0%   -0.68%  (p=0.008 n=5+5)
QueryRange-8     59.8k ± 0%     58.0k ± 0%   -3.08%  (p=0.008 n=5+5)
```

The nice thing about these builders is that they give us freedom to manipulate memory as we wish (see ergonomic improvements to appending nulls and repeating last values during distinct optimizations). This is dangerous, but nice for performance reasons. I envision these builders to be used in operators in the future (which is what I think my next step is).