### PR TITLE
builder: append offset when appending NULL in OptBinaryBuilder

### DIFF
--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -121,6 +121,7 @@ func (b *OptBinaryBuilder) Release() {
 // AppendNull adds a new null value to the array being built. This is slow,
 // don't use it.
 func (b *OptBinaryBuilder) AppendNull() {
+	b.offsets = append(b.offsets, uint32(len(b.data)))
 	b.builderBase.AppendNulls(1)
 }
 

--- a/pqarrow/builder/optbuilders_test.go
+++ b/pqarrow/builder/optbuilders_test.go
@@ -1,0 +1,25 @@
+package builder_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/frostdb/pqarrow/builder"
+)
+
+// https://github.com/polarsignals/frostdb/issues/270
+func TestIssue270(t *testing.T) {
+	b := builder.NewOptBinaryBuilder(arrow.BinaryTypes.Binary)
+	b.AppendNull()
+	const expString = "hello"
+	b.Append([]byte(expString))
+	require.Equal(t, b.Len(), 2)
+
+	a := b.NewArray().(*array.Binary)
+	require.Equal(t, a.Len(), 2)
+	require.True(t, a.IsNull(0))
+	require.Equal(t, string(a.Value(1)), expString)
+}

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -111,9 +111,9 @@ type HashAggregate struct {
 	pool                  memory.Allocator
 	tracer                trace.Tracer
 	resultColumnName      string
-	groupByCols           map[string]array.Builder
+	groupByCols           map[string]builder.ColumnBuilder
 	colOrdering           []string
-	arraysToAggregate     []array.Builder
+	arraysToAggregate     []builder.ColumnBuilder
 	hashToAggregate       map[uint64]int
 	groupByColumnMatchers []logicalplan.Expr
 	columnToAggregate     logicalplan.Expr
@@ -143,9 +143,9 @@ func NewHashAggregate(
 		pool:              pool,
 		tracer:            tracer,
 		resultColumnName:  resultColumnName,
-		groupByCols:       map[string]array.Builder{},
+		groupByCols:       map[string]builder.ColumnBuilder{},
 		colOrdering:       []string{},
-		arraysToAggregate: make([]array.Builder, 0),
+		arraysToAggregate: make([]builder.ColumnBuilder, 0),
 		hashToAggregate:   map[uint64]int{},
 		columnToAggregate: columnToAggregate,
 		// TODO: Matchers can be optimized to be something like a radix tree or just a fast-lookup datastructure for exact matches or prefix matches.
@@ -347,7 +347,7 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 
 		k, ok := a.hashToAggregate[hash]
 		if !ok {
-			agg := array.NewBuilder(a.pool, columnToAggregate.DataType())
+			agg := builder.NewBuilder(a.pool, columnToAggregate.DataType())
 			a.arraysToAggregate = append(a.arraysToAggregate, agg)
 			k = len(a.arraysToAggregate) - 1
 			a.hashToAggregate[hash] = k
@@ -358,7 +358,7 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 
 				groupByCol, found := a.groupByCols[fieldName]
 				if !found {
-					groupByCol = array.NewBuilder(a.pool, groupByFields[j].Type)
+					groupByCol = builder.NewBuilder(a.pool, groupByFields[j].Type)
 					a.groupByCols[fieldName] = groupByCol
 					a.colOrdering = append(a.colOrdering, fieldName)
 				}

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -81,9 +81,9 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 		}
 	}
 
-	resBuilders := make([]array.Builder, 0, len(distinctArrays))
+	resBuilders := make([]builder.ColumnBuilder, 0, len(distinctArrays))
 	for _, arr := range distinctArrays {
-		resBuilders = append(resBuilders, array.NewBuilder(d.pool, arr.DataType()))
+		resBuilders = append(resBuilders, builder.NewBuilder(d.pool, arr.DataType()))
 	}
 	rows := int64(0)
 


### PR DESCRIPTION
Fixes #270 

This PR also adds the optimized builders back into the hash aggregate and distinct given they were removed until the issue was resolved.