### PR TITLE
Arrow record ingestion support

### DIFF
--- a/bufutils/dyncols.go
+++ b/bufutils/dyncols.go
@@ -2,6 +2,7 @@ package bufutils
 
 import "sort"
 
+// Dedupe deduplicates the slices of values for each key in the map.
 func Dedupe(s map[string][]string) map[string][]string {
 	final := map[string][]string{}
 	set := map[string]map[string]struct{}{}

--- a/bufutils/dyncols.go
+++ b/bufutils/dyncols.go
@@ -1,0 +1,24 @@
+package bufutils
+
+import "sort"
+
+func Dedupe(s map[string][]string) map[string][]string {
+	final := map[string][]string{}
+	set := map[string]map[string]struct{}{}
+	for k, v := range s {
+		if set[k] == nil {
+			set[k] = map[string]struct{}{}
+		}
+		for _, i := range v {
+			if _, ok := set[k][i]; !ok {
+				set[k][i] = struct{}{}
+				final[k] = append(final[k], i)
+			}
+		}
+	}
+
+	for _, s := range final {
+		sort.Strings(s)
+	}
+	return final
+}

--- a/compaction.go
+++ b/compaction.go
@@ -551,7 +551,7 @@ func compactLevel0IntoLevel1(
 		// All the row groups in a part are wrapped in a single row group given
 		// that all rows are sorted within a part. This reduces the number of
 		// cursors open when merging the row groups.
-		bufs = append(bufs, p.Buf().MultiDynamicRowGroup())
+		bufs = append(bufs, buf.MultiDynamicRowGroup())
 	}
 
 	cursor := 0

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -62,7 +62,6 @@ func insertSampleRecords(ctx context.Context, t *testing.T, table *Table, timest
 	tx, err := table.InsertRecord(ctx, ar)
 	require.NoError(t, err)
 	return tx
-
 }
 
 func TestCompaction(t *testing.T) {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -333,10 +333,11 @@ func TestCompaction(t *testing.T) {
 							table.active.Index().Len(),
 							"tests assume only a single granule as input",
 						)
-						success, err := table.active.compactGranule(
-							(table.active.Index().Min()).(*Granule),
-							table.db.columnStore.compactionConfig,
-						)
+						cfg := table.db.columnStore.compactionConfig
+						if asArrow {
+							cfg.l1ToGranuleSizeRatio = 0.6 // use a different ratio for arrow records
+						}
+						success, err := table.active.compactGranule((table.active.Index().Min()).(*Granule), cfg)
 						require.True(t, success)
 						require.NoError(t, err)
 					case recordGranuleSizeCommand:

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -434,7 +434,9 @@ func TestCompaction(t *testing.T) {
 					if expectedPart.numRowGroups == 0 {
 						require.Equal(t, int64(expectedPart.numRows), p.Record().NumRows())
 					} else {
-						rgs := p.Buf().ParquetFile().RowGroups()
+						buf, err := p.AsSerializedBuffer(table.Schema())
+						require.NoError(t, err)
+						rgs := buf.ParquetFile().RowGroups()
 						require.Equal(t, expectedPart.numRowGroups, len(rgs))
 						require.Equal(t, expectedPart.compactionLevel, p.CompactionLevel())
 						rowsRead := make([]parquet.Row, 0)

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -36,6 +36,15 @@ func (r *DynamicRows) GetCopy(i int) *DynamicRow {
 	}
 }
 
+func NewDynamicRow(row parquet.Row, schema *parquet.Schema, dyncols map[string][]string, fields []parquet.Field) *DynamicRow {
+	return &DynamicRow{
+		Row:            row,
+		Schema:         schema,
+		DynamicColumns: dyncols,
+		fields:         fields,
+	}
+}
+
 type DynamicRow struct {
 	Row            parquet.Row
 	Schema         *parquet.Schema

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/trace v0.20.0
 	go.uber.org/goleak v1.1.12
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	google.golang.org/protobuf v1.28.1
 )
@@ -67,7 +68,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.18.1 // indirect
-	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20220829200755-d48e67d00261 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/granule.go
+++ b/granule.go
@@ -86,15 +86,15 @@ func (g *Granule) Append(p *parts.Part) (uint64, error) {
 	return newSize, nil
 }
 
-// PartBuffersForTx returns the PartBuffers for the given transaction constraints.
-func (g *Granule) PartBuffersForTx(watermark uint64, iterator func(*dynparquet.SerializedBuffer) bool) {
+// PartsForTx returns the parts for the given transaction constraints.
+func (g *Granule) PartsForTx(watermark uint64, iterator func(*parts.Part) bool) {
 	g.parts.Iterate(func(p *parts.Part) bool {
 		// Don't iterate over parts from an uncompleted transaction
 		if p.TX() > watermark {
 			return true
 		}
 
-		return iterator(p.Buf())
+		return iterator(p)
 	})
 }
 

--- a/granule.go
+++ b/granule.go
@@ -137,7 +137,6 @@ func (g *Granule) Collect(ctx context.Context, tx uint64, filter TrueNegativeFil
 			if mayContainUsefulData {
 				select {
 				case <-ctx.Done():
-					err = ctx.Err()
 					return false
 				case collector <- rg:
 				}

--- a/parts/part.go
+++ b/parts/part.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/apache/arrow/go/v7/arrow"
+	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/segmentio/parquet-go"
 
 	"github.com/polarsignals/frostdb/dynparquet"

--- a/parts/part.go
+++ b/parts/part.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/segmentio/parquet-go"
 
 	"github.com/polarsignals/frostdb/dynparquet"
@@ -44,6 +45,21 @@ func WithCompactionLevel(level CompactionLevel) Option {
 	return func(p *Part) {
 		p.compactionLevel = level
 	}
+}
+
+// NewArrowPart returns a new Arrow part.
+func NewArrowPart(tx uint64, record arrow.Record, schema *dynparquet.Schema, options ...Option) *Part {
+	p := &Part{
+		tx:     tx,
+		record: record,
+		schema: schema,
+	}
+
+	for _, opt := range options {
+		opt(p)
+	}
+
+	return p
 }
 
 func NewPart(tx uint64, buf *dynparquet.SerializedBuffer, options ...Option) *Part {

--- a/parts/part.go
+++ b/parts/part.go
@@ -153,6 +153,16 @@ func (p *Part) most() (*dynparquet.DynamicRow, error) {
 		return p.maxRow, nil
 	}
 
+	if p.record != nil {
+		var err error
+		p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, p.record, int(p.record.NumRows()-1))
+		if err != nil {
+			return nil, err
+		}
+
+		return p.maxRow, nil
+	}
+
 	rowBuf := &dynparquet.DynamicRows{Rows: make([]parquet.Row, 1)}
 	rg := p.buf.DynamicRowGroup(p.buf.NumRowGroups() - 1)
 	reader := rg.DynamicRows()

--- a/parts/part.go
+++ b/parts/part.go
@@ -3,7 +3,6 @@ package parts
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math"
 
 	"github.com/apache/arrow/go/v7/arrow"
@@ -44,12 +43,6 @@ func (p *Part) SerializeBuffer(schema *dynparquet.Schema, w *parquet.Writer) err
 	}
 
 	return pqarrow.RecordToFile(schema, w, p.record)
-}
-
-type SchemaWriter interface {
-	GetWriter(io.Writer, map[string][]string) (*dynparquet.PooledWriter, error)
-	PutWriter(io.Writer, map[string][]string) (*dynparquet.PooledWriter, error)
-	Schema() *dynparquet.Schema
 }
 
 func (p *Part) AsSerializedBuffer(schema *dynparquet.Schema) (*dynparquet.SerializedBuffer, error) {

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -20,20 +20,11 @@ import (
 )
 
 // ParquetRowGroupToArrowSchema converts a parquet row group to an arrow schema.
-func ParquetRowGroupToArrowSchema(
-	ctx context.Context,
-	rg parquet.RowGroup,
-	options logicalplan.IterOptions,
-) (*arrow.Schema, error) {
+func ParquetRowGroupToArrowSchema(ctx context.Context, rg parquet.RowGroup, options logicalplan.IterOptions) (*arrow.Schema, error) {
 	return ParquetSchemaToArrowSchema(ctx, rg.Schema(), options)
 }
 
-func ParquetSchemaToArrowSchema(
-	ctx context.Context,
-	schema *parquet.Schema,
-	options logicalplan.IterOptions,
-) (*arrow.Schema, error) {
-
+func ParquetSchemaToArrowSchema(ctx context.Context, schema *parquet.Schema, options logicalplan.IterOptions) (*arrow.Schema, error) {
 	parquetFields := schema.Fields()
 
 	if len(options.DistinctColumns) == 1 && options.Filter == nil {

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -35,42 +35,17 @@ func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 }
 
 func appendToRow(row []parquet.Value, c arrow.Array, index, rep, def, col int) ([]parquet.Value, error) {
-	switch c.DataType().ID() {
-	case arrow.INT64:
-		array, ok := c.(*array.Int64)
-		if !ok {
-			return nil, fmt.Errorf("column not of expected type")
-		}
-
-		row = append(row, parquet.ValueOf(array.Value(index)).Level(rep, def, col))
-	case arrow.BOOL:
-		array, ok := c.(*array.Boolean)
-		if !ok {
-			return nil, fmt.Errorf("column not of expected type")
-		}
-
-		row = append(row, parquet.ValueOf(array.Value(index)).Level(rep, def, col))
-	case arrow.BINARY:
-		array, ok := c.(*array.Binary)
-		if !ok {
-			return nil, fmt.Errorf("column not of expected type")
-		}
-
-		row = append(row, parquet.ValueOf(array.Value(index)).Level(rep, def, col))
-	case arrow.STRING:
-		array, ok := c.(*array.String)
-		if !ok {
-			return nil, fmt.Errorf("column not of expected type")
-		}
-
-		row = append(row, parquet.ValueOf(array.Value(index)).Level(rep, def, col))
-	case arrow.UINT64:
-		array, ok := c.(*array.Uint64)
-		if !ok {
-			return nil, fmt.Errorf("column not of expected type")
-		}
-
-		row = append(row, parquet.ValueOf(array.Value(index)).Level(rep, def, col))
+	switch arr := c.(type) {
+	case *array.Int64:
+		row = append(row, parquet.ValueOf(arr.Value(index)).Level(rep, def, col))
+	case *array.Boolean:
+		row = append(row, parquet.ValueOf(arr.Value(index)).Level(rep, def, col))
+	case *array.Binary:
+		row = append(row, parquet.ValueOf(arr.Value(index)).Level(rep, def, col))
+	case *array.String:
+		row = append(row, parquet.ValueOf(arr.Value(index)).Level(rep, def, col))
+	case *array.Uint64:
+		row = append(row, parquet.ValueOf(arr.Value(index)).Level(rep, def, col))
 	default:
 		return nil, fmt.Errorf("column not of expected type: %v", c.DataType().ID())
 	}

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -8,9 +8,10 @@ import (
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
 	"github.com/apache/arrow/go/v8/arrow/scalar"
+	"github.com/segmentio/parquet-go"
+
 	"github.com/polarsignals/frostdb/bufutils"
 	"github.com/polarsignals/frostdb/dynparquet"
-	"github.com/segmentio/parquet-go"
 )
 
 func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
@@ -115,10 +116,8 @@ func isDynamicColumn(schema *dynparquet.Schema, column string) bool {
 func RecordDynamicCols(record arrow.Record) map[string][]string {
 	dyncols := map[string][]string{}
 	for _, af := range record.Schema().Fields() {
-		name := af.Name
-		parts := strings.SplitN(name, ".", 2)
+		parts := strings.SplitN(af.Name, ".", 2)
 		if len(parts) == 2 { // dynamic column
-			name = parts[0]
 			dyncols[parts[0]] = append(dyncols[parts[0]], parts[1])
 		}
 	}
@@ -126,7 +125,7 @@ func RecordDynamicCols(record arrow.Record) map[string][]string {
 	return bufutils.Dedupe(dyncols)
 }
 
-// RecordToDynamicSchema converts an arrow record into a parquet schema, dynamic cols, and parquet fields
+// RecordToDynamicSchema converts an arrow record into a parquet schema, dynamic cols, and parquet fields.
 func RecordToDynamicSchema(schema *dynparquet.Schema, record arrow.Record) (*parquet.Schema, map[string][]string, []parquet.Field) {
 	dyncols := map[string][]string{}
 	g := parquet.Group{}

--- a/store.go
+++ b/store.go
@@ -46,7 +46,7 @@ func (t *Table) IterateBucketBlocks(
 	logger log.Logger,
 	lastBlockTimestamp uint64,
 	filter TrueNegativeFilter,
-	rowGroups chan<- dynparquet.DynamicRowGroup,
+	rowGroups chan<- any,
 ) error {
 	if t.db.bucket == nil || t.db.ignoreStorageOnQuery {
 		return nil
@@ -94,7 +94,7 @@ func (t *Table) openBlockFile(ctx context.Context, blockName string, size int64)
 }
 
 // ProcessFile will process a bucket block parquet file.
-func (t *Table) ProcessFile(ctx context.Context, blockDir string, lastBlockTimestamp uint64, filter TrueNegativeFilter, rowGroups chan<- dynparquet.DynamicRowGroup) error {
+func (t *Table) ProcessFile(ctx context.Context, blockDir string, lastBlockTimestamp uint64, filter TrueNegativeFilter, rowGroups chan<- any) error {
 	ctx, span := t.tracer.Start(ctx, "Table/IterateBucketBlocks/Iter/ProcessFile")
 	defer span.End()
 
@@ -131,7 +131,7 @@ func (t *Table) ProcessFile(ctx context.Context, blockDir string, lastBlockTimes
 	return t.filterRowGroups(ctx, buf, filter, rowGroups)
 }
 
-func (t *Table) filterRowGroups(ctx context.Context, buf *dynparquet.SerializedBuffer, filter TrueNegativeFilter, rowGroups chan<- dynparquet.DynamicRowGroup) error {
+func (t *Table) filterRowGroups(ctx context.Context, buf *dynparquet.SerializedBuffer, filter TrueNegativeFilter, rowGroups chan<- any) error {
 	_, span := t.tracer.Start(ctx, "Table/filterRowGroups")
 	defer span.End()
 	span.SetAttributes(attribute.Int("row_groups", buf.NumRowGroups()))

--- a/table.go
+++ b/table.go
@@ -1067,7 +1067,11 @@ func (t *TableBlock) RowGroupIterator(
 				return true
 			}
 
-			buf := p.Buf()
+			var buf *dynparquet.SerializedBuffer
+			buf, err = p.AsSerializedBuffer(t.table.config.schema)
+			if err != nil {
+				return false
+			}
 			f := buf.ParquetFile()
 			for i := range f.RowGroups() {
 				rg := buf.DynamicRowGroup(i)

--- a/table.go
+++ b/table.go
@@ -787,6 +787,8 @@ func (t *Table) Iterator(
 							}
 							r.Release()
 						}
+					default:
+						return fmt.Errorf("unknown row group type: %T", t)
 					}
 				}
 			}
@@ -878,6 +880,8 @@ func (t *Table) SchemaIterator(
 						}
 						record.Release()
 						b.Release()
+					default:
+						return fmt.Errorf("unknown row group type: %T", t)
 					}
 				}
 			}

--- a/table.go
+++ b/table.go
@@ -1142,7 +1142,7 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 			isLess := t.table.config.schema.RowLessThan(row, least)
 			if isLess {
 				if prev != nil {
-					if _, err := prev.AddPart(parts.NewArrowPart(tx, record.NewSlice(ri, ri), t.table.config.schema)); err != nil {
+					if _, err := prev.AddPart(parts.NewArrowPart(tx, record.NewSlice(ri, ri+1), t.table.config.schema)); err != nil {
 						ascendErr = err
 						return false
 					}

--- a/table.go
+++ b/table.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/polarsignals/frostdb/bufutils"
 	"github.com/polarsignals/frostdb/dynparquet"
 	schemapb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha1"
 	schemav2pb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha2"
@@ -307,6 +308,22 @@ func (t *Table) newTableBlock(prevTx, tx uint64, id ulid.ULID) error {
 	return nil
 }
 
+func (t *Table) dropPendingBlock(block *TableBlock) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	block.Index().Ascend(func(i btree.Item) bool {
+		g := i.(*Granule)
+		g.PartsForTx(math.MaxUint64, func(p *parts.Part) bool {
+			if r := p.Record(); r != nil {
+				r.Release()
+			}
+			return true
+		})
+		return true
+	})
+	delete(t.pendingBlocks, block)
+}
+
 func (t *Table) writeBlock(block *TableBlock) {
 	level.Debug(t.logger).Log("msg", "syncing block")
 	block.pendingWritersWg.Wait()
@@ -317,9 +334,7 @@ func (t *Table) writeBlock(block *TableBlock) {
 
 	// Persist the block
 	err := block.Persist()
-	t.mtx.Lock()
-	delete(t.pendingBlocks, block)
-	t.mtx.Unlock()
+	t.dropPendingBlock(block)
 	if err != nil {
 		level.Error(t.logger).Log("msg", "failed to persist block")
 		level.Error(t.logger).Log("msg", err.Error())
@@ -450,27 +465,6 @@ func ToSnakeCase(str string) string {
 	return strings.ToLower(snake)
 }
 
-func dedupe(s map[string][]string) map[string][]string {
-	final := map[string][]string{}
-	set := map[string]map[string]struct{}{}
-	for k, v := range s {
-		if set[k] == nil {
-			set[k] = map[string]struct{}{}
-		}
-		for _, i := range v {
-			if _, ok := set[k][i]; !ok {
-				set[k][i] = struct{}{}
-				final[k] = append(final[k], i)
-			}
-		}
-	}
-
-	for _, s := range final {
-		sort.Strings(s)
-	}
-	return final
-}
-
 func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer, error) {
 	dynamicColumns := map[string][]string{}
 	rows := make([]parquet.Row, 0, len(vals))
@@ -510,7 +504,7 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 		}
 	}
 
-	dynamicColumns = dedupe(dynamicColumns)
+	dynamicColumns = bufutils.Dedupe(dynamicColumns)
 
 	// Create all rows
 	for _, v := range vals {
@@ -586,6 +580,30 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 	}
 
 	return pb, nil
+}
+
+func (t *Table) InsertRecord(ctx context.Context, record arrow.Record) (uint64, error) {
+	block, close, err := t.appender()
+	if err != nil {
+		return 0, fmt.Errorf("get appender: %w", err)
+	}
+	defer close()
+
+	tx, _, commit := t.db.begin()
+	defer commit()
+
+	/* TODO: implement arrow record WAL
+	if err := t.appendToLog(ctx, tx, buf); err != nil {
+		return tx, fmt.Errorf("append to log: %w", err)
+	}
+	*/
+
+	err = block.InsertRecord(ctx, tx, record)
+	if err != nil {
+		return tx, fmt.Errorf("insert buffer into block: %w", err)
+	}
+
+	return tx, nil
 }
 
 func (t *Table) InsertBuffer(ctx context.Context, buf *dynparquet.Buffer) (uint64, error) {
@@ -707,7 +725,7 @@ func (t *Table) Iterator(
 	if len(callbacks) == 0 {
 		return errors.New("no callbacks provided")
 	}
-	rowGroups := make(chan dynparquet.DynamicRowGroup, len(callbacks)*4) // buffer up to 4 row groups per callback
+	rowGroups := make(chan any, len(callbacks)*4) // buffer up to 4 row groups per callback
 
 	// Previously we sorted all row groups into a single row group here,
 	// but it turns out that none of the downstream uses actually rely on
@@ -745,21 +763,30 @@ func (t *Table) Iterator(
 						r.Release()
 						return nil
 					}
-					rgSchema = rg.Schema()
-					if err := converter.Convert(ctx, rg); err != nil {
-						return fmt.Errorf("failed to convert row group to arrow record: %v", err)
-					}
-					// This RowGroup had no relevant data. Ignore it.
-					if len(converter.Fields()) == 0 {
-						continue
-					}
-					if converter.NumRows() >= bufferSize {
-						r := converter.NewRecord()
-						prepareForFlush(r, rgSchema)
-						if err := callback(ctx, r); err != nil {
+
+					switch t := rg.(type) {
+					case arrow.Record:
+						t.Retain()
+						if err := callback(ctx, t); err != nil {
 							return err
 						}
-						r.Release()
+					case dynparquet.DynamicRowGroup:
+						rgSchema = t.Schema()
+						if err := converter.Convert(ctx, t); err != nil {
+							return fmt.Errorf("failed to convert row group to arrow record: %v", err)
+						}
+						// This RowGroup had no relevant data. Ignore it.
+						if len(converter.Fields()) == 0 {
+							continue
+						}
+						if converter.NumRows() >= bufferSize {
+							r := converter.NewRecord()
+							prepareForFlush(r, rgSchema)
+							if err := callback(ctx, r); err != nil {
+								return err
+							}
+							r.Release()
+						}
 					}
 				}
 			}
@@ -796,7 +823,7 @@ func (t *Table) SchemaIterator(
 		return errors.New("no callbacks provided")
 	}
 
-	rowGroups := make(chan dynparquet.DynamicRowGroup, len(callbacks)*4) // buffer up to 4 row groups per callback
+	rowGroups := make(chan any, len(callbacks)*4) // buffer up to 4 row groups per callback
 
 	schema := arrow.NewSchema(
 		[]arrow.Field{
@@ -817,25 +844,41 @@ func (t *Table) SchemaIterator(
 					if !ok {
 						return nil // we're done
 					}
-					if rg == nil {
-						return errors.New("received nil rowGroup") // shouldn't happen, but anyway
-					}
+
 					b := array.NewRecordBuilder(pool, schema)
 
-					parquetFields := rg.Schema().Fields()
-					fieldNames := make([]string, 0, len(parquetFields))
-					for _, f := range parquetFields {
-						fieldNames = append(fieldNames, f.Name())
-					}
+					switch t := rg.(type) {
+					case arrow.Record:
+						toRecord := func() error {
+							for _, f := range t.Schema().Fields() {
+								b.Field(0).(*array.StringBuilder).Append(f.Name)
+							}
+							record := b.NewRecord()
+							defer record.Release()
+							return callback(ctx, record)
+						}
+						if err := toRecord(); err != nil {
+							return err
+						}
+					case dynparquet.DynamicRowGroup:
+						if rg == nil {
+							return errors.New("received nil rowGroup") // shouldn't happen, but anyway
+						}
+						parquetFields := t.Schema().Fields()
+						fieldNames := make([]string, 0, len(parquetFields))
+						for _, f := range parquetFields {
+							fieldNames = append(fieldNames, f.Name())
+						}
 
-					b.Field(0).(*array.StringBuilder).AppendValues(fieldNames, nil)
+						b.Field(0).(*array.StringBuilder).AppendValues(fieldNames, nil)
 
-					record := b.NewRecord()
-					if err := callback(ctx, record); err != nil {
-						return err
+						record := b.NewRecord()
+						if err := callback(ctx, record); err != nil {
+							return err
+						}
+						record.Release()
+						b.Release()
 					}
-					record.Release()
-					b.Release()
 				}
 			}
 		})
@@ -878,6 +921,24 @@ func newTableBlock(table *Table, prevTx, tx uint64, id ulid.ULID) (*TableBlock, 
 // EnsureCompaction forces a TableBlock compaction.
 func (t *TableBlock) EnsureCompaction() error {
 	return t.compact(t.table.db.columnStore.compactionConfig)
+}
+
+func (t *TableBlock) InsertRecord(ctx context.Context, tx uint64, record arrow.Record) error {
+	defer func() {
+		t.table.metrics.rowsInserted.Add(float64(record.NumRows()))
+		t.table.metrics.rowInsertSize.Observe(float64(record.NumRows()))
+	}()
+
+	if record.NumRows() == 0 {
+		t.table.metrics.zeroRowsInserted.Add(1)
+		return nil
+	}
+
+	if err := t.insertRecordToGranules(tx, record); err != nil {
+		return fmt.Errorf("failed to insert record into granules: %w", err)
+	}
+
+	return nil
 }
 
 func (t *TableBlock) Insert(ctx context.Context, tx uint64, buf *dynparquet.SerializedBuffer) error {
@@ -984,7 +1045,7 @@ func (t *TableBlock) RowGroupIterator(
 	ctx context.Context,
 	tx uint64,
 	filter TrueNegativeFilter,
-	rowGroups chan<- dynparquet.DynamicRowGroup,
+	rowGroups chan<- any,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "TableBlock/RowGroupIterator")
 	span.SetAttributes(attribute.Int64("tx", int64(tx))) // Attributes don't support uint64...
@@ -996,7 +1057,13 @@ func (t *TableBlock) RowGroupIterator(
 	index.Ascend(func(i btree.Item) bool {
 		g := i.(*Granule)
 
-		g.PartBuffersForTx(tx, func(buf *dynparquet.SerializedBuffer) bool {
+		g.PartsForTx(tx, func(p *parts.Part) bool {
+			if record := p.Record(); record != nil {
+				rowGroups <- record
+				return true
+			}
+
+			buf := p.Buf()
 			f := buf.ParquetFile()
 			for i := range f.RowGroups() {
 				rg := buf.DynamicRowGroup(i)
@@ -1032,6 +1099,75 @@ func (t *TableBlock) Size() int64 {
 // Index provides atomic access to the table index.
 func (t *TableBlock) Index() *btree.BTree {
 	return (*btree.BTree)(t.index.Load())
+}
+
+func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) error {
+	index := t.Index()
+	if index.Len() == 1 {
+		record.Retain()
+		index.Min().(*Granule).AddPart(parts.NewArrowPart(tx, record, t.table.config.schema))
+		t.table.metrics.numParts.Add(float64(1))
+		return nil
+	}
+
+	ps := t.table.config.schema
+
+	ri := int64(0)
+	exhaustedAllRows := false
+	row, err := pqarrow.RecordToDynamicRow(ps, record, int(ri))
+	if err != nil {
+		if err == io.EOF {
+			level.Debug(t.logger).Log("msg", "inserted record with no rows")
+			return nil
+		}
+		return err
+	}
+
+	var prev *Granule
+	var ascendErr error
+	index.Ascend(func(i btree.Item) bool {
+		g := i.(*Granule)
+
+		for {
+			least := g.Least()
+			isLess := t.table.config.schema.RowLessThan(row, least)
+			if isLess {
+				if prev != nil {
+					if _, err := prev.AddPart(parts.NewArrowPart(tx, record.NewSlice(ri, ri), t.table.config.schema)); err != nil {
+						ascendErr = err
+						return false
+					}
+					ri++
+					t.table.metrics.numParts.Add(float64(1))
+
+					row, err = pqarrow.RecordToDynamicRow(ps, record, int(ri))
+					if err != nil {
+						if err == io.EOF {
+							exhaustedAllRows = true
+							return false
+						}
+						ascendErr = err
+						return false
+					}
+				}
+			}
+
+			// stop at the first granule where this is not the least
+			// this might be the correct granule, but we need to check that it isn't the next granule
+			prev = g
+			return true // continue btree iteration
+		}
+	})
+	if ascendErr != nil {
+		return ascendErr
+	}
+
+	if !exhaustedAllRows {
+		prev.AddPart(parts.NewArrowPart(tx, record.NewSlice(ri, record.NumRows()), t.table.config.schema))
+		t.table.metrics.numParts.Add(float64(1))
+	}
+
+	return nil
 }
 
 func (t *TableBlock) splitRowsByGranule(buf *dynparquet.SerializedBuffer) (map[*Granule]map[int]struct{}, error) {
@@ -1183,16 +1319,43 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 	// Read all row groups
 	rowGroups := []dynparquet.DynamicRowGroup{}
 
-	rowGroupsChan := make(chan dynparquet.DynamicRowGroup)
+	rowGroupsChan := make(chan any)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	errg := &errgroup.Group{}
+	errg.Go(func() error {
 		for rg := range rowGroupsChan {
-			rowGroups = append(rowGroups, rg)
+			switch p := rg.(type) {
+			case arrow.Record:
+				b := &bytes.Buffer{}
+				w, err := t.table.config.schema.GetWriter(b, pqarrow.RecordDynamicCols(p))
+				if err != nil {
+					return err
+				}
+
+				if err := pqarrow.RecordToFile(t.table.config.schema, w.ParquetWriter(), p); err != nil {
+					return err
+				}
+
+				f, err := parquet.OpenFile(bytes.NewReader(b.Bytes()), int64(b.Len()))
+				if err != nil {
+					return err
+				}
+
+				buf, err := dynparquet.NewSerializedBuffer(f)
+				if err != nil {
+					return err
+				}
+
+				rowGroups = append(rowGroups, buf.MultiDynamicRowGroup())
+
+			case dynparquet.DynamicRowGroup:
+				rowGroups = append(rowGroups, p)
+			default:
+				return fmt.Errorf("unknown part type: %T", p)
+			}
 		}
-		wg.Done()
-	}()
+		return nil
+	})
 
 	// Collect all the row groups just to determine the dynamic cols
 	err := t.RowGroupIterator(ctx, math.MaxUint64, &AlwaysTrueFilter{}, rowGroupsChan)
@@ -1201,7 +1364,9 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 	}
 
 	close(rowGroupsChan)
-	wg.Wait()
+	if err := errg.Wait(); err != nil {
+		return err
+	}
 
 	// Iterate over all the row groups, and write them to storage
 	return t.writeRowGroups(writer, rowGroups)
@@ -1299,7 +1464,7 @@ func (t *Table) collectRowGroups(
 	ctx context.Context,
 	tx uint64,
 	filterExpr logicalplan.Expr,
-	rowGroups chan<- dynparquet.DynamicRowGroup,
+	rowGroups chan<- any,
 ) error {
 	ctx, span := t.tracer.Start(ctx, "Table/collectRowGroups")
 	defer span.End()


### PR DESCRIPTION
This adds support to ingest Arrow records directly into FrostDB. It **does not** deprecate the previous method of ingesting parquet buffers directly. That may be a future PR to deprecate that write path. 

It stores arrow records inside the `Part` object, where a part may now hold either a parquet buffer or an arrow record. 

Things that are **not** implemented in this PR that should be implemented in follow-on PRs:
- WAL support (writing the wal with arrow records is not supported at this time)
- Nested schema support 
- Dictionary arrays. (We want this to reduce the memory overhead of storing arrow records)