### PR TITLE
physicalplan: support muliple group by columns in the OrderedAggregate

### DIFF
--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -2,6 +2,7 @@ package physicalplan
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"errors"
 	"fmt"
@@ -116,6 +117,9 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 				a.groupByArrays = append(a.groupByArrays, r.Column(i))
 				a.curGroup = append(a.curGroup, nil)
 			}
+			// TODO(asubiotto): To have a 1:1 groupByArrays to fields match,
+			// we might be able to flip the search around and have a virtual
+			// null column for group by's that aren't found.
 		}
 
 		if a.columnToAggregate.MatchColumn(field.Name) {
@@ -129,17 +133,6 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 
 	if !aggregateFieldFound {
 		return errors.New("aggregate field not found, aggregations are not possible without it")
-	}
-
-	// TODO(asubiotto): We currently only support a single group by column.
-	if len(a.groupByArrays) > 1 {
-		var names []string
-		for _, m := range a.groupByColumnMatchers {
-			names = append(names, m.Name())
-		}
-		panic(
-			fmt.Sprintf("multiple group by columns not yet supported %s", strings.Join(names, ", ")),
-		)
 	}
 
 	// TODO(asubiotto): Explore a static schema in the execution engine, all
@@ -157,133 +150,72 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 		}
 	}
 
-	// groupRanges keeps track of the "bounds" of the group by columns.
-	groupRanges := []int64{0}
-	// handleCmpResult is a closure that encapsulates the handling of the result
-	// of comparing a current grouping column with a value in a group array. It
-	// is a closure instead of a function in order to update groupRanges
-	// in-place.
-	handleCmpResult := func(cmp, column int, t arrow.Array, j int) error {
-		switch cmp {
-		case -1:
-			// New group, append range index.
-			groupRanges = append(groupRanges, int64(j))
-			// Append the current group (which is now closed) to the
-			// builder.
-			b := a.groupByCols[a.groupByFields[column].Name]
-			if err := builder.AppendGoValue(b, a.curGroup[column]); err != nil {
-				return err
-			}
-			// And update the current group.
-			v, err := builder.GetValue(t, j)
-			if err != nil {
-				return err
-			}
-			a.curGroup[column] = v
-		case 0:
-			// Equal to group, do nothing.
-		case 1:
-			// New ordered set encountered. Flush aggregation and create
-			// new batch to aggregate into. These will then be merged
-			// before returning any rows.
-			panic("new ordered sets not yet implemented")
-		}
-		return nil
-	}
-	for i, arr := range a.groupByArrays {
-		switch t := arr.(type) {
-		case *array.Binary:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup []byte
-				if a.curGroup[i] != nil {
-					curGroup = a.curGroup[i].([]byte)
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = bytes.Compare(curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return err
-				}
-			}
-		case *array.String:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *string
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(string)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = strings.Compare(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return err
-				}
-			}
-		case *array.Int64:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *int64
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(int64)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = compareInt64(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return err
-				}
-			}
-		case *array.Boolean:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *bool
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(bool)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = compareBools(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return err
-				}
-			}
-		default:
-			panic("unsupported type")
-		}
+	groupRanges, setRanges, err := a.getGroupsAndOrderedSetRanges()
+	if err != nil {
+		return err
 	}
 
-	if len(groupRanges) == 1 {
-		// No new groups found. Accumulate the values to aggregate until the end
-		// of the current group is found (on a future call to Callback).
-
-		// TODO(asubiotto): We don't handle NULL values in aggregation columns
-		// in aggregation functions so disregard them here as well for now. We
-		// should eventually care about this.
-		return builder.AppendArray(a.arrayToAggCarry, columnToAggregate)
+	if setRanges.Len() > 0 {
+		panic("ordered sets not yet implemented")
 	}
 
 	// Aggregate the values for all groups found.
-	arraysToAggregate := make([]arrow.Array, 0, len(groupRanges))
-	for i := 0; i < len(groupRanges)-1; i++ {
-		start, end := groupRanges[i], groupRanges[i+1]
-		toAgg := array.NewSlice(columnToAggregate, start, end)
+	arraysToAggregate := make([]arrow.Array, 0, groupRanges.Len())
+	groupStart := int64(0)
+	for {
+		groupEnd, groupOk := popNextNotEqual(groupRanges, groupStart)
+		if !groupOk {
+			// All groups have been processed.
+			break
+		}
 
+		// Append the values to aggregate.
+		toAgg := array.NewSlice(columnToAggregate, groupStart, groupEnd)
 		if a.arrayToAggCarry.Len() > 0 {
 			if err := builder.AppendArray(a.arrayToAggCarry, toAgg); err != nil {
 				return err
 			}
 			toAgg = a.arrayToAggCarry.NewArray()
 		}
-
 		arraysToAggregate = append(arraysToAggregate, toAgg)
+
+		// Append the groups.
+		for i, field := range a.groupByFields {
+			var (
+				v   any
+				err error
+			)
+			if v, err = builder.GetValue(a.groupByArrays[i], int(groupStart)); err != nil {
+				return err
+			}
+			if err := builder.AppendGoValue(
+				a.groupByCols[field.Name],
+				v,
+			); err != nil {
+				return err
+			}
+		}
+
+		groupStart = groupEnd
+	}
+
+	// The values corresponding to the last group need to be carried over to the
+	// next aggregation since we can't determine that the last group is closed
+	// until we know the first value of the next record passed to Callback.
+	// Note that the current group values should already be set in a.curGroup.
+	// TODO(asubiotto): We don't handle NULL values in aggregation columns
+	// in aggregation functions so disregard them here as well for now. We
+	// should eventually care about this.
+	if err := builder.AppendArray(
+		a.arrayToAggCarry,
+		array.NewSlice(columnToAggregate, groupStart, int64(columnToAggregate.Len())),
+	); err != nil {
+		return err
+	}
+
+	if len(arraysToAggregate) == 0 {
+		// No new groups were found, carry on.
+		return nil
 	}
 
 	results, err := a.aggregationFunction.Aggregate(a.pool, arraysToAggregate)
@@ -350,6 +282,114 @@ func (a *OrderedAggregate) flushToNext(ctx context.Context, results arrow.Array)
 	))
 }
 
+// getGroupsAndOrderedSetRanges returns a min-heap of group ranges and ordered
+// set ranges in that order. The ranges are determined by iterating over the
+// group by arrays and comparing to the current group value for each column.
+func (a *OrderedAggregate) getGroupsAndOrderedSetRanges() (*int64Heap, *int64Heap, error) {
+	// groupRanges keeps track of the bounds of the group by columns.
+	groupRanges := &int64Heap{}
+	heap.Init(groupRanges)
+	// setRanges keeps track of the bounds of ordered sets. i.e. in the
+	// following slice, (a, a, b, c) is an ordered set of three groups. The
+	// second ordered set is (a, e): [a, a, b, c, a, e]
+	setRanges := &int64Heap{}
+	heap.Init(setRanges)
+
+	// handleCmpResult is a closure that encapsulates the handling of the result
+	// of comparing a current grouping column with a value in a group array.
+	handleCmpResult := func(cmp, column int, t arrow.Array, j int) error {
+		switch cmp {
+		case -1:
+			// New group, append range index.
+			heap.Push(groupRanges, int64(j))
+
+			// And update the current group.
+			v, err := builder.GetValue(t, j)
+			if err != nil {
+				return err
+			}
+			a.curGroup[column] = v
+		case 0:
+			// Equal to group, do nothing.
+		case 1:
+			// New ordered set encountered.
+			heap.Push(setRanges, int64(j))
+			heap.Push(groupRanges, int64(j))
+		}
+		return nil
+	}
+	for i, arr := range a.groupByArrays {
+		switch t := arr.(type) {
+		case *array.Binary:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroup []byte
+				if a.curGroup[i] != nil {
+					curGroup = a.curGroup[i].([]byte)
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
+				if !ok {
+					cmp = bytes.Compare(curGroup, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, err
+				}
+			}
+		case *array.String:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroup *string
+				if a.curGroup[i] != nil {
+					g := a.curGroup[i].(string)
+					curGroup = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
+				if !ok {
+					cmp = strings.Compare(*curGroup, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, err
+				}
+			}
+		case *array.Int64:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroup *int64
+				if a.curGroup[i] != nil {
+					g := a.curGroup[i].(int64)
+					curGroup = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
+				if !ok {
+					cmp = compareInt64(*curGroup, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, err
+				}
+			}
+		case *array.Boolean:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroup *bool
+				if a.curGroup[i] != nil {
+					g := a.curGroup[i].(bool)
+					curGroup = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
+				if !ok {
+					cmp = compareBools(*curGroup, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, err
+				}
+			}
+		default:
+			panic("unsupported type")
+		}
+	}
+	return groupRanges, setRanges, nil
+}
+
 // nullComparison encapsulates null comparison when scanning groups in the
 // ordered aggregator. leftNull is whether the current group is null, and
 // rightNull is whether the value we're comparing against is null. Note that
@@ -359,7 +399,8 @@ func (a *OrderedAggregate) flushToNext(ctx context.Context, results arrow.Array)
 // If the returned boolean is false, the comparison should be disregarded.
 func nullGroupComparison(leftNull, rightNull bool) (int, bool) {
 	if !leftNull && !rightNull {
-		// Both are null, this implies equality.
+		// Both are null, this implies that the null comparison should be
+		// disregarded.
 		return 0, false
 	}
 
@@ -391,4 +432,40 @@ func compareBools(a, b bool) int {
 		return -1
 	}
 	return 1
+}
+
+type int64Heap []int64
+
+func (h int64Heap) Len() int {
+	return len(h)
+}
+
+func (h int64Heap) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+func (h int64Heap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *int64Heap) Push(x any) {
+	*h = append(*h, x.(int64))
+}
+
+func (h *int64Heap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func popNextNotEqual(h *int64Heap, compare int64) (int64, bool) {
+	for h.Len() > 0 {
+		v := heap.Pop(h).(int64)
+		if v != compare {
+			return v, true
+		}
+	}
+	return 0, false
 }

--- a/query/physicalplan/ordered_aggregate_test.go
+++ b/query/physicalplan/ordered_aggregate_test.go
@@ -1,0 +1,200 @@
+package physicalplan
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/polarsignals/frostdb/pqarrow/builder"
+	"github.com/polarsignals/frostdb/query/logicalplan"
+)
+
+// TestOrderedAggregate unit tests aggregation logic specific to
+// OrderedAggregate internals using arrow records.
+func TestOrderedAggregate(t *testing.T) {
+	ctx := context.Background()
+
+	type record struct {
+		// NOTE: "" and 0 are considered NULL in this test to introduce a bit
+		// of excitement.
+		groups [][]string
+		vals   []int64
+	}
+	testCases := []struct {
+		name          string
+		numGroupCols  int
+		inputRecords  []record
+		resultRecords []record
+	}{
+		{
+			name:         "SingleGroupCol",
+			numGroupCols: 1,
+			inputRecords: []record{
+				{
+					groups: [][]string{
+						{"a", "a", "b", "c", "c"},
+					},
+					vals: []int64{1, 1, 1, 1, 1},
+				},
+			},
+			resultRecords: []record{
+				{
+					groups: [][]string{
+						{"a", "b"},
+					},
+					vals: []int64{2, 1},
+				},
+				{
+					groups: [][]string{
+						{"c"},
+					},
+					vals: []int64{2},
+				},
+			},
+		},
+		{
+			name:         "MultiGroupCol",
+			numGroupCols: 2,
+			inputRecords: []record{
+				{
+					groups: [][]string{
+						{"a", "a", "a", "c", "d"},
+						{"b", "b", "c", "c", "d"},
+					},
+					vals: []int64{1, 1, 1, 1, 1},
+				},
+			},
+			resultRecords: []record{
+				{
+					groups: [][]string{
+						{"a", "a", "c"},
+						{"b", "c", "c"},
+					},
+					vals: []int64{2, 1, 1},
+				},
+				{
+					groups: [][]string{
+						{"d"},
+						{"d"},
+					},
+					vals: []int64{1},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			groupColNameForIdx := func(i int) string {
+				return fmt.Sprintf("group%d", i)
+			}
+			const valColName = "vals"
+			groupCols := make([]logicalplan.Expr, 0, tc.numGroupCols)
+			for i := 0; i < tc.numGroupCols; i++ {
+				groupCols = append(groupCols, logicalplan.Col(groupColNameForIdx(i)))
+			}
+			groupBuilders := make([]*builder.OptBinaryBuilder, 0, tc.numGroupCols)
+			for i := 0; i < tc.numGroupCols; i++ {
+				groupBuilders = append(groupBuilders, builder.NewOptBinaryBuilder(arrow.BinaryTypes.Binary))
+			}
+			valBuilder := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+			o := NewOrderedAggregate(
+				memory.DefaultAllocator,
+				trace.NewNoopTracerProvider().Tracer(""),
+				"result",
+				&Int64SumAggregation{},
+				logicalplan.Col(valColName),
+				groupCols,
+				true,
+			)
+			resultCursor := 0
+			o.SetNext(&OutputPlan{
+				callback: func(ctx context.Context, r arrow.Record) error {
+					if r.NumRows() == 0 {
+						require.True(t, resultCursor < len(tc.resultRecords))
+						return nil
+					}
+					expected := tc.resultRecords[resultCursor]
+					resultCursor++
+
+					for i, groupCol := range expected.groups {
+						a := r.Column(i).(*array.Binary)
+						require.Equal(t, len(groupCol), a.Len())
+						for j, v := range groupCol {
+							require.Equal(t, v, string(a.Value(j)))
+						}
+					}
+					a := r.Column(len(expected.groups)).(*array.Int64)
+					require.Equal(t, len(expected.vals), a.Len())
+					for i, v := range expected.vals {
+						require.Equal(t, v, a.Value(i))
+					}
+					return nil
+				},
+			})
+
+			for _, record := range tc.inputRecords {
+				recordFields := make([]arrow.Field, 0)
+				arrays := make([]arrow.Array, 0)
+				nrows := -1
+				for i, groupCol := range record.groups {
+					if len(groupCol) == 0 {
+						// Test omitted this group column on purpose.
+						continue
+					}
+					if nrows == -1 {
+						nrows = len(groupCol)
+					}
+					require.Equal(t, nrows, len(groupCol), "group %d has wrong number of values", i)
+
+					for _, v := range groupCol {
+						if v == "" {
+							groupBuilders[i].AppendNull()
+							continue
+						}
+						groupBuilders[i].Append([]byte(v))
+					}
+					a := groupBuilders[i].NewArray()
+					recordFields = append(
+						recordFields,
+						arrow.Field{
+							Name: groupColNameForIdx(i), Type: a.DataType(),
+						},
+					)
+					arrays = append(arrays, a)
+				}
+				require.Equal(t, nrows, len(record.vals), "val col has wrong number of values")
+				for _, v := range record.vals {
+					if v == 0 {
+						valBuilder.AppendNull()
+						continue
+					}
+					valBuilder.Append(v)
+				}
+				a := valBuilder.NewArray()
+				recordFields = append(
+					recordFields,
+					arrow.Field{
+						Name: valColName, Type: a.DataType(),
+					},
+				)
+				arrays = append(arrays, a)
+				require.NoError(t, o.Callback(ctx, array.NewRecord(
+					arrow.NewSchema(
+						recordFields,
+						nil,
+					),
+					arrays,
+					int64(nrows),
+				)))
+			}
+			require.NoError(t, o.Finish(ctx))
+		})
+	}
+}


### PR DESCRIPTION
This commit supports grouping by multiple columns in ordered aggregations. It implements this using a min-heap of group ranges so that the first group by value to differ in any column is considered the start of a new group.

This commit also adds a TestOrderedAggregate unit test that creates and pushes arrow records to the ordered aggregate.