### PR TITLE
Ignore RowGroups that don't have data when converting

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -201,6 +201,11 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup) err
 	if err != nil {
 		return err
 	}
+	// If the schema has no fields we simply ignore this RowGroup that has no data.
+	if len(schema.Fields()) == 0 {
+		return nil
+	}
+
 	if c.outputSchema == nil {
 		c.outputSchema = schema
 		c.builder = builder.NewRecordBuilder(c.pool, c.outputSchema)
@@ -328,6 +333,13 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup) err
 	}
 
 	return nil
+}
+
+func (c *ParquetConverter) Fields() []builder.ColumnBuilder {
+	if c.builder == nil {
+		return nil
+	}
+	return c.builder.Fields()
 }
 
 func (c *ParquetConverter) NumRows() int {

--- a/table.go
+++ b/table.go
@@ -725,6 +725,10 @@ func (t *Table) Iterator(
 					if err := converter.Convert(ctx, rg); err != nil {
 						return fmt.Errorf("failed to convert row group to arrow record: %v", err)
 					}
+					// This RowGroup had no relevant data. Ignore it.
+					if len(converter.Fields()) == 0 {
+						continue
+					}
 					if converter.NumRows() >= bufferSize {
 						r := converter.NewRecord()
 						prepareForFlush(r, rgSchema)


### PR DESCRIPTION
Previously we've been ignoring the RowGroups that had no data for the queried labels, aka no fields, but since the refactor in #247 we haven't been doing that and it panicked. 
Now, going forward we'll simply ignore those RowGroups again. 

Seems to work just fine again locally with the parca-agent ingesting and parca-load querying. 

Closes https://github.com/parca-dev/parca/issues/2111