### PR TITLE
deps: update parquet to 3f277a9

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -852,6 +852,10 @@ func (s *Schema) SerializeBuffer(w io.Writer, buffer *Buffer) error {
 	return nil
 }
 
+// bloomFilterBitsPerValue is the number of bits used by the bloom filter. 10
+// was the default value used by parquet before it was made configurable.
+const bloomFilterBitsPerValue = 10
+
 // NewWriter returns a new parquet writer with a concrete parquet schema
 // generated using the given concrete dynamic column names.
 func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (*parquet.Writer, error) {
@@ -873,7 +877,9 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (*pa
 			continue
 		}
 
-		bloomFilterColumns = append(bloomFilterColumns, parquet.SplitBlockFilter(col.Path()...))
+		bloomFilterColumns = append(
+			bloomFilterColumns, parquet.SplitBlockFilter(bloomFilterBitsPerValue, col.Path()...),
+		)
 	}
 
 	return parquet.NewWriter(w,

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pingcap/tidb/parser v0.0.0-20220921115303-5aab87679fde
 	github.com/prometheus/client_golang v1.12.2
-	github.com/segmentio/parquet-go v0.0.0-20221207043206-db0f5ce13cf1
+	github.com/segmentio/parquet-go v0.0.0-20221209161419-3f277a904e0e
 	github.com/stretchr/testify v1.7.2
 	github.com/thanos-io/objstore v0.0.0-20220715165016-ce338803bc1e
 	github.com/tidwall/wal v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.3.5 h1:UZEiaZ55nlXGDL92scoVuw00RmiRCazIEmvPSbSvt8Y=
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
-github.com/segmentio/parquet-go v0.0.0-20221207043206-db0f5ce13cf1 h1:MajB8YDwcYNncLcHaw59hh8upwuMDRsXVZxJH2Kn/UQ=
-github.com/segmentio/parquet-go v0.0.0-20221207043206-db0f5ce13cf1/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
+github.com/segmentio/parquet-go v0.0.0-20221209161419-3f277a904e0e h1:oB6VqjFrx6HC1G736iZIe3xII1Zj/QCWInKdUw98AtU=
+github.com/segmentio/parquet-go v0.0.0-20221209161419-3f277a904e0e/go.mod h1:SclLlCfB7c7CH0YerV+OtYmZExyK5rhVOd6UT90erVw=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=


### PR DESCRIPTION
This adds a bunch of recent performance and memory improvements. Notable ones are:
https://github.com/segmentio/parquet-go/pull/434
https://github.com/segmentio/parquet-go/pull/435
https://github.com/segmentio/parquet-go/pull/436