### PR TITLE
pqarrow: fix RepeatLastValue

### DIFF
--- a/pqarrow/builder/optbuilders_test.go
+++ b/pqarrow/builder/optbuilders_test.go
@@ -23,3 +23,35 @@ func TestIssue270(t *testing.T) {
 	require.True(t, a.IsNull(0))
 	require.Equal(t, string(a.Value(1)), expString)
 }
+
+func TestRepeatLastValue(t *testing.T) {
+	testCases := []struct {
+		b builder.OptimizedBuilder
+		v any
+	}{
+		{
+			b: builder.NewOptBinaryBuilder(arrow.BinaryTypes.Binary),
+			v: []byte("hello"),
+		},
+		{
+			b: builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64),
+			v: int64(123),
+		},
+		{
+			b: builder.NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean),
+			v: true,
+		},
+	}
+	for _, tc := range testCases {
+		require.NoError(t, builder.AppendGoValue(tc.b, tc.v))
+		require.Equal(t, tc.b.Len(), 1)
+		tc.b.RepeatLastValue(9)
+		require.Equal(t, tc.b.Len(), 10)
+		a := tc.b.NewArray()
+		for i := 0; i < a.Len(); i++ {
+			v, err := builder.GetValue(a, i)
+			require.NoError(t, err)
+			require.Equal(t, tc.v, v)
+		}
+	}
+}


### PR DESCRIPTION
This was broken in all optimized builders. Also added a test.