### PR TITLE
Add support for average aggregations

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -104,6 +104,11 @@ func TestAggregateInconsistentSchema(t *testing.T) {
 			alias:   "value_count",
 			expVals: []int64{2, 1},
 		},
+		{
+			fn:      logicalplan.Avg,
+			alias:   "value_avg",
+			expVals: []int64{2, 2},
+		},
 	} {
 		t.Run(testCase.alias, func(t *testing.T) {
 			var res arrow.Record

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -107,7 +107,7 @@ func TestAggregateInconsistentSchema(t *testing.T) {
 		{
 			fn:      logicalplan.Avg,
 			alias:   "value_avg",
-			expVals: []int64{2, 2},
+			expVals: []int64{2, 1},
 		},
 	} {
 		t.Run(testCase.alias, func(t *testing.T) {

--- a/logictest/testdata/aggregate/aggregate
+++ b/logictest/testdata/aggregate/aggregate
@@ -29,6 +29,17 @@ select count(value) as value_count group by labels.label2
 value2  6
 
 exec
+select avg(value) as value_avg group by labels.label2
+----
+value2  3
+
+exec
+select avg(value) as value_avg group by labels.label4
+----
+        3
+value4  4
+
+exec
 select sum(value), count(value) group by stacktrace
 ----
 stack1  21      6

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -19,6 +19,10 @@ var DefaultOptimizers = []Optimizer{
 type AverageAggregationPushDown struct{}
 
 func (p *AverageAggregationPushDown) Optimize(plan *LogicalPlan) *LogicalPlan {
+	if plan.Aggregation == nil {
+		return plan
+	}
+
 	for i, aggExpr := range plan.Aggregation.AggExprs {
 		if aliasExpr, ok := aggExpr.(*AliasExpr); ok {
 			if aggFunc, ok := aliasExpr.Expr.(*AggregationFunction); ok {

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -284,6 +284,14 @@ func (a *averageProjection) Name() string {
 
 func (a *averageProjection) Project(mem memory.Allocator, r arrow.Record) ([]arrow.Field, []arrow.Array, error) {
 	columnName := a.expr.Name()
+	resultName := "avg(" + columnName + ")"
+	if avgExpr, ok := a.expr.(*logicalplan.AverageExpr); ok {
+		if ae, ok := avgExpr.Expr.(*logicalplan.AliasExpr); ok {
+			columnName = ae.Expr.Name()
+			resultName = ae.Alias
+		}
+	}
+
 	columnSum := "sum(" + columnName + ")"
 	columnCount := "count(" + columnName + ")"
 
@@ -314,7 +322,7 @@ func (a *averageProjection) Project(mem memory.Allocator, r arrow.Record) ([]arr
 
 	// Add the field and column for the projected average aggregation.
 	fields = append(fields, arrow.Field{
-		Name: "avg(" + columnName + ")",
+		Name: resultName,
 		Type: &arrow.Int64Type{},
 	})
 	columns = append(columns, avgInt64arrays(mem, sums, counts))

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -90,6 +90,8 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			v.exprStack[lastExpr] = logicalplan.Min(v.exprStack[lastExpr])
 		case "max":
 			v.exprStack[lastExpr] = logicalplan.Max(v.exprStack[lastExpr])
+		case "avg":
+			v.exprStack[lastExpr] = logicalplan.Avg(v.exprStack[lastExpr])
 		default:
 			return fmt.Errorf("unhandled aggregate function %s", expr.F)
 		}


### PR DESCRIPTION
Thanks to @asubiotto we had the idea to make the average aggregation a projection. 

The way it works now is that the logical plan creates an average aggregation but then optimizes those into the two `sum` and `count` aggregations plus an `avg` projection. The logical plan makes sure to wrap both aggregations with the average projection, such that anything reading the column afterward will only see the final result. 

TODO:
- [x] Improve `AverageAggregationPushDown.Optimize()` to support with and without alias columns

Closes #177 
Superseeds #266 & #190