### PR TITLE
dynamically build the output schema

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -212,16 +212,10 @@ func TestDBWithWAL(t *testing.T) {
 
 	pool := memory.NewGoAllocator()
 	err = table.View(ctx, func(ctx context.Context, tx uint64) error {
-		as, err := table.ArrowSchema(ctx, tx, pool, logicalplan.IterOptions{})
-		if err != nil {
-			return err
-		}
-
 		return table.Iterator(
 			ctx,
 			tx,
 			pool,
-			as,
 			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				t.Log(ar)

--- a/pqarrow/builder/recordbuilder.go
+++ b/pqarrow/builder/recordbuilder.go
@@ -107,3 +107,24 @@ func (b *RecordBuilder) NewRecord() arrow.Record {
 
 	return array.NewRecord(b.schema, cols, rows)
 }
+
+// ExpandSchema expands the record builder schema by adding new fields.
+func (b *RecordBuilder) ExpandSchema(schema *arrow.Schema) {
+	for i, f := range schema.Fields() {
+		found := false
+		for _, old := range b.schema.Fields() {
+			if f.Equal(old) {
+				found = true
+				break
+			}
+		}
+		if found { // field already exists
+			continue
+		}
+
+		// Add the new field
+		b.fields = append(b.fields[:i], append([]ColumnBuilder{NewBuilder(b.mem, f.Type)}, b.fields[i:]...)...)
+	}
+
+	b.schema = schema
+}

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -119,7 +119,6 @@ type TableReader interface {
 		ctx context.Context,
 		tx uint64,
 		pool memory.Allocator,
-		schema *arrow.Schema,
 		options IterOptions,
 		callbacks []Callback,
 	) error
@@ -130,12 +129,6 @@ type TableReader interface {
 		options IterOptions,
 		callbacks []Callback,
 	) error
-	ArrowSchema(
-		ctx context.Context,
-		tx uint64,
-		pool memory.Allocator,
-		options IterOptions,
-	) (*arrow.Schema, error)
 	Schema() *dynparquet.Schema
 }
 type TableProvider interface {

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +26,6 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	schema *arrow.Schema,
 	iterOpts IterOptions,
 	callbacks []Callback,
 ) error {
@@ -42,15 +40,6 @@ func (m *mockTableReader) SchemaIterator(
 	callbacks []Callback,
 ) error {
 	return nil
-}
-
-func (m *mockTableReader) ArrowSchema(
-	ctx context.Context,
-	tx uint64,
-	pool memory.Allocator,
-	iterOpts IterOptions,
-) (*arrow.Schema, error) {
-	return nil, nil
 }
 
 type mockTableProvider struct {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -117,26 +117,11 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 	}
 
 	err = table.View(ctx, func(ctx context.Context, tx uint64) error {
-		schema, err := table.ArrowSchema(
-			ctx,
-			tx,
-			pool,
-			logicalplan.IterOptions{
-				PhysicalProjection: s.options.PhysicalProjection,
-				Projection:         s.options.Projection,
-				Filter:             s.options.Filter,
-				DistinctColumns:    s.options.Distinct,
-			},
-		)
-		if err != nil {
-			return err
-		}
-
 		return table.Iterator(
 			ctx,
 			tx,
 			pool,
-			schema,
+			nil,
 			logicalplan.IterOptions{
 				PhysicalProjection: s.options.PhysicalProjection,
 				Projection:         s.options.Projection,

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -121,7 +121,6 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			nil,
 			logicalplan.IterOptions{
 				PhysicalProjection: s.options.PhysicalProjection,
 				Projection:         s.options.Projection,

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -29,7 +29,6 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	schema *arrow.Schema,
 	iterOpts logicalplan.IterOptions,
 	callbacks []logicalplan.Callback,
 ) error {
@@ -44,15 +43,6 @@ func (m *mockTableReader) SchemaIterator(
 	callbacks []logicalplan.Callback,
 ) error {
 	return nil
-}
-
-func (m *mockTableReader) ArrowSchema(
-	ctx context.Context,
-	tx uint64,
-	pool memory.Allocator,
-	iterOpts logicalplan.IterOptions,
-) (*arrow.Schema, error) {
-	return nil, nil
 }
 
 type mockTableProvider struct {


### PR DESCRIPTION
This addresses issue #230 by removing the `ArrowSchema` call in the physical plan execute function. It instead builds the output schema as it converts row groups. 

Benchmark with simulated network latency to storage
```
name                      old time/op    new time/op    delta
PersistentQuery/Types-10     638ms ± 2%     317ms ± 2%  -50.32%  (p=0.000 n=29+28)
PersistentQuery/Merge-10     2.51s ± 3%     2.22s ± 3%  -11.61%  (p=0.000 n=29+28)
PersistentQuery/Range-10     877ms ± 2%     562ms ± 3%  -35.91%  (p=0.000 n=30+28)

name                      old alloc/op   new alloc/op   delta
PersistentQuery/Types-10    68.3MB ± 0%    36.7MB ± 0%  -46.36%  (p=0.000 n=29+30)
PersistentQuery/Merge-10    32.0GB ± 3%    32.0GB ± 1%     ~     (p=0.296 n=30+28)
PersistentQuery/Range-10    2.43GB ± 1%    2.40GB ± 2%   -1.50%  (p=0.000 n=30+30)

name                      old allocs/op  new allocs/op  delta
PersistentQuery/Types-10     1.09M ± 0%     0.57M ± 0%  -47.27%  (p=0.000 n=30+30)
PersistentQuery/Merge-10     12.9M ± 1%     12.4M ± 1%   -4.16%  (p=0.000 n=29+30)
PersistentQuery/Range-10     2.86M ± 1%     2.34M ± 1%  -18.24%  (p=0.000 n=28+27)
```

Benchmark without the simulated network latency
```
name                      old time/op    new time/op    delta
PersistentQuery/Types-10    35.7ms ± 1%    17.1ms ± 1%  -51.95%  (p=0.000 n=22+28)
PersistentQuery/Merge-10     1.94s ± 7%     1.92s ± 5%     ~     (p=0.099 n=28+29)
PersistentQuery/Range-10     283ms ± 4%     268ms ± 5%   -5.41%  (p=0.000 n=29+29)

name                      old alloc/op   new alloc/op   delta
PersistentQuery/Types-10    68.2MB ± 0%    36.6MB ± 0%  -46.40%  (p=0.000 n=30+30)
PersistentQuery/Merge-10    32.0GB ± 2%    32.0GB ± 2%     ~     (p=0.781 n=29+30)
PersistentQuery/Range-10    2.42GB ± 1%    2.39GB ± 1%   -1.35%  (p=0.000 n=30+28)

name                      old allocs/op  new allocs/op  delta
PersistentQuery/Types-10     1.08M ± 0%     0.57M ± 0%  -47.30%  (p=0.000 n=29+30)
PersistentQuery/Merge-10     12.9M ± 0%     12.4M ± 1%   -4.01%  (p=0.000 n=30+30)
PersistentQuery/Range-10     2.85M ± 1%     2.33M ± 2%  -18.32%  (p=0.000 n=29+30)
```