### PR TITLE
Accept multiple aggregations within a single query

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -71,7 +71,10 @@ func getLatest15MinInterval(ctx context.Context, b testing.TB, engine *query.Loc
 	var result arrow.Record
 	require.NoError(b, engine.ScanTable(tableName).
 		Aggregate(
-			logicalplan.Max(logicalplan.Col("timestamp")),
+			[]logicalplan.Expr{
+				logicalplan.Max(logicalplan.Col("timestamp")),
+			},
+			nil,
 		).Execute(ctx,
 		func(ctx context.Context, r arrow.Record) error {
 			r.Retain()
@@ -156,8 +159,12 @@ func BenchmarkQuery(b *testing.B) {
 					logicalplan.And(filterExprs(start, end)...),
 				).
 				Aggregate(
-					logicalplan.Sum(logicalplan.Col("value")),
-					logicalplan.Col("stacktrace"),
+					[]logicalplan.Expr{
+						logicalplan.Sum(logicalplan.Col("value")),
+					},
+					[]logicalplan.Expr{
+						logicalplan.Col("stacktrace"),
+					},
 				).
 				Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 					if r.NumRows() == 0 {
@@ -178,9 +185,13 @@ func BenchmarkQuery(b *testing.B) {
 					logicalplan.And(filterExprs(start, end)...),
 				).
 				Aggregate(
-					logicalplan.Sum(logicalplan.Col("value")),
-					logicalplan.DynCol("labels"),
-					logicalplan.Col("timestamp"),
+					[]logicalplan.Expr{
+						logicalplan.Sum(logicalplan.Col("value")),
+					},
+					[]logicalplan.Expr{
+						logicalplan.DynCol("labels"),
+						logicalplan.Col("timestamp"),
+					},
 				).
 				Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 					if r.NumRows() == 0 {

--- a/logictest/testdata/aggregate/aggregate
+++ b/logictest/testdata/aggregate/aggregate
@@ -7,32 +7,38 @@ value2  value2  value3  null    stack1  2   2
 value3  value2  null    value4  stack1  3   3
 ----
 
+insert cols=(labels.label1, labels.label2, labels.label3, labels.label4, stacktrace, timestamp, value)
+value4  value2  null    null    stack1  4   4
+value5  value2  value3  null    stack1  5   5
+value6  value2  null    value4  stack1  6   6
+----
+
 exec
 select sum(value) as value_sum group by labels.label2
 ----
-value2  6
+value2  21
 
 exec
 select max(value) as value_max group by labels.label2
 ----
-value2  3
+value2  6
 
 exec
 select count(value) as value_count group by labels.label2
 ----
-value2  3
+value2  6
 
 exec
 select sum(value), count(value) group by stacktrace
 ----
-stack1  6       3
+stack1  21      6
 
 exec
 select sum(value) as value_sum, count(value) as value_count group by stacktrace
 ----
-stack1  6       3
+stack1  21      6
 
 exec
 select sum(value), count(value), max(value) group by labels.label2
 ----
-value2  6       3       3
+value2  21      6       6

--- a/logictest/testdata/aggregate/aggregate
+++ b/logictest/testdata/aggregate/aggregate
@@ -21,3 +21,18 @@ exec
 select count(value) as value_count group by labels.label2
 ----
 value2  3
+
+exec
+select sum(value), count(value) group by stacktrace
+----
+stack1  6       3
+
+exec
+select sum(value) as value_sum, count(value) as value_count group by stacktrace
+----
+stack1  6       3
+
+exec
+select sum(value), count(value), max(value) group by labels.label2
+----
+value2  6       3       3

--- a/logictest/testdata/aggregate/aggregate_nulls
+++ b/logictest/testdata/aggregate/aggregate_nulls
@@ -26,3 +26,9 @@ select count(value) as value_count group by labels.label2
 ----
         1
 value2  2
+
+exec
+select sum(value) as value_sum, count(value) as value_count group by labels.label2
+----
+        1       1
+value2  5       2

--- a/logictest/testdata/aggregate/window
+++ b/logictest/testdata/aggregate/window
@@ -31,6 +31,12 @@ select sum(value) as value_sum group by second(3)
 123000  4
 
 exec
+select sum(value) as value_sum, count(value) as value_count group by second(3)
+----
+120000  6       3
+123000  4       1
+
+exec
 select sum(value) as value_sum group by second(4)
 ----
 120000  10

--- a/query/engine.go
+++ b/query/engine.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Builder interface {
-	Aggregate(aggExpr logicalplan.Expr, groupExprs ...logicalplan.Expr) Builder
+	Aggregate(aggExpr, groupExprs []logicalplan.Expr) Builder
 	Filter(expr logicalplan.Expr) Builder
 	Distinct(expr ...logicalplan.Expr) Builder
 	Project(projections ...logicalplan.Expr) Builder
@@ -74,13 +74,13 @@ func (e *LocalEngine) ScanSchema(name string) Builder {
 }
 
 func (b LocalQueryBuilder) Aggregate(
-	aggExpr logicalplan.Expr,
-	groupExprs ...logicalplan.Expr,
+	aggExpr []logicalplan.Expr,
+	groupExprs []logicalplan.Expr,
 ) Builder {
 	return LocalQueryBuilder{
 		pool:        b.pool,
 		tracer:      b.tracer,
-		planBuilder: b.planBuilder.Aggregate(aggExpr, groupExprs...),
+		planBuilder: b.planBuilder.Aggregate(aggExpr, groupExprs),
 	}
 }
 

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -108,15 +108,15 @@ func (b Builder) Distinct(
 }
 
 func (b Builder) Aggregate(
-	aggExpr Expr,
-	groupExprs ...Expr,
+	aggExpr []Expr,
+	groupExprs []Expr,
 ) Builder {
 	return Builder{
 		plan: &LogicalPlan{
 			Input: b.plan,
 			Aggregation: &Aggregation{
 				GroupExprs: groupExprs,
-				AggExpr:    aggExpr,
+				AggExprs:   aggExpr,
 			},
 		},
 	}

--- a/query/logicalplan/builder_test.go
+++ b/query/logicalplan/builder_test.go
@@ -15,8 +15,8 @@ func TestLogicalPlanBuilder(t *testing.T) {
 		Scan(tableProvider, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -32,10 +32,10 @@ func TestLogicalPlanBuilder(t *testing.T) {
 		Input: &LogicalPlan{
 			Aggregation: &Aggregation{
 				GroupExprs: []Expr{&Column{ColumnName: "stacktrace"}},
-				AggExpr: &AliasExpr{
+				AggExprs: []Expr{&AliasExpr{
 					Expr:  &AggregationFunction{Func: AggFuncSum, Expr: &Column{ColumnName: "value"}},
 					Alias: "value_sum",
-				},
+				}},
 			},
 			Input: &LogicalPlan{
 				Filter: &Filter{

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -210,10 +210,10 @@ func (p *Projection) String() string {
 }
 
 type Aggregation struct {
+	AggExprs   []Expr
 	GroupExprs []Expr
-	AggExpr    Expr
 }
 
 func (a *Aggregation) String() string {
-	return "Aggregation " + fmt.Sprint(a.AggExpr) + " Group: " + fmt.Sprint(a.GroupExprs)
+	return "Aggregation " + fmt.Sprint(a.AggExprs) + " Group: " + fmt.Sprint(a.GroupExprs)
 }

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -60,8 +60,8 @@ func TestInputSchemaGetter(t *testing.T) {
 		Scan(&mockTableProvider{schema}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -72,8 +72,8 @@ func TestInputSchemaGetter(t *testing.T) {
 		ScanSchema(&mockTableProvider{schema}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -84,8 +84,8 @@ func TestInputSchemaGetter(t *testing.T) {
 	plan, _ = (&Builder{}).
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -42,7 +42,9 @@ func (p *PhysicalProjectionPushDown) optimize(plan *LogicalPlan, columnsUsedExpr
 		for _, expr := range plan.Aggregation.GroupExprs {
 			columnsUsedExprs = append(columnsUsedExprs, expr.ColumnsUsedExprs()...)
 		}
-		columnsUsedExprs = append(columnsUsedExprs, plan.Aggregation.AggExpr.ColumnsUsedExprs()...)
+		for _, expr := range plan.Aggregation.AggExprs {
+			columnsUsedExprs = append(columnsUsedExprs, expr.ColumnsUsedExprs()...)
+		}
 	}
 
 	if plan.Input != nil {
@@ -136,7 +138,9 @@ func aggregationColumns(plan *LogicalPlan) []Expr {
 		for _, expr := range plan.Aggregation.GroupExprs {
 			columnsUsedExprs = append(columnsUsedExprs, expr.ColumnsUsedExprs()...)
 		}
-		columnsUsedExprs = append(columnsUsedExprs, plan.Aggregation.AggExpr.ColumnsUsedExprs()...)
+		for _, expr := range plan.Aggregation.AggExprs {
+			columnsUsedExprs = append(columnsUsedExprs, expr.ColumnsUsedExprs()...)
+		}
 	}
 
 	return append(columnsUsedExprs, aggregationColumns(plan.Input)...)

--- a/query/logicalplan/optimize_test.go
+++ b/query/logicalplan/optimize_test.go
@@ -15,8 +15,8 @@ func TestOptimizePhysicalProjectionPushDown(t *testing.T) {
 		Scan(tableProvider, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -69,8 +69,8 @@ func TestOptimizeFilterPushDown(t *testing.T) {
 		Scan(tableProvider, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -100,8 +100,8 @@ func TestRemoveProjectionAtRoot(t *testing.T) {
 		Scan(&mockTableProvider{schema: dynparquet.NewSampleSchema()}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()
@@ -117,8 +117,8 @@ func TestRemoveMiddleProjection(t *testing.T) {
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Project(Col("stacktrace")).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Build()
 
@@ -133,8 +133,8 @@ func TestRemoveLowestProjection(t *testing.T) {
 		Project(Col("stacktrace")).
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Build()
 
@@ -148,8 +148,8 @@ func TestProjectionPushDown(t *testing.T) {
 		Scan(&mockTableProvider{schema: dynparquet.NewSampleSchema()}, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("labels")).
 		Build()
@@ -176,8 +176,8 @@ func TestAllOptimizers(t *testing.T) {
 		Scan(tableProvider, "table1").
 		Filter(Col("labels.test").Eq(Literal("abc"))).
 		Aggregate(
-			Sum(Col("value")).Alias("value_sum"),
-			Col("stacktrace"),
+			[]Expr{Sum(Col("value")).Alias("value_sum")},
+			[]Expr{Col("stacktrace")},
 		).
 		Project(Col("stacktrace")).
 		Build()

--- a/query/logicalplan/validate_test.go
+++ b/query/logicalplan/validate_test.go
@@ -59,7 +59,7 @@ func TestCanTraverseInputThatIsInvalid(t *testing.T) {
 
 func TestAggregationMustHaveExpr(t *testing.T) {
 	_, err := (&Builder{}).
-		Aggregate(nil).
+		Aggregate(nil, nil).
 		Build()
 
 	require.NotNil(t, err)
@@ -70,13 +70,14 @@ func TestAggregationMustHaveExpr(t *testing.T) {
 }
 
 func TestAggregationExprCannotHaveInvalidType(t *testing.T) {
-	invalidExprs := []Expr{
-		Literal(4),
-		Col("Test"),
+	invalidExprs := [][]Expr{
+		{Literal(4)},
+		{Col("Test")},
 	}
+
 	for _, expr := range invalidExprs {
 		_, err := (&Builder{}).
-			Aggregate(expr).
+			Aggregate(expr, nil).
 			Build()
 
 		require.NotNil(t, err)
@@ -93,7 +94,7 @@ func TestAggregationExprCannotHaveInvalidType(t *testing.T) {
 func TestAggregationExprColumnMustExistInSchema(t *testing.T) {
 	_, err := (&Builder{}).
 		Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-		Aggregate(Sum(Col("bad_column"))).
+		Aggregate([]Expr{Sum(Col("bad_column"))}, nil).
 		Build()
 
 	require.NotNil(t, err)
@@ -122,7 +123,7 @@ func TestAggregationCannotSumOrMaxTextColumn(t *testing.T) {
 	} {
 		_, err := (&Builder{}).
 			Scan(&mockTableProvider{dynparquet.NewSampleSchema()}, "table1").
-			Aggregate(testCase.fn(Col("example_type"))).
+			Aggregate([]Expr{testCase.fn(Col("example_type"))}, nil).
 			Build()
 
 		require.NotNil(t, err)

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -321,17 +321,10 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 		}
 
 		for j, col := range a.columns {
-			if a.finalStage {
-				if col.resultName == field.Name {
+				if col.expr.MatchColumn(field.Name) || col.resultName == field.Name {
 					columnToAggregate[j] = r.Column(i)
 					aggregateFieldFound[j] = true
 				}
-			} else {
-				if col.expr.MatchColumn(field.Name) {
-					columnToAggregate[j] = r.Column(i)
-					aggregateFieldFound[j] = true
-				}
-			}
 		}
 	}
 

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -428,8 +428,9 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 		groupByArrays = append(groupByArrays, arr)
 	}
 
-	aggregateColumns := append(groupByArrays)
-	aggregateFields := append(groupByFields)
+	// Rename to clarity upon appending aggregations later
+	aggregateColumns := groupByArrays
+	aggregateFields := groupByFields
 
 	for _, aggregation := range a.aggregations {
 		var (

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
+	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
@@ -174,13 +175,17 @@ func (a *HashAggregate) Draw() *Diagram {
 		child = a.next.Draw()
 	}
 
+	names := make([]string, 0, len(a.aggregations))
+	for _, agg := range a.aggregations {
+		names = append(names, agg.resultName)
+	}
+
 	var groupings []string
 	for _, grouping := range a.groupByColumnMatchers {
 		groupings = append(groupings, grouping.Name())
 	}
 
-	// details := fmt.Sprintf("HashAggregate (%s by %s)", a.columnsToAggregate[0].Name(), strings.Join(groupings, ","))
-	details := ""
+	details := fmt.Sprintf("HashAggregate (%s by %s)", strings.Join(names, ","), strings.Join(groupings, ","))
 	return &Diagram{Details: details, Child: child}
 }
 

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
-	"strings"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
@@ -27,51 +26,56 @@ func Aggregate(
 	agg *logicalplan.Aggregation,
 	final bool,
 ) (*HashAggregate, error) {
-	var (
-		aggFunc      logicalplan.AggFunc
-		aggFuncFound bool
+	aggregateColumns := make([]AggregateColumn, 0, len(agg.AggExprs))
 
-		aggColumnExpr  logicalplan.Expr
-		aggColumnFound bool
-	)
+	for _, expr := range agg.AggExprs {
+		var (
+			aggColumn      AggregateColumn
+			aggFunc        logicalplan.AggFunc
+			aggFuncFound   bool
+			aggColumnFound bool
+		)
+		expr.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
+			switch e := expr.(type) {
+			case *logicalplan.AggregationFunction:
+				aggFunc = e.Func
+				aggFuncFound = true
+			case *logicalplan.Column:
+				aggColumn.expr = e
+				aggColumnFound = true
+			}
 
-	agg.AggExpr.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
-		switch e := expr.(type) {
-		case *logicalplan.AggregationFunction:
-			aggFunc = e.Func
-			aggFuncFound = true
-		case *logicalplan.Column:
-			aggColumnExpr = e
-			aggColumnFound = true
+			return true
+		}))
+
+		if !aggFuncFound {
+			return nil, errors.New("aggregation function not found")
 		}
 
-		return true
-	}))
+		if !aggColumnFound {
+			return nil, errors.New("aggregation column not found")
+		}
 
-	if !aggFuncFound {
-		return nil, errors.New("aggregation function not found")
-	}
+		dataType, err := expr.DataType(s)
+		if err != nil {
+			return nil, err
+		}
 
-	if !aggColumnFound {
-		return nil, errors.New("aggregation column not found")
-	}
+		f, err := chooseAggregationFunction(aggFunc, dataType)
+		if err != nil {
+			return nil, err
+		}
 
-	dataType, err := agg.AggExpr.DataType(s)
-	if err != nil {
-		return nil, err
-	}
+		aggColumn.resultName = expr.Name()
+		aggColumn.function = f
 
-	f, err := chooseAggregationFunction(aggFunc, dataType)
-	if err != nil {
-		return nil, err
+		aggregateColumns = append(aggregateColumns, aggColumn)
 	}
 
 	return NewHashAggregate(
 		pool,
 		tracer,
-		agg.AggExpr.Name(),
-		f,
-		aggColumnExpr,
+		aggregateColumns,
 		agg.GroupExprs,
 		final,
 	), nil
@@ -103,6 +107,14 @@ func chooseAggregationFunction(
 	}
 }
 
+// AggregateColumn groups together some lower level primitives to aggregate.
+type AggregateColumn struct {
+	expr       logicalplan.Expr
+	resultName string
+	function   AggregationFunction
+	arrays     []builder.ColumnBuilder // TODO: These can actually live outside this struct and be shared. Only at the very end will they be read by each column and then aggregated separately.
+}
+
 type AggregationFunction interface {
 	Aggregate(pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error)
 }
@@ -110,14 +122,11 @@ type AggregationFunction interface {
 type HashAggregate struct {
 	pool                  memory.Allocator
 	tracer                trace.Tracer
-	resultColumnName      string
+	columns               []AggregateColumn
 	groupByCols           map[string]builder.ColumnBuilder
 	colOrdering           []string
-	arraysToAggregate     []builder.ColumnBuilder
 	hashToAggregate       map[uint64]int
 	groupByColumnMatchers []logicalplan.Expr
-	columnToAggregate     logicalplan.Expr
-	aggregationFunction   AggregationFunction
 	hashSeed              maphash.Seed
 	next                  PhysicalPlan
 	// Indicate is this is the last aggregation or
@@ -133,25 +142,20 @@ type HashAggregate struct {
 func NewHashAggregate(
 	pool memory.Allocator,
 	tracer trace.Tracer,
-	resultColumnName string,
-	aggregationFunction AggregationFunction,
-	columnToAggregate logicalplan.Expr,
+	columns []AggregateColumn,
 	groupByColumnMatchers []logicalplan.Expr,
 	finalStage bool,
 ) *HashAggregate {
 	return &HashAggregate{
-		pool:              pool,
-		tracer:            tracer,
-		resultColumnName:  resultColumnName,
-		groupByCols:       map[string]builder.ColumnBuilder{},
-		colOrdering:       []string{},
-		arraysToAggregate: make([]builder.ColumnBuilder, 0),
-		hashToAggregate:   map[uint64]int{},
-		columnToAggregate: columnToAggregate,
+		pool:            pool,
+		tracer:          tracer,
+		columns:         columns,
+		groupByCols:     map[string]builder.ColumnBuilder{},
+		colOrdering:     []string{},
+		hashToAggregate: map[uint64]int{},
 		// TODO: Matchers can be optimized to be something like a radix tree or just a fast-lookup datastructure for exact matches or prefix matches.
 		groupByColumnMatchers: groupByColumnMatchers,
 		hashSeed:              maphash.MakeSeed(),
-		aggregationFunction:   aggregationFunction,
 		finalStage:            finalStage,
 
 		groupByFields:      make([]arrow.Field, 0, 10),
@@ -175,7 +179,8 @@ func (a *HashAggregate) Draw() *Diagram {
 		groupings = append(groupings, grouping.Name())
 	}
 
-	details := fmt.Sprintf("HashAggregate (%s by %s)", a.columnToAggregate.Name(), strings.Join(groupings, ","))
+	// details := fmt.Sprintf("HashAggregate (%s by %s)", a.columnsToAggregate[0].Name(), strings.Join(groupings, ","))
+	details := ""
 	return &Diagram{Details: details, Child: child}
 }
 
@@ -292,8 +297,8 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 		groupByArrays = groupByArrays[:0]
 	}()
 
-	var columnToAggregate arrow.Array
-	aggregateFieldFound := false
+	columnToAggregate := make([]arrow.Array, len(a.columns))
+	aggregateFieldFound := make([]bool, len(a.columns))
 
 	for i, field := range r.Schema().Fields() {
 		for _, matcher := range a.groupByColumnMatchers {
@@ -315,14 +320,25 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 			}
 		}
 
-		if a.columnToAggregate.MatchColumn(field.Name) {
-			columnToAggregate = r.Column(i)
-			aggregateFieldFound = true
+		for j, col := range a.columns {
+			if a.finalStage {
+				if col.resultName == field.Name {
+					columnToAggregate[j] = r.Column(i)
+					aggregateFieldFound[j] = true
+				}
+			} else {
+				if col.expr.MatchColumn(field.Name) {
+					columnToAggregate[j] = r.Column(i)
+					aggregateFieldFound[j] = true
+				}
+			}
 		}
 	}
 
-	if !aggregateFieldFound {
-		return errors.New("aggregate field not found, aggregations are not possible without it")
+	for _, found := range aggregateFieldFound {
+		if !found {
+			return errors.New("aggregate field not found, aggregations are not possible without it")
+		}
 	}
 
 	numRows := int(r.NumRows())
@@ -347,9 +363,11 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 
 		k, ok := a.hashToAggregate[hash]
 		if !ok {
-			agg := builder.NewBuilder(a.pool, columnToAggregate.DataType())
-			a.arraysToAggregate = append(a.arraysToAggregate, agg)
-			k = len(a.arraysToAggregate) - 1
+			for j, col := range columnToAggregate {
+				agg := builder.NewBuilder(a.pool, col.DataType())
+				a.columns[j].arrays = append(a.columns[j].arrays, agg)
+			}
+			k = len(a.columns[0].arrays) - 1
 			a.hashToAggregate[hash] = k
 
 			// insert new row into columns grouped by and create new aggregate array to append to.
@@ -366,7 +384,7 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 				// We already appended to the arrays to aggregate, so we have
 				// to account for that. We only want to back-fill null values
 				// up until the index that we are about to insert into.
-				for groupByCol.Len() < len(a.arraysToAggregate)-1 {
+				for groupByCol.Len() < len(a.columns[0].arrays)-1 {
 					groupByCol.AppendNull()
 				}
 
@@ -377,8 +395,10 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 			}
 		}
 
-		if err := builder.AppendValue(a.arraysToAggregate[k], columnToAggregate, i); err != nil {
-			return err
+		for j, col := range columnToAggregate {
+			if err := builder.AppendValue(a.columns[j].arrays[k], col, i); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -390,7 +410,7 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 	defer span.End()
 
 	numCols := len(a.groupByCols) + 1
-	numRows := len(a.arraysToAggregate)
+	numRows := len(a.columns[0].arrays)
 
 	groupByFields := make([]arrow.Field, 0, numCols)
 	groupByArrays := make([]arrow.Array, 0, numCols)
@@ -412,44 +432,46 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 		groupByArrays = append(groupByArrays, arr)
 	}
 
-	arrs := make([]arrow.Array, 0, numRows)
-	for _, arr := range a.arraysToAggregate {
-		arrs = append(arrs, arr.NewArray())
-	}
+	aggregateColumns := append(groupByArrays)
+	aggregateFields := append(groupByFields)
 
-	var (
-		aggregateArray arrow.Array
-		err            error
-	)
-	switch a.aggregationFunction.(type) {
-	case *CountAggregation:
-		if a.finalStage {
-			// The final stage of aggregation needs to sum up all the counts of the previous steps,
-			// instead of counting the previous counts.
-			aggregateArray, err = (&Int64SumAggregation{}).Aggregate(a.pool, arrs)
-		} else {
-			// If this isn't the final stage we simply run the count aggregation.
-			aggregateArray, err = a.aggregationFunction.Aggregate(a.pool, arrs)
+	for _, column := range a.columns {
+		var (
+			aggregateArray arrow.Array
+			err            error
+		)
+
+		arr := make([]arrow.Array, 0, numRows)
+		for _, a := range column.arrays {
+			arr = append(arr, a.NewArray())
 		}
-	default:
-		aggregateArray, err = a.aggregationFunction.Aggregate(a.pool, arrs)
-	}
-	if err != nil {
-		return fmt.Errorf("aggregate batched arrays: %w", err)
+
+		switch column.function.(type) {
+		case *CountAggregation:
+			if a.finalStage {
+				// The final stage of aggregation needs to sum up all the counts of the previous steps,
+				// instead of counting the previous counts.
+				aggregateArray, err = (&Int64SumAggregation{}).Aggregate(a.pool, arr)
+			} else {
+				// If this isn't the final stage we simply run the count aggregation.
+				aggregateArray, err = column.function.Aggregate(a.pool, arr)
+			}
+		default:
+			aggregateArray, err = column.function.Aggregate(a.pool, arr)
+		}
+		if err != nil {
+			return fmt.Errorf("aggregate batched arrays: %w", err)
+		}
+		aggregateColumns = append(aggregateColumns, aggregateArray)
+
+		aggregateFields = append(aggregateFields, arrow.Field{
+			Name: column.resultName, Type: aggregateArray.DataType(),
+		})
 	}
 
-	// Only the last Aggregation should rename the underlying column
-	fieldName := a.columnToAggregate.Name()
-	if a.finalStage {
-		fieldName = a.resultColumnName
-	}
-
-	aggregateField := arrow.Field{Name: fieldName, Type: aggregateArray.DataType()}
-	cols := append(groupByArrays, aggregateArray)
-
-	err = a.next.Callback(ctx, array.NewRecord(
-		arrow.NewSchema(append(groupByFields, aggregateField), nil),
-		cols,
+	err := a.next.Callback(ctx, array.NewRecord(
+		arrow.NewSchema(aggregateFields, nil),
+		aggregateColumns,
 		int64(numRows),
 	))
 	if err != nil {

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -406,7 +406,8 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 	defer span.End()
 
 	numCols := len(a.groupByCols) + 1
-	numRows := len(a.aggregations[0].arrays)
+	// Each hash that's aggregated by will become one row in the final result.
+	numRows := len(a.hashToAggregate)
 
 	groupByFields := make([]arrow.Field, 0, numCols)
 	groupByArrays := make([]arrow.Array, 0, numCols)

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -60,8 +60,8 @@ func TestBuildPhysicalPlan(t *testing.T) {
 		Scan(&mockTableProvider{schema: dynparquet.NewSampleSchema()}, "table1").
 		Filter(logicalplan.Col("labels.test").Eq(logicalplan.Literal("abc"))).
 		Aggregate(
-			logicalplan.Sum(logicalplan.Col("value")).Alias("value_sum"),
-			logicalplan.Col("stacktrace"),
+			[]logicalplan.Expr{logicalplan.Sum(logicalplan.Col("value")).Alias("value_sum")},
+			[]logicalplan.Expr{logicalplan.Col("stacktrace")},
 		).
 		Project(logicalplan.Col("stacktrace"), logicalplan.Col("value_sum")).
 		Build()

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -64,9 +64,7 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 
 			for _, expr := range v.exprStack {
 				switch expr.(type) {
-				case *logicalplan.AliasExpr:
-					agg = append(agg, expr)
-				case *logicalplan.AggregationFunction:
+				case *logicalplan.AliasExpr, *logicalplan.AggregationFunction:
 					agg = append(agg, expr)
 				default:
 					groups = append(groups, expr)

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -59,11 +59,20 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 		case expr.Distinct:
 			v.builder = v.builder.Distinct(v.exprStack...)
 		case expr.GroupBy != nil:
-			v.builder = v.builder.Aggregate(
-				// Aggregation function is evaluated first.
-				v.exprStack[0],
-				v.exprStack[1:]...,
-			)
+			var agg []logicalplan.Expr
+			var groups []logicalplan.Expr
+
+			for _, expr := range v.exprStack {
+				switch expr.(type) {
+				case *logicalplan.AliasExpr:
+					agg = append(agg, expr)
+				case *logicalplan.AggregationFunction:
+					agg = append(agg, expr)
+				default:
+					groups = append(groups, expr)
+				}
+			}
+			v.builder = v.builder.Aggregate(agg, groups)
 		default:
 			v.builder = v.builder.Project(v.exprStack...)
 		}


### PR DESCRIPTION
FrostDB should be able to accept queries like:
```
select sum(value), count(value), max(value) group by labels.label2
select sum(value) as value_sum, count(value) as value_count group by second(3)
```

For this, to work FrostDB needs to accept multiple aggregations within a single query. 
FrostDBs Aggregate interface has to be updated:
```diff
-Aggregate(aggExpr logicalplan.Expr, groupExprs ...logicalplan.Expr) Builder
+Aggregate(aggExpr, groupExprs []logicalplan.Expr) Builder
```

To make our lives easier to figure out all the things that belong to a single column that's being aggregated, I've introduced `AggregateColumn`. 

Benchmarks show no significant impact:
```
name                  old time/op    new time/op    delta
Aggregation/sum-24      1.84ms ± 3%    1.87ms ± 1%    ~     (p=0.065 n=10+9)
Aggregation/count-24    1.85ms ± 1%    1.85ms ± 1%    ~     (p=0.489 n=9+9)
Aggregation/max-24      1.83ms ± 2%    1.86ms ± 1%  +1.25%  (p=0.004 n=10+9)

name                  old alloc/op   new alloc/op   delta
Aggregation/sum-24      1.45MB ± 0%    1.46MB ± 0%  +0.16%  (p=0.000 n=10+10)
Aggregation/count-24    1.45MB ± 0%    1.46MB ± 0%  +0.17%  (p=0.000 n=10+10)
Aggregation/max-24      1.45MB ± 0%    1.46MB ± 0%  +0.17%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
Aggregation/sum-24       1.43k ± 0%     1.50k ± 0%  +5.23%  (p=0.000 n=10+9)
Aggregation/count-24     1.43k ± 0%     1.50k ± 0%  +5.25%  (p=0.000 n=10+10)
Aggregation/max-24       1.43k ± 0%     1.50k ± 0%  +5.25%  (p=0.000 n=9+8)
```