### PR TITLE
frostdb: remove unnecessary SeekToRow call during compaction

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -566,9 +566,6 @@ func compactLevel0IntoLevel1(
 
 		for {
 			var mergedBytes bytes.Buffer
-			if err := rows.SeekToRow(int64(cursor)); err != nil {
-				return err
-			}
 			n, err := t.writeRows(&mergedBytes, rows, merged.DynamicColumns(), estimatedRowsPerPart)
 			if err != nil {
 				return err

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -216,6 +216,46 @@ func TestCompaction(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "MultipleL0ToL1",
+			inserts: []int64{
+				acc, 1, 2, 3, flushAcc,
+				acc, 4, 5, 6, flushAcc,
+				recordGranuleSizeCommand,
+				acc, 7, 8, 9, flushAcc,
+				setRecordedGranuleSizeCommand,
+				compactCommand,
+			},
+			expected: []expectedGranule{
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{1, 2, 3, 4},
+						},
+					},
+				},
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    2,
+							compactionLevel: compactionLevel1,
+							data:            []int64{5, 6, 7, 8},
+						},
+					},
+				},
+				{
+					[]expectedPart{
+						{
+							numRowGroups:    1,
+							compactionLevel: compactionLevel1,
+							data:            []int64{9},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	numParts := func(g *Granule) int {

--- a/table_test.go
+++ b/table_test.go
@@ -334,6 +334,7 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 		WithStoragePath(dir),
 	)
 	require.NoError(b, err)
+	defer c.Close()
 
 	db, err := c.DB(context.Background(), "test")
 	require.NoError(b, err)


### PR DESCRIPTION
This call would simply verify that we placed the cursor at the desired row. However, this SeekToRow is causing correctness issues although it's supposed to be a noop.

Fixes #294 