### PR TITLE
query/physicalplan: Fix aggregations for columns that are grouped by

### DIFF
--- a/logictest/testdata/aggregate/window
+++ b/logictest/testdata/aggregate/window
@@ -48,3 +48,15 @@ value1  120000  1
 value2  121000  2
 value3  122000  3
 value4  123000  4
+
+exec
+select sum(value) as value_sum, count(timestamp) as timestamp_count group by second(2)
+----
+120000  3       2
+122000  7       2
+
+exec
+select count(timestamp) as timestamp_count group by second(3)
+----
+120000  3
+123000  1


### PR DESCRIPTION
In case of a query like `select count(timestamp) as timestamp_count group by second(3)` we have to add the `timestamp` column arrays once to the `columnToAggregate` with the way it was rewritten the column was added twice. 
In the end `columnToAggregate` had the timestamp column twice and return `aggregate field not found, aggregations are not possible without it` as error. 