### PR TITLE
arrowutils: introduce arrow utility package and MergeRecords

### DIFF
--- a/pqarrow/arrowutils/merge.go
+++ b/pqarrow/arrowutils/merge.go
@@ -1,0 +1,139 @@
+package arrowutils
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+
+	"github.com/polarsignals/frostdb/pqarrow/builder"
+)
+
+// MergeRecords merges the given records. The records must all have the same
+// schema. orderByCols is a slice of indexes into the columns that the records
+// and resulting records are ordered by. Note that the given records should
+// already be ordered by the given columns.
+// WARNING: Only ascending ordering is currently supported.
+func MergeRecords(
+	mem memory.Allocator, records []arrow.Record, orderByCols []int,
+) (arrow.Record, error) {
+	h := cursorHeap{
+		cursors:     make([]cursor, len(records)),
+		orderByCols: orderByCols,
+	}
+	for i := range h.cursors {
+		h.cursors[i].r = records[i]
+	}
+
+	schema := records[0].Schema()
+	recordBuilder := builder.NewRecordBuilder(mem, schema)
+
+	heap.Init(&h)
+	for h.Len() > 0 {
+		// Minimum cursor is always at index 0.
+		r := h.cursors[0].r
+		i := h.cursors[0].curIdx
+		for colIdx, b := range recordBuilder.Fields() {
+			if err := builder.AppendValue(b, r.Column(colIdx), i); err != nil {
+				return nil, err
+			}
+		}
+		if int64(i+1) >= r.NumRows() {
+			// Pop the cursor since it has no more data.
+			_ = heap.Pop(&h)
+			continue
+		}
+		h.cursors[0].curIdx++
+		heap.Fix(&h, 0)
+	}
+
+	return recordBuilder.NewRecord(), nil
+}
+
+type cursor struct {
+	r      arrow.Record
+	curIdx int
+}
+
+type cursorHeap struct {
+	cursors     []cursor
+	orderByCols []int
+}
+
+func (h cursorHeap) Len() int {
+	return len(h.cursors)
+}
+
+func (h cursorHeap) Less(i, j int) bool {
+	c1 := h.cursors[i]
+	c2 := h.cursors[j]
+	for _, i := range h.orderByCols {
+		col1 := c1.r.Column(i)
+		col2 := c2.r.Column(i)
+		if cmp, ok := nullComparison(col1.IsNull(c1.curIdx), col2.IsNull(c2.curIdx)); ok {
+			if cmp == 0 {
+				continue
+			}
+			return cmp < 0
+		}
+		switch arr1 := c1.r.Column(i).(type) {
+		case *array.Binary:
+			arr2 := c2.r.Column(i).(*array.Binary)
+			cmp := bytes.Compare(arr1.Value(c1.curIdx), arr2.Value(c2.curIdx))
+			if cmp == 0 {
+				continue
+			}
+			return cmp < 0
+		case *array.Int64:
+			arr2 := c2.r.Column(i).(*array.Int64)
+			v1 := arr1.Value(c1.curIdx)
+			v2 := arr2.Value(c2.curIdx)
+			if v1 == v2 {
+				continue
+			}
+			return v1 < v2
+		default:
+			panic(fmt.Sprintf("unsupported type for record merging %T", arr1))
+		}
+	}
+	return false
+}
+
+// TODO(asubiotto): This is an exact copy of nullGroupComparison the
+// OrderedAggregate uses. Should this be extracted to a comparison package?
+// Nulls sort first.
+func nullComparison(leftNull, rightNull bool) (int, bool) {
+	if !leftNull && !rightNull {
+		// Both are not null, this implies that the null comparison should be
+		// disregarded.
+		return 0, false
+	}
+
+	if leftNull {
+		if !rightNull {
+			return -1, true
+		}
+		return 0, true
+	}
+	return 1, true
+}
+
+func (h cursorHeap) Swap(i, j int) {
+	h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i]
+}
+
+func (h cursorHeap) Push(x any) {
+	panic(
+		"number of cursors are known at Init time, none should ever be pushed",
+	)
+}
+
+func (h *cursorHeap) Pop() any {
+	n := len(h.cursors) - 1
+	c := h.cursors[n]
+	h.cursors = h.cursors[:n]
+	return c
+}

--- a/pqarrow/arrowutils/merge_test.go
+++ b/pqarrow/arrowutils/merge_test.go
@@ -1,0 +1,50 @@
+package arrowutils_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
+)
+
+func TestMerge(t *testing.T) {
+	schema := arrow.NewSchema(
+		[]arrow.Field{{Name: "test", Type: arrow.PrimitiveTypes.Int64}},
+		nil,
+	)
+
+	b := array.NewInt64Builder(memory.DefaultAllocator)
+	b.Append(0)
+	b.Append(1)
+	b.Append(3)
+	b.Append(5)
+	a := b.NewArray()
+	record1 := array.NewRecord(schema, []arrow.Array{a}, int64(a.Len()))
+	b.Append(2)
+	b.Append(4)
+	b.Append(5)
+	b.Append(6)
+	a = b.NewArray()
+	record2 := array.NewRecord(schema, []arrow.Array{a}, int64(a.Len()))
+	b.AppendNull()
+	a = b.NewArray()
+	record3 := array.NewRecord(schema, []arrow.Array{a}, int64(a.Len()))
+
+	res, err := arrowutils.MergeRecords(
+		memory.DefaultAllocator, []arrow.Record{record1, record2, record3}, []int{0},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.NumCols())
+	col := res.Column(0).(*array.Int64)
+	require.Equal(t, 9, col.Len())
+	// Nulls sort first.
+	require.True(t, col.IsNull(0))
+	expected := []int64{0, 1, 2, 3, 4, 5, 5, 6}
+	for i := 1; i < col.Len(); i++ {
+		require.Equal(t, expected[i-1], col.Value(i))
+	}
+}

--- a/pqarrow/arrowutils/utils.go
+++ b/pqarrow/arrowutils/utils.go
@@ -1,0 +1,31 @@
+package arrowutils
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+)
+
+// GetValue returns the value at index i in arr. If the value is null, nil is
+// returned.
+func GetValue(arr arrow.Array, i int) (any, error) {
+	if arr.IsNull(i) {
+		return nil, nil
+	}
+
+	switch a := arr.(type) {
+	case *array.Binary:
+		return a.Value(i), nil
+	case *array.FixedSizeBinary:
+		return a.Value(i), nil
+	case *array.String:
+		return a.Value(i), nil
+	case *array.Int64:
+		return a.Value(i), nil
+	case *array.Boolean:
+		return a.Value(i), nil
+	default:
+		return nil, fmt.Errorf("unsupported type for GetValue %T", a)
+	}
+}

--- a/pqarrow/builder/optbuilders_test.go
+++ b/pqarrow/builder/optbuilders_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"github.com/stretchr/testify/require"
 
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/pqarrow/builder"
 )
 
@@ -51,7 +52,7 @@ func TestRepeatLastValue(t *testing.T) {
 		require.Equal(t, tc.b.Len(), 10)
 		a := tc.b.NewArray()
 		for i := 0; i < a.Len(); i++ {
-			v, err := builder.GetValue(a, i)
+			v, err := arrowutils.GetValue(a, i)
 			require.NoError(t, err)
 			require.Equal(t, tc.v, v)
 		}

--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -126,26 +126,3 @@ func AppendGoValue(cb ColumnBuilder, v any) error {
 	}
 	return nil
 }
-
-// GetValue returns the value at index i in arr. If the value is null, nil is
-// returned.
-func GetValue(arr arrow.Array, i int) (any, error) {
-	if arr.IsNull(i) {
-		return nil, nil
-	}
-
-	switch a := arr.(type) {
-	case *array.Binary:
-		return a.Value(i), nil
-	case *array.FixedSizeBinary:
-		return a.Value(i), nil
-	case *array.String:
-		return a.Value(i), nil
-	case *array.Int64:
-		return a.Value(i), nil
-	case *array.Boolean:
-		return a.Value(i), nil
-	default:
-		return nil, fmt.Errorf("unsupported type for GetValue %T", a)
-	}
-}

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow/go/v8/arrow/memory"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/pqarrow/builder"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
@@ -142,7 +143,7 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 			b := builder.NewBuilder(a.pool, field.Type)
 			a.groupByCols[field.Name] = b
 			// Append the first group value to use below.
-			v, err := builder.GetValue(a.groupByArrays[i], 0)
+			v, err := arrowutils.GetValue(a.groupByArrays[i], 0)
 			if err != nil {
 				return err
 			}
@@ -185,7 +186,7 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 				v   any
 				err error
 			)
-			if v, err = builder.GetValue(a.groupByArrays[i], int(groupStart)); err != nil {
+			if v, err = arrowutils.GetValue(a.groupByArrays[i], int(groupStart)); err != nil {
 				return err
 			}
 			if err := builder.AppendGoValue(
@@ -304,7 +305,7 @@ func (a *OrderedAggregate) getGroupsAndOrderedSetRanges() (*int64Heap, *int64Hea
 			heap.Push(groupRanges, int64(j))
 
 			// And update the current group.
-			v, err := builder.GetValue(t, j)
+			v, err := arrowutils.GetValue(t, j)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR introduces a way to merge two sorted arrow records according to given sorting columns.

I also have a change on the back burner to drop duplicates/call a callback on equal values, but it's not working given I assumed some incorrect things about `container/heap`. I think the best thing will be to merge this without special duplicate behavior and then see how we use it in the ordered aggregator.