### PR TITLE
frostdb: use parquet.MultiRowGroup to reduce compaction memory usage

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -541,10 +541,10 @@ func compactLevel0IntoLevel1(
 
 	bufs := make([]dynparquet.DynamicRowGroup, 0, len(level0Parts))
 	for _, p := range partsToCompact {
-		numRowGroups := p.Buf.NumRowGroups()
-		for i := 0; i < numRowGroups; i++ {
-			bufs = append(bufs, p.Buf.DynamicRowGroup(i))
-		}
+		// All the row groups in a part are wrapped in a single row group given
+		// that all rows are sorted within a part. This reduces the number of
+		// cursors open when merging the row groups.
+		bufs = append(bufs, p.Buf.MultiDynamicRowGroup())
 	}
 
 	cursor := 0

--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -84,6 +84,12 @@ func (b *SerializedBuffer) DynamicRowGroup(i int) DynamicRowGroup {
 	return b.newDynamicRowGroup(b.f.RowGroups()[i])
 }
 
+// MultiDynamicRowGroup returns all the row groups wrapped in a single multi
+// row group.
+func (b *SerializedBuffer) MultiDynamicRowGroup() DynamicRowGroup {
+	return b.newDynamicRowGroup(parquet.MultiRowGroup(b.f.RowGroups()...))
+}
+
 func (b *SerializedBuffer) newDynamicRowGroup(rowGroup parquet.RowGroup) DynamicRowGroup {
 	return &serializedRowGroup{
 		RowGroup: rowGroup,


### PR DESCRIPTION
Inspired by @thorfour's recent changes to our cloud product to use a MultiRowGroup to wrap multiple sorted row groups in a single row group, this change does the same for compaction in FrostDB.

The idea is to reduce the number of decompressed pages held in memory at any one time, which should drastically reduce memory usage. Given that we know that all row groups within a part are sorted, exposing a part as a single row group lets us have one cursor per part instead of one cursor per row group per part.