### PR TITLE
frostdb: add leveled compaction

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1,14 +1,20 @@
 package frostdb
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"math"
 	"runtime"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log/level"
 	"github.com/google/btree"
 	"github.com/thanos-io/objstore/errutil"
+
+	"github.com/polarsignals/frostdb/dynparquet"
 )
 
 type compactorPool struct {
@@ -99,11 +105,400 @@ func (t *TableBlock) compact() error {
 		}
 
 		defer t.table.metrics.compactions.Inc()
-		if err := t.compactGranule(granuleToCompact); err != nil {
-			t.abort(granuleToCompact)
-			compactionErrors.Add(err)
+		if successful, err := t.compactGranule(granuleToCompact); !successful || err != nil {
+			t.abortCompaction(granuleToCompact)
+			if err != nil {
+				compactionErrors.Add(err)
+			}
 		}
 		return true
 	})
 	return compactionErrors.Err()
+}
+
+// compactGranule is the "meat" of granule compaction. It returns whether the
+// compaction succeeded or not as well as an error (there are cases in which
+// false, nil is returned).
+// The goal of this method is to optimize both memory usage and scan speed.
+// Memory usage is optimized by merging multiple row groups into fewer row
+// groups, since the more data there is in a row group, the higher the benefits
+// of things like parquet compression (this is applied at the row group level).
+// Optimizing for memory usage is a tradeoff, since the more data there is in a
+// row group, the more sequential reads need to be done to find data that
+// queries want. This is why we aim to have a granule maximum size, since
+// searching for granules that satisfy query filters is an
+// O(log(number of granules)) operation, so the more granules we have, the less
+// O(n) work we have to do to search for row groups that satisfy query filters.
+// The compaction logic is as follows:
+//
+//  1. Before any compaction has happened, granules contain a variable number of
+//     parts (basically an encapsulation of a parquet file). These parts contain
+//     a variable number of variable-length row groups. The row group size in
+//     this case is the buffer size that was used by the client on the
+//     corresponding insert call. The compaction strategy in this simple case is
+//     to rewrite the row groups into multiple parts that contain optimally
+//     sized row groups (set by the user using the WithRowGroupSize table
+//     option). The new part sizes aim to be
+//     level1ToGranuleSizeRatio*granuleSize bytes large. The resulting parts are
+//     marked as compacted using compactionLevel1.
+//
+//  2. As more data is added to a granule compacted in point 1, the new data
+//     will again be stored in a suboptimal multi-part format with multiple
+//     variable length row groups. The same compaction as point 1 is performed
+//     but only on the new data as long as it does not overlap with any level1
+//     data (otherwise the overlapping parts are merged into new level1 parts).
+//     If the sum of the part sizes is above the target granule size, a split is
+//     performed, which simply means that the parts will be assigned to new
+//     granules.
+//
+// Some things to be aware of:
+//   - The current compaction strategy assumes there is no benefit to having
+//     muliple parts over a single part as long as the row groups are of equal
+//     length.
+//   - Currently, our compaction strategy is based on a sweep on a timed
+//     interval. This is OK for now, but ideally we would track metrics that
+//     are proxies for memory size/scan speed that would trigger compactions.
+//     For example, the ratio of uncompacted bytes to total bytes. Or performing
+//     split operations based on load.
+//
+// A note on ordering guarantees:
+// FrostDB guarantees ordering amongst granules. This means that if there are
+// two granules in the index, all rows in granule A are less than granule B.
+// However, within a granule, rows are only ordered at a part level since parts
+// are created when a client appends rows and clients are not required to
+// append in order. The current compaction strategy ensures that ordering
+// guarantees between granules are upheld. Additionally, level1 parts will never
+// overlap.
+func (t *TableBlock) compactGranule(granule *Granule) (bool, error) {
+	// Use the latest watermark as the tx id.
+	tx := t.table.db.tx.Load()
+
+	level0Parts, level1Parts, partsWithUncompletedTxns, sizeBefore, err := collectPartsForCompaction(
+		// Start compaction by adding a sentinel node to its parts list.
+		tx, granule.parts.Sentinel(Compacting),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if len(level0Parts) == 0 && len(level1Parts) == 0 {
+		// Edge case in which only parts with uncompleted txns are found and
+		// they are already bigger than the max size. A future compaction cycle
+		// will take care of this, so return that the compaction was not
+		// successful
+		return false, nil
+	}
+
+	partsBefore := len(level0Parts) + len(level1Parts)
+	if len(level0Parts) > 0 {
+		var err error
+		level1Parts, err = compactLevel0IntoLevel1(t, tx, level0Parts, level1Parts)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	// This sort is done to simplify the splitting of non-overlapping parts
+	// amongst new granules. There might be something more clever we could do
+	// here if we maintain stronger guarantees about the part ordering given
+	// that level1 parts should already be sorted when collected at the start
+	// of this method (since this is the only place level1 parts get added to
+	// granules). However, it seems like new parts are prepended so the sort
+	// order is inverted. Another option is to recursively split using
+	// addPartToGranule, which would be cheap in the general case.
+	sorter := &partSorter{schema: t.table.config.schema, parts: level1Parts}
+	sort.Sort(sorter)
+	if sorter.err != nil {
+		return false, fmt.Errorf("error sorting level1: %w", sorter.err)
+	}
+
+	newParts, err := divideLevel1PartsForGranule(
+		t,
+		tx,
+		level1Parts,
+		// Set a maximum size of the l1 ratio to give "breathing room" to new
+		// level0 parts. Otherwise, compactions will be initiated more often
+		// and work on less data. This ends up creating granules half filled
+		// up with a level1 part.
+		int64(float64(t.table.db.columnStore.granuleSizeBytes)*level1ToGranuleTargetSizeRatio),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	newGranules := make([]*Granule, 0, len(newParts))
+	partsAfter := 0
+	for _, parts := range newParts {
+		partsAfter += len(parts)
+		newGranule, err := NewGranule(
+			t.table.metrics.granulesCreated, t.table.config, nil, /* firstPart */
+		)
+		if err != nil {
+			if err != nil {
+				return false, fmt.Errorf("failed to create new granule: %w", err)
+			}
+		}
+		for _, p := range parts {
+			if _, err := newGranule.AddPart(p); err != nil {
+				return false, fmt.Errorf("failed to add level1 part to granule: %w", err)
+			}
+		}
+		newGranules = append(newGranules, newGranule)
+	}
+
+	// Size calculation is done before adding the ignored parts to the new
+	// granules.
+	var sizeAfter uint64
+	for _, g := range newGranules {
+		sizeAfter += g.metadata.size.Load()
+	}
+
+	// Add remaining parts onto new granules.
+	for _, p := range partsWithUncompletedTxns {
+		if err := addPartToGranule(newGranules, p); err != nil {
+			return false, fmt.Errorf("add parts to granules: %w", err)
+		}
+	}
+
+	// We disable compaction for new granules before allowing new inserts to be
+	// propagated to them.
+	for _, childGranule := range newGranules {
+		childGranule.metadata.pruned.Store(1)
+	}
+
+	// We restore the possibility to trigger compaction after we exit the
+	// function.
+	defer func() {
+		for _, childGranule := range newGranules {
+			childGranule.metadata.pruned.Store(0)
+		}
+	}()
+
+	// Set the newGranules pointer, so new writes will propogate into these new
+	// granules.
+	granule.newGranules = newGranules
+
+	// Mark compaction complete in the granule; this will cause new writes to
+	// start using the newGranules pointer. Iterate over the resulting part
+	// list to copy any new parts that were added while we were compacting.
+	var addPartErr error
+	granule.parts.Sentinel(Compacted).Iterate(func(p *Part) bool {
+		if err := addPartToGranule(newGranules, p); err != nil {
+			addPartErr = err
+			return false
+		}
+		return true
+	})
+	if addPartErr != nil {
+		return false, fmt.Errorf("add part to granules: %w", addPartErr)
+	}
+
+	for {
+		curIndex := t.Index()
+		t.mtx.Lock()
+		index := curIndex.Clone() // TODO(THOR): we can't clone concurrently
+		t.mtx.Unlock()
+
+		if index.Delete(granule) == nil {
+			level.Error(t.logger).Log("msg", "failed to delete granule during split")
+			continue
+		}
+
+		for _, g := range newGranules {
+			if dupe := index.ReplaceOrInsert(g); dupe != nil {
+				level.Error(t.logger).Log("duplicate insert performed")
+			}
+		}
+
+		// Point to the new index.
+		if t.index.CompareAndSwap(curIndex, index) {
+			sizeDiff := int64(sizeAfter) - sizeBefore
+			t.size.Add(sizeDiff)
+
+			t.table.metrics.numParts.Add(float64(partsAfter - partsBefore))
+			break
+		}
+	}
+	return true, nil
+}
+
+// level1ToGranuleTargetSizeRatio*granuleSize is the target size for new level1
+// parts.
+// 0.5 was chosen so that a level1 part takes up around half the space in a full
+// granule, allowing for level0 parts to grow up to the remaining space before
+// compaction. The higher this ratio, the less data is compacted and the more
+// compactions occur. However, a lower ratio implies leaving some parquet
+// compression size savings on the table.
+const level1ToGranuleTargetSizeRatio = 0.5
+
+// compactLevel0IntoLevel1 compacts the given level0Parts into level1Parts by
+// merging them with overlapping level1 parts and producing parts that are up
+// to the TableBlock's maximum granule size. These parts are guaranteed to be
+// non-overlapping.
+// The size limit is a best effort as there is currently no easy way to
+// determine the size of a parquet file while writing row groups to it.
+func compactLevel0IntoLevel1(
+	t *TableBlock, tx uint64, level0Parts, level1Parts []*Part,
+) ([]*Part, error) {
+	// Verify whether the level0 parts overlap with level1 parts. If they do,
+	// we need to merge the overlapping parts. Not merging these parts could
+	// cause them to be split to different granules, rendering the index
+	// useless.
+	nonOverlapping := make([]*Part, 0, len(level1Parts))
+	partsToCompact := level0Parts
+	// size and numRows are used to estimate the number of bytes per row so that
+	// we can provide a maximum number of rows to write in writeRowGroups which
+	// will more or less keep the compacted part under the maximum granule size.
+	var size, numRows int64
+	if len(level1Parts) == 0 {
+		for _, p0 := range level0Parts {
+			// If no level1 parts exist, then we estimate the parquet rows to
+			// write based on level0.
+			size += p0.Buf.ParquetFile().Size()
+			numRows += p0.Buf.ParquetFile().NumRows()
+		}
+	}
+	for _, p1 := range level1Parts {
+		size += p1.Buf.ParquetFile().Size()
+		numRows += p1.Buf.ParquetFile().NumRows()
+		overlapped := false
+		for _, p0 := range level0Parts {
+			if overlaps, err := p0.overlapsWith(t.table.config.schema, p1); err != nil {
+				return nil, err
+			} else if overlaps {
+				partsToCompact = append(partsToCompact, p1)
+				overlapped = true
+				break
+			}
+		}
+		if !overlapped {
+			nonOverlapping = append(nonOverlapping, p1)
+		}
+	}
+
+	bufs := make([]dynparquet.DynamicRowGroup, 0, len(level0Parts))
+	for _, p := range partsToCompact {
+		numRowGroups := p.Buf.NumRowGroups()
+		for i := 0; i < numRowGroups; i++ {
+			bufs = append(bufs, p.Buf.DynamicRowGroup(i))
+		}
+	}
+
+	cursor := 0
+	merged, err := t.table.config.schema.MergeDynamicRowGroups(bufs)
+	if err != nil {
+		return nil, err
+	}
+
+	estimatedBytesPerRow := float64(size) / float64(numRows)
+	estimatedRowsPerPart := int(
+		math.Ceil(
+			(float64(t.table.db.columnStore.granuleSizeBytes) * level1ToGranuleTargetSizeRatio) /
+				estimatedBytesPerRow,
+		),
+	)
+	if err := func() error {
+		rows := merged.Rows()
+		defer rows.Close()
+
+		for {
+			var mergedBytes bytes.Buffer
+			if err := rows.SeekToRow(int64(cursor)); err != nil {
+				return err
+			}
+			n, err := t.writeRows(&mergedBytes, rows, merged.DynamicColumns(), estimatedRowsPerPart)
+			if err != nil {
+				return err
+			}
+			if n == 0 {
+				break
+			}
+			cursor += n
+			serBuf, err := dynparquet.ReaderFromBytes(mergedBytes.Bytes())
+			if err != nil {
+				return err
+			}
+			compactedPart := NewPart(tx, serBuf)
+			compactedPart.compactionLevel = compactionLevel1
+			nonOverlapping = append(nonOverlapping, compactedPart)
+		}
+		return nil
+	}(); err != nil {
+		return nil, fmt.Errorf("failed level0->level1 compaction: %w", err)
+	}
+
+	return nonOverlapping, nil
+}
+
+func collectPartsForCompaction(tx uint64, parts *PartList) (
+	level0Parts, level1Parts, partsWithUncompletedTxns []*Part,
+	size int64, err error,
+) {
+	parts.Iterate(func(p *Part) bool {
+		if p.tx > tx {
+			if !p.hasTombstone() {
+				partsWithUncompletedTxns = append(partsWithUncompletedTxns, p)
+			}
+			// Parts with a tombstone are dropped.
+			return true
+		}
+
+		switch p.compactionLevel {
+		case compactionLevel0:
+			level0Parts = append(level0Parts, p)
+		case compactionLevel1:
+			level1Parts = append(level1Parts, p)
+		default:
+			err = fmt.Errorf(
+				"unexpected part compaction level %d", p.compactionLevel,
+			)
+			return false
+		}
+		size += p.Buf.ParquetFile().Size()
+		return true
+	})
+	return
+}
+
+// divideLevel1PartsForGranule returns a two-dimensional slice of parts where
+// each element is a slice of parts that all together have a sum of sizes less
+// than maxSize.
+// The global sort order of the input parts is maintained.
+func divideLevel1PartsForGranule(t *TableBlock, tx uint64, parts []*Part, maxSize int64) ([][]*Part, error) {
+	var totalSize int64
+	sizes := make([]int64, len(parts))
+	for i, p := range parts {
+		size := p.Buf.ParquetFile().Size()
+		totalSize += size
+		sizes[i] = size
+	}
+	if totalSize <= maxSize {
+		// No splits needed.
+		return [][]*Part{parts}, nil
+	}
+
+	// We want to maximize the size of each split slice, so we follow a greedy
+	// approach. Note that in practice because we create level1 parts that are
+	// around half the size of a granule (level1ToGranuleSizeRatio), if a
+	// granule is split, it will be split into two granules that are half filled
+	// up with a level1 part.
+	var (
+		runningSize int64
+		newParts    [][]*Part
+	)
+	for i, size := range sizes {
+		runningSize += size
+		if runningSize > maxSize {
+			// Close the current subslice and create a new one.
+			newParts = append(newParts, []*Part{parts[i]})
+			runningSize = size
+			continue
+		}
+		if i == 0 {
+			newParts = append(newParts, []*Part{parts[i]})
+		} else {
+			newParts[len(newParts)-1] = append(newParts[len(newParts)-1], parts[i])
+		}
+	}
+	return newParts, nil
 }

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -2,82 +2,351 @@ package frostdb
 
 import (
 	"context"
+	"io"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/google/btree"
+	"github.com/segmentio/parquet-go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/polarsignals/frostdb/dynparquet"
 )
 
-func TestCompaction(t *testing.T) {
-	c, table := basicTable(t)
-	defer c.Close()
-	table.config.rowGroupSize = 2 // override row group size setting
-
-	samples := dynparquet.Samples{{
-		Labels: []dynparquet.Label{
-			{Name: "label1", Value: "value1"},
-			{Name: "label2", Value: "value2"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 1,
-		Value:     1,
-	}, {
-		Labels: []dynparquet.Label{
-			{Name: "label1", Value: "value1"},
-			{Name: "label2", Value: "value2"},
-			{Name: "label3", Value: "value3"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 2,
-		Value:     2,
-	}, {
-		Labels: []dynparquet.Label{
-			{Name: "label1", Value: "value1"},
-			{Name: "label2", Value: "value2"},
-			{Name: "label4", Value: "value4"},
-		},
-		Stacktrace: []uuid.UUID{
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
-			{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
-		},
-		Timestamp: 3,
-		Value:     3,
-	}}
-
-	ctx := context.Background()
-	tx, err := table.Write(ctx, samples[0], samples[1], samples[2])
+// insertSamples is a helper function to insert a deterministic sample with a
+// given timestamp. Note that rows inserted should be sorted by timestamp since
+// it is a sorting column.
+func insertSamples(ctx context.Context, t *testing.T, table *Table, timestamps ...int64) uint64 {
+	t.Helper()
+	samples := make([]any, 0, len(timestamps))
+	for _, ts := range timestamps {
+		samples = append(samples, dynparquet.Sample{
+			Labels: []dynparquet.Label{
+				{Name: "label1", Value: "value1"},
+			},
+			Timestamp: ts,
+		})
+	}
+	tx, err := table.Write(ctx, samples...)
 	require.NoError(t, err)
+	return tx
+}
 
-	// Wait for the writes to have been marked as completed
-	table.db.Wait(tx)
+func TestCompaction(t *testing.T) {
+	// expectedPart specifies the expected part data the test should verify.
+	type expectedPart struct {
+		compactionLevel compactionLevel
+		numRowGroups    int
+		// data is the expected data. Only the timestamps are verified in this
+		// test for simplicity.
+		data []int64
+	}
+	// expectedGranule specifies the expected granule data the test should
+	// verify.
+	type expectedGranule struct {
+		parts []expectedPart
+	}
 
-	// Expect only a single granule to have been created
-	require.Equal(t, 1, table.active.Index().Len())
+	const (
+		// comactCommand indicates a compaction should be performed. Note that
+		// compactions need to be specified explicitly.
+		compactCommand = -1
+		// recordGranuleSizeCommand records the granule size at that moment.
+		recordGranuleSizeCommand = -2
+		// setRecordedGranuleSizeCommand sets the granule size to the size that
+		// was recorded when recordGranuleSizeCommand was executed.
+		setRecordedGranuleSizeCommand = -3
+		// acc accumulates the following inserts into a buffer.
+		acc = -4
+		// flushAcc inserts the accumulated data into the table. Useful to
+		// create row groups larger than one row.
+		flushAcc = -5
+	)
 
-	// Force compaction on the granule
-	g := (table.active.Index().Min()).(*Granule)
-	table.active.compactGranule(g)
+	testCases := []struct {
+		name string
+		// rgSize is the desired row group size. If unspecified, will default to
+		// 2 rows.
+		rgSize int
+		// inserts are the timestamps to insert at. Negative int64s are
+		// interpreted as commands to do something, see the const declaration
+		// above.
+		inserts  []int64
+		expected []expectedGranule
+	}{
+		{
+			name: "SimpleLevel0ToLevel1",
+			// Insert three rows.
+			inserts: []int64{1, 2, 3, compactCommand},
+			// Expect compaction into a single part with level1 compaction.
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 3},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This test is the same as above, but inserts a couple more rows,
+			// expecting a second part with compaction level 0 to be created.
+			name: "AddLevel0ToLevel1",
+			// Insert three rows.
+			inserts: []int64{1, 2, 3, compactCommand, 4},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    1,
+							compactionLevel: compactionLevel0,
+							data:            []int64{4},
+						},
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 3},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This test is the same as above, but adds a command to set the
+			// granule size artificially low followed by a compaction. This
+			// should trigger a split: i.e. the new part is reassigned to a new
+			// granule.
+			name: "Split",
+			inserts: []int64{
+				1, 2, 3,
+				compactCommand, recordGranuleSizeCommand,
+				4, 5,
+				setRecordedGranuleSizeCommand, compactCommand,
+			},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 3},
+						},
+					},
+				},
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    1,
+							compactionLevel: compactionLevel1,
+							data:            []int64{4, 5},
+						},
+					},
+				},
+			},
+		},
+		{
+			// SimpleOverlap tests out of order inserts after a compaction. The
+			// new inserts should be merged into the existing part, because
+			// otherwise a new granule could be created with overlapping data,
+			// rendering the index useless.
+			name:    "SimpleOverlap",
+			inserts: []int64{1, 2, 3, compactCommand, 2, compactCommand},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 2, 3},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "MultiOverlap",
+			inserts: []int64{
+				1, 3, // Don't insert 2 to test non-equality overlapping.
+				compactCommand,
+				4, 5, 6,
+				compactCommand,
+				7, 8, 9,
+				compactCommand,
+				5, 2, 1,
+				compactCommand,
+			},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{7, 8, 9},
+						},
+						{
+							numRowGroups:    4,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 1, 2, 3, 4, 5, 5, 6},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SingleL0MultipleL1Overlaps",
+			inserts: []int64{
+				1, 3,
+				compactCommand,
+				4, 5, 6,
+				compactCommand,
+				acc, 2, 4, flushAcc,
+				compactCommand,
+			},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    4,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 3, 4, 4, 5, 6},
+						},
+					},
+				},
+			},
+		},
+	}
 
-	// Expect the granule to have been compacted into a single granule
-	require.Equal(t, 1, table.active.Index().Len())
+	numParts := func(g *Granule) int {
+		parts := 0
+		g.parts.Iterate(func(p *Part) bool {
+			parts++
+			return true
+		})
+		return parts
+	}
 
-	// Expect the granule to contain a single part with multiple row groups
-	g = (table.active.Index().Min()).(*Granule)
-	parts := 0
-	g.parts.Iterate(func(p *Part) bool {
-		parts++
-		require.Equal(t, 2, p.Buf.NumRowGroups())
-		return true
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, table := basicTable(t)
+			defer c.Close()
+			// Disable interval compaction for tests. These are triggered
+			// manually.
+			table.db.compactorPool.stop()
+			table.db.compactorPool = nil
 
-	// There should only be a single part that contains multiple row groups
-	require.Equal(t, 1, parts)
+			table.config.rowGroupSize = 2
+			if tc.rgSize != 0 {
+				table.config.rowGroupSize = tc.rgSize
+			}
+
+			var (
+				numInserts          int
+				accumulating        bool
+				accBuf              []int64
+				lastTx              uint64
+				recordedGranuleSize uint64
+			)
+			for _, v := range tc.inserts {
+				switch v {
+				case compactCommand:
+					table.db.Wait(lastTx)
+					require.Equal(
+						t,
+						1,
+						table.active.Index().Len(),
+						"tests assume only a single granule as input",
+					)
+					success, err := table.active.compactGranule((table.active.Index().Min()).(*Granule))
+					require.True(t, success)
+					require.NoError(t, err)
+				case recordGranuleSizeCommand:
+					table.db.Wait(lastTx)
+					require.Equal(
+						t,
+						1,
+						table.active.Index().Len(),
+						"tests assume only a single granule as input",
+					)
+					recordedGranuleSize = (table.active.Index().Min()).(*Granule).metadata.size.Load()
+				case setRecordedGranuleSizeCommand:
+					table.db.columnStore.granuleSizeBytes = int64(recordedGranuleSize)
+				case acc:
+					accumulating = true
+				case flushAcc:
+					accumulating = false
+					lastTx = insertSamples(context.Background(), t, table, accBuf...)
+					accBuf = accBuf[:0]
+					numInserts++
+				default:
+					if accumulating {
+						accBuf = append(accBuf, v)
+						continue
+					}
+					lastTx = insertSamples(context.Background(), t, table, v)
+					numInserts++
+				}
+			}
+
+			require.Equal(t, len(tc.expected), table.active.Index().Len())
+			i := 0
+			table.active.Index().Ascend(func(item btree.Item) bool {
+				g := item.(*Granule)
+				expected := tc.expected[i]
+				require.Equal(t, len(expected.parts), numParts(g))
+
+				j := 0
+				g.parts.Iterate(func(p *Part) bool {
+					expectedPart := expected.parts[j]
+					rgs := p.Buf.ParquetFile().RowGroups()
+					require.Equal(t, expectedPart.numRowGroups, len(rgs))
+					require.Equal(t, expectedPart.compactionLevel, p.compactionLevel)
+					rowsRead := make([]parquet.Row, 0)
+					for _, rg := range rgs {
+						func() {
+							rows := rg.Rows()
+							defer rows.Close()
+
+							for {
+								rowBuf := make([]parquet.Row, 1)
+								n, err := rows.ReadRows(rowBuf)
+								if err != nil && err != io.EOF {
+									require.NoError(t, err)
+								}
+								if n > 0 {
+									rowsRead = append(rowsRead, rowBuf...)
+								}
+
+								if err == io.EOF {
+									break
+								}
+							}
+						}()
+					}
+					require.Equal(
+						t,
+						len(expectedPart.data),
+						len(rowsRead),
+						"different number of rows read for granule %d part %d",
+						i,
+						j,
+					)
+
+					// This is a bit of a hack. If the check below fails
+					// unexpectedly after a change to the default schema, think
+					// about a more robust search of the timestamp column index.
+					const timestampColumnIdx = 3
+					for k, expectedTimestamp := range expectedPart.data {
+						require.Equal(t, rowsRead[k][timestampColumnIdx].Int64(), expectedTimestamp)
+					}
+
+					j++
+					return true
+				})
+				i++
+				return true
+			})
+		})
+	}
 }

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -258,7 +258,10 @@ func TestCompaction(t *testing.T) {
 						table.active.Index().Len(),
 						"tests assume only a single granule as input",
 					)
-					success, err := table.active.compactGranule((table.active.Index().Min()).(*Granule))
+					success, err := table.active.compactGranule(
+						(table.active.Index().Min()).(*Granule),
+						table.db.columnStore.compactionConfig,
+					)
 					require.True(t, success)
 					require.NoError(t, err)
 				case recordGranuleSizeCommand:

--- a/db.go
+++ b/db.go
@@ -40,10 +40,7 @@ type ColumnStore struct {
 	bucket               storage.Bucket
 	ignoreStorageOnQuery bool
 	enableWAL            bool
-	compactionOptions    struct {
-		concurrency   int
-		sweepInterval time.Duration
-	}
+	compactionConfig     *CompactionConfig
 
 	// indexDegree is the degree of the btree index (default = 2)
 	indexDegree int
@@ -66,6 +63,7 @@ func New(
 		splitSize:        2,
 		granuleSizeBytes: 1 * 1024 * 1024,   // 1MB granule size before splitting
 		activeMemorySize: 512 * 1024 * 1024, // 512MB
+		compactionConfig: NewCompactionConfig(),
 	}
 
 	for _, option := range options {
@@ -166,18 +164,9 @@ func WithIgnoreStorageOnQuery() Option {
 	}
 }
 
-// WithCompactionConcurrency specfies the number of concurrent goroutines
-// compacting data for each database.
-func WithCompactionConcurrency(c int) Option {
+func WithCompactionConfig(c *CompactionConfig) Option {
 	return func(s *ColumnStore) error {
-		s.compactionOptions.concurrency = c
-		return nil
-	}
-}
-
-func WithCompactionSweepInterval(interval time.Duration) Option {
-	return func(s *ColumnStore) error {
-		s.compactionOptions.sweepInterval = interval
+		s.compactionConfig = c
 		return nil
 	}
 }
@@ -322,7 +311,7 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 
 	if dbSetupErr := func() error {
 		db.txPool = NewTxPool(db.highWatermark)
-		db.compactorPool = newCompactorPool(db)
+		db.compactorPool = newCompactorPool(db, s.compactionConfig)
 		// If bucket storage is configured; scan for existing tables in the database
 		if db.bucket != nil {
 			if err := db.bucket.Iter(ctx, "", func(tableName string) error {

--- a/db.go
+++ b/db.go
@@ -440,7 +440,9 @@ func (db *DB) replayWAL(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
+				db.mtx.Lock()
 				db.tables[tableName] = table
+				db.mtx.Unlock()
 				return nil
 			}
 			if err != nil {

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -42,6 +42,10 @@ type DynamicRow struct {
 }
 
 func (s *Schema) RowLessThan(a, b *DynamicRow) bool {
+	return s.Cmp(a, b) < 0
+}
+
+func (s *Schema) Cmp(a, b *DynamicRow) int {
 	dynamicColumns := mergeDynamicColumnSets([]map[string][]string{a.DynamicColumns, b.DynamicColumns})
 	cols := s.parquetSortingColumns(dynamicColumns)
 	for _, col := range cols {
@@ -64,16 +68,16 @@ func (s *Schema) RowLessThan(a, b *DynamicRow) bool {
 		av, bv := extractValues(a, b, aIndex, bIndex)
 		cmp := compare(col, node, av, bv)
 		if cmp < 0 {
-			return true
+			return cmp
 		}
 		if cmp > 0 {
-			return false
+			return cmp
 		}
 		// neither of those case are true so a and b are equal for this column
 		// and we need to continue with the next column.
 	}
 
-	return false
+	return 0
 }
 
 func compare(col parquet.SortingColumn, node parquet.Node, av, bv []parquet.Value) int {

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -479,6 +479,7 @@ type DynamicRowGroup interface {
 
 // DynamicRowReaders is an iterator over the rows in a DynamicRowGroup.
 type DynamicRowReader interface {
+	parquet.RowSeeker
 	ReadRows(*DynamicRows) (int, error)
 	Close() error
 }
@@ -497,6 +498,10 @@ func newDynamicRowGroupReader(rg DynamicRowGroup, fields []parquet.Field) *dynam
 		rows:           rg.Rows(),
 		fields:         fields,
 	}
+}
+
+func (r *dynamicRowGroupReader) SeekToRow(i int64) error {
+	return r.rows.SeekToRow(i)
 }
 
 // Implements the DynamicRows interface.

--- a/granule.go
+++ b/granule.go
@@ -32,12 +32,11 @@ type GranuleMetadata struct {
 	// iterator.
 	least atomic.Pointer[dynparquet.DynamicRow]
 
-	// size is the raw committed, and uncommitted size of the granule. It is
-	// used as a suggestion for potential compaction.
-	size *atomic.Uint64
+	// size is the raw commited, and uncommited size of the granule. It is used as a suggestion for potential compaction
+	size atomic.Uint64
 
-	// pruned indicates if this Granule is longer found in the index.
-	pruned *atomic.Uint64
+	// pruned indicates if this Granule is longer found in the index
+	pruned atomic.Uint64
 }
 
 func NewGranule(granulesCreated prometheus.Counter, tableConfig *TableConfig, firstPart *Part) (*Granule, error) {
@@ -47,9 +46,7 @@ func NewGranule(granulesCreated prometheus.Counter, tableConfig *TableConfig, fi
 		tableConfig:     tableConfig,
 
 		metadata: GranuleMetadata{
-			least:  atomic.Pointer[dynparquet.DynamicRow]{},
-			size:   &atomic.Uint64{},
-			pruned: &atomic.Uint64{},
+			least: atomic.Pointer[dynparquet.DynamicRow]{},
 		},
 	}
 

--- a/granule.go
+++ b/granule.go
@@ -1,9 +1,7 @@
 package frostdb
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"sync/atomic"
 
 	"github.com/google/btree"
@@ -85,7 +83,8 @@ func (g *Granule) addPart(p *Part, r *dynparquet.DynamicRow) (uint64, error) {
 		}
 	}
 
-	// If the prepend returned that we're adding to the compacted list; then we need to propogate the Part to the new granules
+	// If the prepend returned that we're adding to the compacted list; then we
+	// need to propagate the Part to the new granules.
 	if node.sentinel == Compacted {
 		err := addPartToGranule(g.newGranules, p)
 		if err != nil {
@@ -113,108 +112,6 @@ func (g *Granule) AddPart(p *Part) (uint64, error) {
 	}
 
 	return g.addPart(p, r)
-}
-
-// split a granule into n granules. With the last granule containing the remainder.
-// Returns the granules in order.
-// This assumes the Granule has had its parts merged into a single part.
-func (g *Granule) split(tx uint64, count int) ([]*Granule, int64, error) {
-	// Get the first part in the granule's part list.
-	var p *Part
-	g.parts.Iterate(func(part *Part) bool {
-		// Since all parts are already merged into one, this iterator will only
-		// iterate over the one and only part.
-		p = part
-		return false
-	})
-
-	// Build all the new granules
-	granules := make([]*Granule, 0, count)
-
-	// TODO: Buffers should be able to efficiently slice themselves.
-	var (
-		rowBuf = make([]parquet.Row, 1)
-		b      *bytes.Buffer
-		w      *dynparquet.PooledWriter
-	)
-	b = bytes.NewBuffer(nil)
-	w, err := g.tableConfig.schema.GetWriter(b, p.Buf.DynamicColumns())
-	if err != nil {
-		return nil, 0, ErrCreateSchemaWriter{err}
-	}
-
-	rowsWritten := 0
-	totalSize := int64(0)
-	n := int(p.Buf.NumRows()) / count
-
-	f := p.Buf.ParquetFile()
-	for _, rowGroup := range f.RowGroups() {
-		rows := rowGroup.Rows()
-		for {
-			_, err = rows.ReadRows(rowBuf)
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return nil, 0, ErrReadRow{err}
-			}
-
-			_, err = w.WriteRows(rowBuf)
-			if err != nil {
-				return nil, 0, ErrWriteRow{err}
-			}
-			rowsWritten++
-
-			if rowsWritten == n && len(granules) != count-1 { // If we have n rows, and aren't on the last granule create a new granule
-				err = w.Close()
-				if err != nil {
-					return nil, 0, fmt.Errorf("close writer: %w", err)
-				}
-				r, err := dynparquet.ReaderFromBytes(b.Bytes())
-				if err != nil {
-					return nil, 0, fmt.Errorf("create reader: %w", err)
-				}
-				totalSize += r.ParquetFile().Size()
-				gran, err := NewGranule(g.granulesCreated, g.tableConfig, NewPart(tx, r))
-				if err != nil {
-					return nil, 0, fmt.Errorf("new granule failed: %w", err)
-				}
-				granules = append(granules, gran)
-				b = bytes.NewBuffer(nil)
-				g.tableConfig.schema.PutWriter(w)
-				w, err = g.tableConfig.schema.GetWriter(b, p.Buf.DynamicColumns())
-				if err != nil {
-					return nil, 0, ErrCreateSchemaWriter{err}
-				}
-				rowsWritten = 0
-			}
-		}
-		if err := rows.Close(); err != nil {
-			return nil, 0, err
-		}
-	}
-
-	if rowsWritten > 0 {
-		// Save the remaining Granule
-		err = w.Close()
-		if err != nil {
-			return nil, 0, fmt.Errorf("close last writer: %w", err)
-		}
-		g.tableConfig.schema.PutWriter(w)
-
-		r, err := dynparquet.ReaderFromBytes(b.Bytes())
-		if err != nil {
-			return nil, 0, fmt.Errorf("create last reader: %w", err)
-		}
-		totalSize += r.ParquetFile().Size()
-		gran, err := NewGranule(g.granulesCreated, g.tableConfig, NewPart(tx, r))
-		if err != nil {
-			return nil, 0, fmt.Errorf("new granule failed: %w", err)
-		}
-		granules = append(granules, gran)
-	}
-
-	return granules, totalSize, nil
 }
 
 // PartBuffersForTx returns the PartBuffers for the given transaction constraints.

--- a/part.go
+++ b/part.go
@@ -2,17 +2,35 @@ package frostdb
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/segmentio/parquet-go"
 
 	"github.com/polarsignals/frostdb/dynparquet"
 )
 
+type compactionLevel uint8
+
+const (
+	// compactionLevel0 is the default compaction level for new Parts. This
+	// means that the Part contains multiple variable-length row groups.
+	compactionLevel0 compactionLevel = iota
+	// compactionLevel1 is the compaction level for Parts that are the result of
+	// a compaction. Parts with this compaction level contain multiple row
+	// groups with the row group size specified on table creation.
+	compactionLevel1
+)
+
 type Part struct {
 	Buf *dynparquet.SerializedBuffer
 
-	// transaction id that this part was inserted under
+	// tx is the id of the transaction that created this part.
 	tx uint64
+
+	compactionLevel compactionLevel
+
+	minRow *dynparquet.DynamicRow
+	maxRow *dynparquet.DynamicRow
 }
 
 func NewPart(tx uint64, buf *dynparquet.SerializedBuffer) *Part {
@@ -24,19 +42,110 @@ func NewPart(tx uint64, buf *dynparquet.SerializedBuffer) *Part {
 
 // Least returns the least row  in the part.
 func (p *Part) Least() (*dynparquet.DynamicRow, error) {
-	rowBuf := &dynparquet.DynamicRows{Rows: make([]parquet.Row, 1)}
-	reader := p.Buf.DynamicRowGroup(0).DynamicRows()
-	n, err := reader.ReadRows(rowBuf)
-	if err != nil {
-		return nil, fmt.Errorf("read first row of part: %w", err)
-	}
-	if n != 1 {
-		return nil, fmt.Errorf("expected to read exactly 1 row, but read %d", n)
-	}
-	r := rowBuf.GetCopy(0)
-	if err := reader.Close(); err != nil {
-		return nil, err
+	if p.minRow != nil {
+		return p.minRow, nil
 	}
 
-	return r, nil
+	rowBuf := &dynparquet.DynamicRows{Rows: make([]parquet.Row, 1)}
+	reader := p.Buf.DynamicRowGroup(0).DynamicRows()
+	defer reader.Close()
+
+	if n, err := reader.ReadRows(rowBuf); err != nil {
+		return nil, fmt.Errorf("read first row of part: %w", err)
+	} else if n != 1 {
+		return nil, fmt.Errorf("expected to read exactly 1 row, but read %d", n)
+	}
+
+	// Copy here so that this reference does not prevent the decompressed page
+	// from being GCed.
+	p.minRow = rowBuf.GetCopy(0)
+	return p.minRow, nil
+}
+
+func (p *Part) most() (*dynparquet.DynamicRow, error) {
+	if p.maxRow != nil {
+		return p.maxRow, nil
+	}
+
+	rowBuf := &dynparquet.DynamicRows{Rows: make([]parquet.Row, 1)}
+	rg := p.Buf.DynamicRowGroup(p.Buf.NumRowGroups() - 1)
+	reader := rg.DynamicRows()
+	defer reader.Close()
+
+	if err := reader.SeekToRow(rg.NumRows() - 1); err != nil {
+		return nil, fmt.Errorf("seek to last row of part: %w", err)
+	}
+
+	if n, err := reader.ReadRows(rowBuf); err != nil {
+		return nil, fmt.Errorf("read last row of part: %w", err)
+	} else if n != 1 {
+		return nil, fmt.Errorf("expected to read exactly 1 row, but read %d", n)
+	}
+
+	// Copy here so that this reference does not prevent the decompressed page
+	// from being GCed.
+	p.maxRow = rowBuf.GetCopy(0)
+	return p.maxRow, nil
+}
+
+func (p Part) overlapsWith(schema *dynparquet.Schema, otherPart *Part) (bool, error) {
+	a, err := p.Least()
+	if err != nil {
+		return false, err
+	}
+	b, err := p.most()
+	if err != nil {
+		return false, err
+	}
+	c, err := otherPart.Least()
+	if err != nil {
+		return false, err
+	}
+	d, err := otherPart.most()
+	if err != nil {
+		return false, err
+	}
+
+	return schema.Cmp(a, d) <= 0 && schema.Cmp(c, b) <= 0, nil
+}
+
+// tombstone marks all the parts with the max tx id to ensure they aren't
+// included in reads. Tombstoned parts will be eventually be dropped from the
+// database during compaction.
+func tombstone(parts []*Part) {
+	for _, part := range parts {
+		part.tx = math.MaxUint64
+	}
+}
+
+func (p Part) hasTombstone() bool {
+	return p.tx == math.MaxUint64
+}
+
+type partSorter struct {
+	schema *dynparquet.Schema
+	parts  []*Part
+	err    error
+}
+
+func (p partSorter) Len() int {
+	return len(p.parts)
+}
+
+func (p *partSorter) Less(i, j int) bool {
+	a, err := p.parts[i].Least()
+	if err != nil {
+		p.err = err
+		return false
+	}
+	b, err := p.parts[j].Least()
+	if err != nil {
+		p.err = err
+		return false
+	}
+	return p.schema.RowLessThan(a, b)
+}
+
+func (p *partSorter) Swap(i, j int) {
+	p.parts[i], p.parts[j] = p.parts[j], p.parts[i]
 }

--- a/table.go
+++ b/table.go
@@ -154,6 +154,7 @@ type tableMetrics struct {
 	rowInsertSize             prometheus.Histogram
 	lastCompletedBlockTx      prometheus.Gauge
 	numParts                  prometheus.Gauge
+	compactionMetrics         *compactionMetrics
 }
 
 func newTable(
@@ -227,6 +228,7 @@ func newTable(
 				Name: "last_completed_block_tx",
 				Help: "Last completed block transaction.",
 			}),
+			compactionMetrics: newCompactionMetrics(reg, float64(db.columnStore.granuleSizeBytes)),
 		},
 	}
 
@@ -931,7 +933,7 @@ func newTableBlock(table *Table, prevTx, tx uint64, id ulid.ULID) (*TableBlock, 
 
 // EnsureCompaction forces a TableBlock compaction.
 func (t *TableBlock) EnsureCompaction() error {
-	return t.compact()
+	return t.compact(t.table.db.columnStore.compactionConfig)
 }
 
 func (t *TableBlock) Insert(ctx context.Context, tx uint64, buf *dynparquet.SerializedBuffer) error {


### PR DESCRIPTION
This PR implements simple leveled compaction of parts into level 1 parts as described in #223, which are guaranteed to never be overlapping. This will hopefully improve our memory usage during compactions and avoid the spikes we've seen in our clusters. Please refer to the individual commits for details. I've tried to split it up into 1) The addition of leveled compaction, 2) Handling out-of-order inserts which should only happen very rarely but it is an edge case we need to handle.