### PR TITLE
tx list: Removes the requirement for the ticker

### DIFF
--- a/db.go
+++ b/db.go
@@ -723,7 +723,7 @@ func (db *DB) begin() (uint64, uint64, func()) {
 		}
 
 		// place completed transaction in the waiting pool
-		db.txPool.Prepend(tx)
+		db.txPool.Insert(tx)
 	}
 }
 

--- a/tx_list.go
+++ b/tx_list.go
@@ -42,7 +42,7 @@ func NewTxPool(watermark *atomic.Uint64) *TxPool {
 	return txpool
 }
 
-// Insert performs an insertion sort of the given tx
+// Insert performs an insertion sort of the given tx.
 func (l *TxPool) Insert(tx uint64) {
 	n := &TxNode{
 		tx: tx,
@@ -73,7 +73,7 @@ func (l *TxPool) Insert(tx uint64) {
 	}
 }
 
-// insert will insert the node after previous and before next
+// insert will insert the node after previous and before next.
 func (l *TxPool) insert(node, prev, next *TxNode) bool {
 	node.next.Store(next)
 	success := prev.next.CompareAndSwap(next, node)
@@ -94,7 +94,7 @@ func (l *TxPool) Iterate(iterate func(tx uint64) bool) {
 	}
 }
 
-// delete iterates over the list and deletes until the delete function returns false
+// delete iterates over the list and deletes until the delete function returns false.
 func (l *TxPool) delete(deleteFunc func(tx uint64) bool) {
 	for node := l.head.Load().next.Load(); node.tx != 0; node = getUnmarked(node) {
 		if !deleteFunc(node.tx) {

--- a/tx_list.go
+++ b/tx_list.go
@@ -2,7 +2,7 @@ package frostdb
 
 import (
 	"sync/atomic"
-	"time"
+	"unsafe"
 )
 
 type TxNode struct {
@@ -11,68 +11,134 @@ type TxNode struct {
 }
 
 type TxPool struct {
-	next  atomic.Pointer[TxNode]
+	head  atomic.Pointer[TxNode]
+	tail  atomic.Pointer[TxNode]
 	drain chan interface{}
 }
 
 // NewTxPool returns a new TxPool and starts the pool cleaner routine.
+// TxPool is a sorted lockless linked-list described in https://timharris.uk/papers/2001-disc.pdf
 func NewTxPool(watermark *atomic.Uint64) *TxPool {
+	tail := &TxNode{
+		next: atomic.Pointer[TxNode]{},
+		tx:   0,
+	}
+	head := &TxNode{
+		next: atomic.Pointer[TxNode]{},
+		tx:   0,
+	}
 	txpool := &TxPool{
-		next:  atomic.Pointer[TxNode]{},
+		head:  atomic.Pointer[TxNode]{},
+		tail:  atomic.Pointer[TxNode]{},
 		drain: make(chan interface{}, 1),
 	}
+
+	// [head] -> [tail]
+	head.next.Store(tail)
+	txpool.head.Store(head)
+	txpool.tail.Store(tail)
+
 	go txpool.cleaner(watermark)
 	return txpool
 }
 
-// Prepend a node onto the front of the list.
-func (l *TxPool) Prepend(tx uint64) *TxNode {
-	node := &TxNode{
+// Insert performs an insertion sort of the given tx
+func (l *TxPool) Insert(tx uint64) {
+	n := &TxNode{
 		tx: tx,
 	}
-	for { // continue until a successful compare and swap occurs.
-		next := l.next.Load()
-		node.next.Store(next)
-		if l.next.CompareAndSwap(next, node) {
-			select {
-			case l.drain <- true:
-				return node
-			default:
-				return node
+	assertAlignment(n)
+
+	tryInsert := func() bool {
+		prev := l.head.Load()
+		for node := l.head.Load().next.Load(); node != nil; node = getUnmarked(node) {
+			if node.tx == 0 { // end of list
+				return l.insert(n, prev, node)
+			}
+
+			// remove deleted nodes encountered
+			if isMarked(node) {
+				prev.next.CompareAndSwap(node, getUnmarked(node))
+				return false
+			}
+
+			if node.tx > tx {
+				return l.insert(n, prev, node)
+			}
+			prev = node
+		}
+		return false
+	}
+	for !tryInsert() {
+	}
+}
+
+// insert will insert the node after previous and before next
+func (l *TxPool) insert(node, prev, next *TxNode) bool {
+	node.next.Store(next)
+	success := prev.next.CompareAndSwap(next, node)
+	if success {
+		select {
+		case l.drain <- struct{}{}: // notify the cleaner
+		default:
+		}
+	}
+	return success
+}
+
+func (l *TxPool) Iterate(iterate func(tx uint64) bool) {
+	for node := l.head.Load().next.Load(); node.tx != 0; node = getUnmarked(node) {
+		if !isMarked(node) && !iterate(node.tx) {
+			return
+		}
+	}
+}
+
+// delete iterates over the list and deletes until the delete function returns false
+func (l *TxPool) delete(deleteFunc func(tx uint64) bool) {
+	for node := l.head.Load().next.Load(); node.tx != 0; node = getUnmarked(node) {
+		if !deleteFunc(node.tx) {
+			return
+		}
+		for {
+			next := node.next.Load()
+			if node.next.CompareAndSwap(next, getMarked(node)) {
+				break
 			}
 		}
 	}
 }
 
-// Iterate accesses every node in the list.
-func (l *TxPool) Iterate(iterate func(tx uint64) bool) {
-	next := l.next.Load()
-	prev := atomic.Pointer[TxNode]{}
-	for {
-		node := (*TxNode)(next)
-		if node == nil {
-			return
-		}
-		if iterate(node.tx) {
-			if prev.Load() == nil { // we're removing the first node
-				l.next.CompareAndSwap(nil, node.next.Load())
-			} else {
-				// set the previous nodes next to this nodes nex
-				prevnode := prev.Load()
-				prevnode.next.CompareAndSwap(prevnode.next.Load(), node.next.Load())
-			}
-		}
-		prev.Store(next)
-		next = node.next.Load()
+func assertAlignment(node *TxNode) {
+	if (uintptr(unsafe.Pointer(node)) & uintptr(1)) == 1 {
+		panic("node pointers are required to be aligned")
 	}
+}
+
+func isMarked(node *TxNode) bool {
+	return (uintptr(unsafe.Pointer(node.next.Load())) & uintptr(1)) == 1
+}
+
+func getMarked(node *TxNode) *TxNode {
+	next := node.next.Load()
+	if (uintptr(unsafe.Pointer(next)) & uintptr(1)) == 1 {
+		return next
+	}
+	return (*TxNode)(unsafe.Add(unsafe.Pointer(next), 1))
+}
+
+func getUnmarked(node *TxNode) *TxNode {
+	next := node.next.Load()
+	if (uintptr(unsafe.Pointer(next)) & uintptr(1)) == 0 {
+		return next
+	}
+
+	return (*TxNode)(unsafe.Add(unsafe.Pointer(next), -1))
 }
 
 // cleaner sweeps the pool periodically, and bubbles up the given watermark.
 // this function does not return.
 func (l *TxPool) cleaner(watermark *atomic.Uint64) {
-	ticker := time.NewTicker(time.Millisecond * 10)
-	defer ticker.Stop()
-
 	for {
 		select { // sweep whenever notified or when ticker
 		case _, ok := <-l.drain:
@@ -80,26 +146,20 @@ func (l *TxPool) cleaner(watermark *atomic.Uint64) {
 				// Channel closed.
 				return
 			}
-			l.sweep(watermark)
-		case <-ticker.C:
-			l.sweep(watermark)
+			l.delete(func(tx uint64) bool {
+				mark := watermark.Load()
+				switch {
+				case mark+1 == tx:
+					watermark.Add(1)
+					return true // return true to indicate that this node should be removed from the tx list.
+				case mark >= tx:
+					return true
+				default:
+					return false
+				}
+			})
 		}
 	}
-}
-
-func (l *TxPool) sweep(watermark *atomic.Uint64) {
-	l.Iterate(func(tx uint64) bool {
-		mark := watermark.Load()
-		switch {
-		case mark+1 == tx:
-			watermark.Add(1)
-			return true // return true to indicate that this node should be removed from the tx list.
-		case mark >= tx:
-			return true
-		default:
-			return false
-		}
-	})
 }
 
 // Stop stops the TxPool's cleaner goroutine.

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -1,0 +1,156 @@
+package frostdb
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"sync/atomic"
+
+	"github.com/stretchr/testify/require"
+)
+
+type Uint64Slice []uint64
+
+func (x Uint64Slice) Len() int           { return len(x) }
+func (x Uint64Slice) Less(i, j int) bool { return x[i] < x[j] }
+func (x Uint64Slice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+
+func Test_TXList_Mark(t *testing.T) {
+	node := &TxNode{
+		next: atomic.Pointer[TxNode]{},
+	}
+	next := &TxNode{
+		next: atomic.Pointer[TxNode]{},
+	}
+	node.next.Store(next)
+
+	node.next.Store(getMarked(node))
+	require.True(t, isMarked(node))
+	node.next.Store(getUnmarked(node))
+	require.False(t, isMarked(node))
+}
+
+func Test_TXList_Basic(t *testing.T) {
+
+	wm := &atomic.Uint64{}
+	wm.Store(1) // set the watermark so that the sweeper won't remove any of our txs
+	p := NewTxPool(wm)
+	txs := []uint64{9, 8, 7, 6, 4, 5, 3, 10}
+	for _, tx := range txs {
+		p.Insert(tx)
+	}
+
+	found := make(Uint64Slice, 0, len(txs))
+	p.Iterate(func(tx uint64) bool {
+		found = append(found, tx)
+		return true
+	})
+
+	p.Stop() // stop the sweeper
+	require.True(t, sort.IsSorted(found))
+	require.Equal(t, 8, len(found))
+}
+
+func Test_TXList_Async(t *testing.T) {
+
+	wm := &atomic.Uint64{}
+	p := NewTxPool(wm)
+
+	tx := &atomic.Uint64{}
+	tx.Add(1) // adjust the tx id to ensure the sweeper doesn't drain the pool
+
+	// Swap writers that will each complete n transactions
+	n := 10
+	writers := 100
+	wg := &sync.WaitGroup{}
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < n; j++ {
+				p.Insert(tx.Add(1))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	found := make(Uint64Slice, 0, writers*n)
+	p.Iterate(func(tx uint64) bool {
+		found = append(found, tx)
+		return true
+	})
+	require.True(t, sort.IsSorted(found))
+	require.Equal(t, n*writers, len(found))
+
+	p.Insert(1) // insert the missing tx to drain the pool
+
+	for v := wm.Load(); v < tx.Load(); v = wm.Load() {
+	}
+	require.Equal(t, tx.Load(), wm.Load())
+
+	// Verify the pool is empty
+	foundtx := false
+	p.Iterate(func(tx uint64) bool {
+		foundtx = true
+		return true
+	})
+	require.False(t, foundtx)
+
+	p.Stop() // stop the sweeper
+}
+
+func Benchmark_TXList_InsertAndDrain(b *testing.B) {
+
+	benchmarks := map[string]struct {
+		writers int
+		values  int
+	}{
+		"10:100": {
+			writers: 10,
+			values:  100,
+		},
+		"10:1000": {
+			writers: 10,
+			values:  1000,
+		},
+		"100:100": {
+			writers: 100,
+			values:  100,
+		},
+		"1000:100": {
+			writers: 1000,
+			values:  100,
+		},
+	}
+
+	for name, benchmark := range benchmarks {
+		b.Run(name, func(b *testing.B) {
+			wm := &atomic.Uint64{}
+			p := NewTxPool(wm)
+			tx := &atomic.Uint64{}
+			wg := &sync.WaitGroup{}
+			for i := 0; i < b.N; i++ {
+				wg.Add(benchmark.writers)
+				for i := 0; i < benchmark.writers; i++ {
+					go func() {
+						defer wg.Done()
+						for j := 0; j < benchmark.values; j++ {
+							p.Insert(tx.Add(1))
+						}
+					}()
+				}
+
+				wg.Wait()
+
+				// Wait for the sweeper to drain
+				for v := wm.Load(); v < tx.Load(); v = wm.Load() {
+				}
+				require.Equal(b, tx.Load(), wm.Load())
+
+			}
+			p.Stop()
+		})
+	}
+}

--- a/tx_list_test.go
+++ b/tx_list_test.go
@@ -3,9 +3,8 @@ package frostdb
 import (
 	"sort"
 	"sync"
-	"testing"
-
 	"sync/atomic"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +31,6 @@ func Test_TXList_Mark(t *testing.T) {
 }
 
 func Test_TXList_Basic(t *testing.T) {
-
 	wm := &atomic.Uint64{}
 	wm.Store(1) // set the watermark so that the sweeper won't remove any of our txs
 	p := NewTxPool(wm)
@@ -53,7 +51,6 @@ func Test_TXList_Basic(t *testing.T) {
 }
 
 func Test_TXList_Async(t *testing.T) {
-
 	wm := &atomic.Uint64{}
 	p := NewTxPool(wm)
 
@@ -102,7 +99,6 @@ func Test_TXList_Async(t *testing.T) {
 }
 
 func Benchmark_TXList_InsertAndDrain(b *testing.B) {
-
 	benchmarks := map[string]struct {
 		writers int
 		values  int
@@ -148,7 +144,6 @@ func Benchmark_TXList_InsertAndDrain(b *testing.B) {
 				for v := wm.Load(); v < tx.Load(); v = wm.Load() {
 				}
 				require.Equal(b, tx.Load(), wm.Load())
-
 			}
 			p.Stop()
 		})


### PR DESCRIPTION
Instead of using a periodic ticker to sweep the tx list we instead order the tx list, look for the next tx at the front of the list. The new tx list uses a [Harris linked-list](https://timharris.uk/papers/2001-disc.pdf)
This should address https://github.com/polarsignals/frostdb/issues/246

```
thor@thors-MacBook-Pro frostdb % go test -v -run XXX -bench TX -count 1
goos: darwin
goarch: arm64
pkg: github.com/polarsignals/frostdb
Benchmark_TXList_InsertAndDrain
Benchmark_TXList_InsertAndDrain/1000:100
Benchmark_TXList_InsertAndDrain/1000:100-10         	      14	 396327393 ns/op
Benchmark_TXList_InsertAndDrain/10:100
Benchmark_TXList_InsertAndDrain/10:100-10           	    2991	    409297 ns/op
Benchmark_TXList_InsertAndDrain/10:1000
Benchmark_TXList_InsertAndDrain/10:1000-10          	      86	  13451275 ns/op
Benchmark_TXList_InsertAndDrain/100:100
Benchmark_TXList_InsertAndDrain/100:100-10          	     152	   7706333 ns/op
```

Notably I can't actually compare the benchmark to the previous tx list because it had a concurrency delete bug and would hang on the benchmarks.