### PR TITLE
physicalplan: switch Distinct and HashAggregate to use optimized builders

### DIFF
--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -183,6 +183,14 @@ func (b *OptBinaryBuilder) AppendData(data []byte, offsets []uint32) {
 	bitutil.SetBitsTo(b.validityBitmap, int64(startOffset), int64(len(offsets)), true)
 }
 
+func (b *OptBinaryBuilder) Append(v []byte) {
+	b.offsets = append(b.offsets, uint32(len(b.data)))
+	b.data = append(b.data, v...)
+	b.length++
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
+	bitutil.SetBit(b.validityBitmap, b.length-1)
+}
+
 // AppendParquetValues appends the given parquet values to the builder. The
 // values may be null, but if it is known upfront that none of the values are
 // null, AppendData offers a more efficient way of appending values.
@@ -299,6 +307,13 @@ func (b *OptInt64Builder) AppendData(data []int64) {
 	b.length += len(data)
 	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
 	bitutil.SetBitsTo(b.validityBitmap, int64(oldLength), int64(len(data)), true)
+}
+
+func (b *OptInt64Builder) Append(v int64) {
+	b.data = append(b.data, v)
+	b.length++
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
+	bitutil.SetBit(b.validityBitmap, b.length-1)
 }
 
 func (b *OptInt64Builder) AppendParquetValues(values []parquet.Value) {
@@ -426,6 +441,14 @@ func (b *OptBooleanBuilder) AppendParquetValues(values []parquet.Value) {
 		bitutil.SetBitTo(b.validityBitmap, b.length, true)
 		b.length++
 	}
+}
+
+func (b *OptBooleanBuilder) AppendSingle(v bool) {
+	b.length++
+	b.data = resizeBitmap(b.data, b.length)
+	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length)
+	bitutil.SetBitTo(b.data, b.length-1, v)
+	bitutil.SetBit(b.validityBitmap, b.length-1)
 }
 
 func (b *OptBooleanBuilder) RepeatLastValue(n int) {

--- a/pqarrow/builder/recordbuilder.go
+++ b/pqarrow/builder/recordbuilder.go
@@ -9,21 +9,6 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 )
 
-func NewBuilder(mem memory.Allocator, t arrow.DataType) ColumnBuilder {
-	switch t := t.(type) {
-	case *arrow.BinaryType:
-		return NewOptBinaryBuilder(arrow.BinaryTypes.Binary)
-	case *arrow.Int64Type:
-		return NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
-	case *arrow.ListType:
-		return NewListBuilder(mem, t.Elem())
-	case *arrow.BooleanType:
-		return NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
-	default:
-		return array.NewBuilder(mem, t)
-	}
-}
-
 // The code in this file is based heavily on Apache arrow's array.RecordBuilder,
 // with some modifications to use our own optimized record builders. Ideally, we
 // would eventually merge this upstream.

--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -1,0 +1,80 @@
+package builder
+
+import (
+	"errors"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+)
+
+func NewBuilder(mem memory.Allocator, t arrow.DataType) ColumnBuilder {
+	switch t := t.(type) {
+	case *arrow.BinaryType:
+		return NewOptBinaryBuilder(arrow.BinaryTypes.Binary)
+	case *arrow.Int64Type:
+		return NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+	case *arrow.ListType:
+		return NewListBuilder(mem, t.Elem())
+	case *arrow.BooleanType:
+		return NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
+	default:
+		return array.NewBuilder(mem, t)
+	}
+}
+
+func AppendValue(cb ColumnBuilder, arr arrow.Array, i int) error {
+	if arr == nil || arr.IsNull(i) {
+		cb.AppendNull()
+		return nil
+	}
+
+	switch b := cb.(type) {
+	case *OptBinaryBuilder:
+		b.Append(arr.(*array.Binary).Value(i))
+		return nil
+	case *OptInt64Builder:
+		b.Append(arr.(*array.Int64).Value(i))
+		return nil
+	case *OptBooleanBuilder:
+		b.AppendSingle(arr.(*array.Boolean).Value(i))
+		return nil
+	case *array.Int64Builder:
+		b.Append(arr.(*array.Int64).Value(i))
+		return nil
+	case *array.StringBuilder:
+		b.Append(arr.(*array.String).Value(i))
+		return nil
+	case *array.BinaryBuilder:
+		b.Append(arr.(*array.Binary).Value(i))
+		return nil
+	case *array.FixedSizeBinaryBuilder:
+		b.Append(arr.(*array.FixedSizeBinary).Value(i))
+		return nil
+	case *array.BooleanBuilder:
+		b.Append(arr.(*array.Boolean).Value(i))
+		return nil
+	// case *array.List:
+	//	// TODO: This seems horribly inefficient, we already have the whole
+	//	// array and are just doing an expensive copy, but arrow doesn't seem
+	//	// to be able to append whole list scalars at once.
+	//	length := s.Value.Len()
+	//	larr := arr.(*array.ListBuilder)
+	//	vb := larr.ValueBuilder()
+	//	larr.Append(true)
+	//	for i := 0; i < length; i++ {
+	//		v, err := scalar.GetScalar(s.Value, i)
+	//		if err != nil {
+	//			return err
+	//		}
+
+	//		err = appendValue(vb, v)
+	//		if err != nil {
+	//			return err
+	//		}
+	//	}
+	//	return nil
+	default:
+		return errors.New("unsupported type for arrow append")
+	}
+}

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/segmentio/parquet-go"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/polarsignals/frostdb/pqarrow/builder"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
@@ -330,66 +331,19 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 					groupByCol.AppendNull()
 				}
 
-				err := appendValue(groupByCol, arr, i)
+				err := builder.AppendValue(groupByCol, arr, i)
 				if err != nil {
 					return err
 				}
 			}
 		}
 
-		if err := appendValue(a.arraysToAggregate[k], columnToAggregate, i); err != nil {
+		if err := builder.AppendValue(a.arraysToAggregate[k], columnToAggregate, i); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func appendValue(b array.Builder, arr arrow.Array, i int) error {
-	if arr == nil || arr.IsNull(i) {
-		b.AppendNull()
-		return nil
-	}
-
-	switch arr := arr.(type) {
-	case *array.Int64:
-		b.(*array.Int64Builder).Append(arr.Value(i))
-		return nil
-	case *array.String:
-		b.(*array.StringBuilder).Append(arr.Value(i))
-		return nil
-	case *array.Binary:
-		b.(*array.BinaryBuilder).Append(arr.Value(i))
-		return nil
-	case *array.FixedSizeBinary:
-		b.(*array.FixedSizeBinaryBuilder).Append(arr.Value(i))
-		return nil
-	case *array.Boolean:
-		b.(*array.BooleanBuilder).Append(arr.Value(i))
-		return nil
-	// case *array.List:
-	//	// TODO: This seems horribly inefficient, we already have the whole
-	//	// array and are just doing an expensive copy, but arrow doesn't seem
-	//	// to be able to append whole list scalars at once.
-	//	length := s.Value.Len()
-	//	larr := arr.(*array.ListBuilder)
-	//	vb := larr.ValueBuilder()
-	//	larr.Append(true)
-	//	for i := 0; i < length; i++ {
-	//		v, err := scalar.GetScalar(s.Value, i)
-	//		if err != nil {
-	//			return err
-	//		}
-
-	//		err = appendValue(vb, v)
-	//		if err != nil {
-	//			return err
-	//		}
-	//	}
-	//	return nil
-	default:
-		return errors.New("unsupported type for arrow append")
-	}
 }
 
 func (a *HashAggregate) Finish(ctx context.Context) error {

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -81,9 +81,9 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 		}
 	}
 
-	resBuilders := make([]array.Builder, 0, len(distinctArrays))
+	resBuilders := make([]builder.ColumnBuilder, 0, len(distinctArrays))
 	for _, arr := range distinctArrays {
-		resBuilders = append(resBuilders, array.NewBuilder(d.pool, arr.DataType()))
+		resBuilders = append(resBuilders, builder.NewBuilder(d.pool, arr.DataType()))
 	}
 	rows := int64(0)
 

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/scalar"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/polarsignals/frostdb/pqarrow/builder"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
@@ -117,7 +118,7 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 		d.mtx.RUnlock()
 
 		for j, arr := range distinctArrays {
-			err := appendValue(resBuilders[j], arr, i)
+			err := builder.AppendValue(resBuilders[j], arr, i)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Ran into reorganizing this code while working on the ordered aggregator.

```
benchstat bmain bopt
name           old time/op    new time/op    delta
Query/Types-8    8.31ms ± 3%    7.79ms ± 1%   -6.28%  (p=0.000 n=10+9)
Query/Merge-8    18.9ms ± 4%    15.6ms ± 2%  -17.42%  (p=0.000 n=9+10)
Query/Range-8    6.29ms ± 1%    6.34ms ± 1%   +0.74%  (p=0.006 n=9+9)

name           old alloc/op   new alloc/op   delta
Query/Types-8    51.5MB ± 0%    52.1MB ± 0%   +1.09%  (p=0.000 n=10+10)
Query/Merge-8     101MB ± 0%      92MB ± 0%   -9.24%  (p=0.000 n=9+10)
Query/Range-8    24.9MB ± 0%    24.5MB ± 0%   -1.39%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
Query/Types-8     45.5k ± 0%     45.5k ± 0%   -0.19%  (p=0.000 n=10+10)
Query/Merge-8      205k ± 0%      169k ± 0%  -17.25%  (p=0.000 n=10+10)
Query/Range-8     10.4k ± 0%     11.9k ± 0%  +14.23%  (p=0.000 n=9+10)
```