### PR TITLE
Aggregation projection

### DIFF
--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -99,8 +99,8 @@ func (e *BinaryExpr) Computed() bool {
 	return true
 }
 
-func (e *BinaryExpr) Alias(alias string) AliasExpr {
-	return AliasExpr{Expr: e, Alias: alias}
+func (e *BinaryExpr) Alias(alias string) *AliasExpr {
+	return &AliasExpr{Expr: e, Alias: alias}
 }
 
 type Column struct {
@@ -134,8 +134,8 @@ func (c *Column) DataType(s *parquet.Schema) (arrow.DataType, error) {
 	return nil, errors.New("column not found")
 }
 
-func (c *Column) Alias(alias string) AliasExpr {
-	return AliasExpr{Expr: c, Alias: alias}
+func (c *Column) Alias(alias string) *AliasExpr {
+	return &AliasExpr{Expr: c, Alias: alias}
 }
 
 func (c *Column) ColumnsUsedExprs() []Expr {


### PR DESCRIPTION
This updates the query engine to support two things:
- BinaryExpr Projections of Aggregation columns
- Alias of BinaryExpr projections

ex:
```
	Aggregate(
			logicalplan.Sum(logicalplan.Col("value")),
			logicalplan.DynCol("labels"),
			logicalplan.Col("timestamp"),
		).
		Project(
			logicalplan.Col(logicalplan.Sum(logicalplan.Col("value")).Name()),
			logicalplan.DynCol("labels"),
			logicalplan.Col("timestamp").Gt(logicalplan.Literal(1)).Alias("timestamp"),
		).
```

Where we project the timestamp column from the aggregation to a `timestamp > 1` column and then rename that column to `timestamp`