### PR TITLE
dynparquet: Use parquet-go's copy rows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pingcap/tidb/parser v0.0.0-20220921115303-5aab87679fde
 	github.com/prometheus/client_golang v1.12.2
-	github.com/segmentio/parquet-go v0.0.0-20221020201645-63215c8128ff
+	github.com/segmentio/parquet-go v0.0.0-20221202145634-b835743499b4
 	github.com/stretchr/testify v1.7.2
 	github.com/thanos-io/objstore v0.0.0-20220715165016-ce338803bc1e
 	github.com/tidwall/wal v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSv
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/segmentio/parquet-go v0.0.0-20221020201645-63215c8128ff h1:qLJHWKeFq31XCEKVS4uUlS7D3qGDiTjy/bPNn27m0pQ=
 github.com/segmentio/parquet-go v0.0.0-20221020201645-63215c8128ff/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221202145634-b835743499b4 h1:j2/+OabOE0iwzO7wWiXy4WBw7hD42OJcau4D1GriZyk=
+github.com/segmentio/parquet-go v0.0.0-20221202145634-b835743499b4/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pqarrow/convert/convert_test.go
+++ b/pqarrow/convert/convert_test.go
@@ -63,7 +63,7 @@ func TestParquetNodeToType(t *testing.T) {
 		},
 		{
 			parquetNode: parquet.Decimal(0, 9, parquet.Int32Type),
-			msg:         "unsupported logical type: DECIMAL(0,9)",
+			msg:         "unsupported logical type: DECIMAL(9,0)",
 		},
 		{
 			parquetNode: parquet.UUID(),


### PR DESCRIPTION
I think previously the only thing that was wrong was our usage ... we never called `.Close()`, which caused the goroutine opened by `.Rows()` to leak.

Roughly ~30% of the ingest path of Parca/Polar Signals Cloud is spent in this code, so hopefully this improves that.