### PR TITLE
physicalplan: add partial ordering support do the OrderedAggregate 

### DIFF
--- a/pqarrow/arrowutils/groupranges.go
+++ b/pqarrow/arrowutils/groupranges.go
@@ -1,0 +1,255 @@
+package arrowutils
+
+import (
+	"bytes"
+	"container/heap"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+)
+
+// GetGroupsAndOrderedSetRanges returns a min-heap of group ranges and ordered
+// set ranges of the given arrow arrays in that order. For the given input with
+// a single array:
+// a a c d a b c
+// This function will return [2, 3, 4, 5, 6] for the group ranges and [4] for
+// the ordered set ranges. A group is a collection of values that are equal and
+// an ordered set is a collection of groups that are in increasing order.
+// The ranges are determined by iterating over the arrays and comparing the
+// current group value for each column. The firstGroup to compare against must
+// be provided (it can be initialized to the values at index 0 of each array).
+// The last group found is returned.
+func GetGroupsAndOrderedSetRanges(
+	firstGroup []any, arrs []arrow.Array,
+) (*Int64Heap, *Int64Heap, []any, error) {
+	if len(firstGroup) != len(arrs) {
+		return nil,
+			nil,
+			nil,
+			fmt.Errorf(
+				"columns mismatch (%d != %d) when getting group ranges",
+				len(firstGroup),
+				len(arrs),
+			)
+	}
+
+	// Safe copy the group in order to not overwrite the input slice values.
+	curGroup := make([]any, len(firstGroup))
+	for i, v := range firstGroup {
+		switch concreteV := v.(type) {
+		case []byte:
+			curGroup[i] = append([]byte(nil), concreteV...)
+		default:
+			curGroup[i] = v
+		}
+	}
+
+	// groupRanges keeps track of the bounds of the group by columns.
+	groupRanges := &Int64Heap{}
+	heap.Init(groupRanges)
+	// setRanges keeps track of the bounds of ordered sets. i.e. in the
+	// following slice, (a, a, b, c) is an ordered set of three groups. The
+	// second ordered set is (a, e): [a, a, b, c, a, e]
+	setRanges := &Int64Heap{}
+	heap.Init(setRanges)
+
+	// handleCmpResult is a closure that encapsulates the handling of the result
+	// of comparing a current grouping column with a value in a group array.
+	handleCmpResult := func(cmp, column int, t arrow.Array, j int) error {
+		switch cmp {
+		case -1, 1:
+			// New group, append range index.
+			heap.Push(groupRanges, int64(j))
+			if cmp == 1 {
+				// New ordered set encountered.
+				heap.Push(setRanges, int64(j))
+			}
+
+			// And update the current group.
+			v, err := GetValue(t, j)
+			if err != nil {
+				return err
+			}
+			switch concreteV := v.(type) {
+			case []byte:
+				// Safe copy, otherwise the value might get overwritten.
+				curGroup[column] = append([]byte(nil), concreteV...)
+			default:
+				curGroup[column] = v
+			}
+		case 0:
+			// Equal to group, do nothing.
+		}
+		return nil
+	}
+	for i, arr := range arrs {
+		switch t := arr.(type) {
+		case *array.Binary:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroupValue []byte
+				if curGroup[i] != nil {
+					curGroupValue = curGroup[i].([]byte)
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullComparison(curGroupValue == nil, vIsNull)
+				if !ok {
+					cmp = bytes.Compare(curGroupValue, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, nil, err
+				}
+			}
+		case *array.String:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroupValue *string
+				if curGroup[i] != nil {
+					g := curGroup[i].(string)
+					curGroupValue = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullComparison(curGroupValue == nil, vIsNull)
+				if !ok {
+					cmp = strings.Compare(*curGroupValue, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, nil, err
+				}
+			}
+		case *array.Int64:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroupValue *int64
+				if curGroup[i] != nil {
+					g := curGroup[i].(int64)
+					curGroupValue = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullComparison(curGroupValue == nil, vIsNull)
+				if !ok {
+					cmp = compareInt64(*curGroupValue, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, nil, err
+				}
+			}
+		case *array.Boolean:
+			for j := 0; j < arr.Len(); j++ {
+				var curGroupValue *bool
+				if curGroup[i] != nil {
+					g := curGroup[i].(bool)
+					curGroupValue = &g
+				}
+				vIsNull := t.IsNull(j)
+				cmp, ok := nullComparison(curGroupValue == nil, vIsNull)
+				if !ok {
+					cmp = compareBools(*curGroupValue, t.Value(j))
+				}
+				if err := handleCmpResult(cmp, i, t, j); err != nil {
+					return nil, nil, nil, err
+				}
+			}
+		default:
+			panic("unsupported type")
+		}
+	}
+	return groupRanges, setRanges, curGroup, nil
+}
+
+// nullComparison encapsulates null comparison. leftNull is whether the current
+// Note that this function observes default SQL semantics as well as our own,
+// i.e. nulls sort first.
+// The comparison integer is returned, as well as whether either value was null.
+// If the returned boolean is false, the comparison should be disregarded.
+func nullComparison(leftNull, rightNull bool) (int, bool) {
+	if !leftNull && !rightNull {
+		// Both are null, this implies that the null comparison should be
+		// disregarded.
+		return 0, false
+	}
+
+	if leftNull {
+		if !rightNull {
+			return -1, true
+		}
+		return 0, true
+	}
+	return 1, true
+}
+
+func compareInt64(a, b int64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func compareBools(a, b bool) int {
+	if a == b {
+		return 0
+	}
+
+	if !a {
+		return -1
+	}
+	return 1
+}
+
+type Int64Heap []int64
+
+func (h Int64Heap) Len() int {
+	return len(h)
+}
+
+func (h Int64Heap) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+func (h Int64Heap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *Int64Heap) Push(x any) {
+	*h = append(*h, x.(int64))
+}
+
+func (h *Int64Heap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+// PopNextNotEqual returns the next least element not equal to compare.
+func (h *Int64Heap) PopNextNotEqual(compare int64) (int64, bool) {
+	for h.Len() > 0 {
+		v := heap.Pop(h).(int64)
+		if v != compare {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+// Unwrap unwraps the heap into the provided scratch space. The result is a
+// slice that will have distinct ints in order. This helps with reiterating over
+// the same heap.
+func (h *Int64Heap) Unwrap(scratch []int64) []int64 {
+	scratch = scratch[:0]
+	if h.Len() == 0 {
+		return scratch
+	}
+	cmp := (*h)[0]
+	scratch = append(scratch, cmp)
+	for h.Len() > 0 {
+		if v := heap.Pop(h).(int64); v != cmp {
+			scratch = append(scratch, v)
+			cmp = v
+		}
+	}
+	return scratch
+}

--- a/pqarrow/arrowutils/merge.go
+++ b/pqarrow/arrowutils/merge.go
@@ -102,25 +102,6 @@ func (h cursorHeap) Less(i, j int) bool {
 	return false
 }
 
-// TODO(asubiotto): This is an exact copy of nullGroupComparison the
-// OrderedAggregate uses. Should this be extracted to a comparison package?
-// Nulls sort first.
-func nullComparison(leftNull, rightNull bool) (int, bool) {
-	if !leftNull && !rightNull {
-		// Both are not null, this implies that the null comparison should be
-		// disregarded.
-		return 0, false
-	}
-
-	if leftNull {
-		if !rightNull {
-			return -1, true
-		}
-		return 0, true
-	}
-	return 1, true
-}
-
 func (h cursorHeap) Swap(i, j int) {
 	h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i]
 }

--- a/pqarrow/arrowutils/utils.go
+++ b/pqarrow/arrowutils/utils.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
 )
 
 // GetValue returns the value at index i in arr. If the value is null, nil is
@@ -28,4 +29,28 @@ func GetValue(arr arrow.Array, i int) (any, error) {
 	default:
 		return nil, fmt.Errorf("unsupported type for GetValue %T", a)
 	}
+}
+
+// ArrayConcatenator is an object that helps callers keep track of a slice of
+// arrays and concatenate them into a single one when needed. This is more
+// efficient and memory safe than using a builder.
+type ArrayConcatenator struct {
+	arrs []arrow.Array
+}
+
+func (c *ArrayConcatenator) Add(arr arrow.Array) {
+	c.arrs = append(c.arrs, arr)
+}
+
+func (c *ArrayConcatenator) NewArray(mem memory.Allocator) (arrow.Array, error) {
+	arr, err := array.Concatenate(c.arrs, mem)
+	if err != nil {
+		return nil, err
+	}
+	c.arrs = c.arrs[:0]
+	return arr, err
+}
+
+func (c *ArrayConcatenator) Len() int {
+	return len(c.arrs)
 }

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -1,8 +1,6 @@
 package physicalplan
 
 import (
-	"bytes"
-	"container/heap"
 	"context"
 	"errors"
 	"fmt"
@@ -24,40 +22,82 @@ import (
 // completed once a different aggregation key is found in the ordered stream.
 // OrderedAggregate also supports partially ordered aggregations. This means
 // aggregating on keys that arrive in ordered sets of data that are not mutually
-// exclusive. For example consider the group by columns: a, b, c, a, b, c. The
-// OrderedAggregate will perform the aggregation on the first a, b, c and
-// another one on the second a, b, c. The result of both aggregations is merged.
+// exclusive. For example consider the group by columns: a, a, b, c, a, b, c.
+// The OrderedAggregate will perform the aggregation on the first ordered set
+// a, a, b, c and another one on the second a, b, c. The result of both
+// aggregations is merged. Specifically, if the example is pushed to Callback
+// in two records (a, a, b, c) followed by (a, b, c), and assuming that the
+// aggregation values for each row are 1 for simplicity and we're using a sum
+// aggregation, after the first call to Callback the OrderedAggregate will store
+// [a, b, c], [2, 1, 1] but not emit anything. When the second record is pushed,
+// the OrderedAggregate will realize that the first value in the new record (a)
+// sorts before the "current group" (c), so will store the aggregation results
+// of the second record as another ordered group [a, b, c], [1, 1, 1]. Only when
+// Finish is called, will the OrderedAggregate be able to emit the merged
+// aggregation results. The merged results should be: [a, b, c], [3, 2, 2].
+// TODO(asubiotto): The OrderedAggregate is not yet ready for production use. It
+// doesn't handle dynamic columns very well (i.e. grouping columns appearing and
+// disappearing in input).
 type OrderedAggregate struct {
+	// Fields that are constant throughout execution.
 	pool                  memory.Allocator
 	tracer                trace.Tracer
 	resultColumnName      string
-	groupByCols           map[string]builder.ColumnBuilder
 	groupByColumnMatchers []logicalplan.Expr
-	curGroup              []any
-	columnToAggregate     logicalplan.Expr
 	aggregationFunction   AggregationFunction
 	next                  PhysicalPlan
-	// Indicate is this is the last aggregation or
-	// if this is a aggregation with another aggregation to follow after synchronizing.
+	columnToAggregate     logicalplan.Expr
+	// Indicate is this is the last aggregation or if this is an aggregation
+	// with another aggregation to follow after synchronizing.
 	finalStage bool
 
-	// Buffers that are reused across callback calls.
+	// Buffers that are reused across callback calls. These point to the fields
+	// and arrays in the record passed in to Callback.
 	groupByFields []arrow.Field
 	groupByArrays []arrow.Array
 
-	// arrayToAggCarry is used in cases where there are no new groups found in
-	// a record. In this case, since we cannot know if the group will continue
-	// in the next record, we need to store the data to aggregate to push into
-	// the aggregation function whenever the end of the group is found.
+	// curGroup is used for comparisons against the groupResults found in each
+	// record. It is initialized to the first group of the first record and
+	// updated as new groupResults are found. The key is the field name, as in
+	// groupBuilders below (this will hopefully change once we have static
+	// schemas in the execution engine).
+	curGroup map[string]any
+
+	// groupBuilders is a map from the group by field name to the group column
+	// builders **for the current ordered set**. If a new ordered set is found,
+	// the builders flush the array to groupResults below.
+	groupBuilders map[string]builder.ColumnBuilder
+
+	// groupResults are the group columns. groupResults[i] represents the group
+	// columns of ordered set i.
+	groupResults [][]arrow.Array
+
+	// arrayToAggCarry is used to carry over the values to aggregate for the
+	// last group in a record since we cannot know whether that group continues
+	// in the next record.
 	arrayToAggCarry builder.ColumnBuilder
+
+	// aggResultBuilder is a builder of the aggregation results for the current
+	// ordered set (i.e. each element in this builder is the aggregation result
+	// for one group in the ordered set). When the end of the ordered set is
+	// found, the values in this builder are appended to aggregationResults
+	// below.
+	aggResultBuilder arrowutils.ArrayConcatenator
+
+	// aggregationResults are the results of aggregating the values across
+	// multiple calls to Callback. aggregationResults[i] is the arrow array that
+	// belongs to ordered set i.
+	aggregationResults []arrow.Array
+
+	scratch struct {
+		indexes []int64
+	}
 }
 
 func NewOrderedAggregate(
 	pool memory.Allocator,
 	tracer trace.Tracer,
-	resultColumnName string,
-	aggregationFunction AggregationFunction,
-	columnToAggregate logicalplan.Expr,
+	aggregation Aggregation,
 	groupByColumnMatchers []logicalplan.Expr,
 	finalStage bool,
 ) *OrderedAggregate {
@@ -68,17 +108,20 @@ func NewOrderedAggregate(
 	return &OrderedAggregate{
 		pool:              pool,
 		tracer:            tracer,
-		resultColumnName:  resultColumnName,
-		groupByCols:       make(map[string]builder.ColumnBuilder),
-		columnToAggregate: columnToAggregate,
+		resultColumnName:  aggregation.resultName,
+		columnToAggregate: aggregation.expr,
 		// TODO: Matchers can be optimized to be something like a radix tree or
 		// just a fast-lookup datastructure for exact matches or prefix matches.
 		groupByColumnMatchers: groupByColumnMatchers,
-		aggregationFunction:   aggregationFunction,
+		aggregationFunction:   aggregation.function,
 		finalStage:            finalStage,
 
 		groupByFields: make([]arrow.Field, 0, 10),
 		groupByArrays: make([]arrow.Array, 0, 10),
+
+		groupBuilders: make(map[string]builder.ColumnBuilder),
+
+		aggregationResults: make([]arrow.Array, 0, 1),
 	}
 }
 
@@ -97,11 +140,15 @@ func (a *OrderedAggregate) Draw() *Diagram {
 		groupings = append(groupings, grouping.Name())
 	}
 
-	details := fmt.Sprintf("OrderedAggregate (%s by %s)", a.columnToAggregate.Name(), strings.Join(groupings, ","))
+	details := fmt.Sprintf(
+		"OrderedAggregate (%s by %s)",
+		a.columnToAggregate.Name(),
+		strings.Join(groupings, ","),
+	)
 	return &Diagram{Details: details, Child: child}
 }
 
-func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
+func (a *OrderedAggregate) Callback(_ context.Context, r arrow.Record) error {
 	// Generates high volume of spans. Comment out if needed during development.
 	// ctx, span := a.tracer.Start(ctx, "OrderedAggregate/Callback")
 	// defer span.End()
@@ -116,11 +163,7 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 			if matcher.MatchColumn(field.Name) {
 				a.groupByFields = append(a.groupByFields, field)
 				a.groupByArrays = append(a.groupByArrays, r.Column(i))
-				a.curGroup = append(a.curGroup, nil)
 			}
-			// TODO(asubiotto): To have a 1:1 groupByArrays to fields match,
-			// we might be able to flip the search around and have a virtual
-			// null column for group by's that aren't found.
 		}
 
 		if a.columnToAggregate.MatchColumn(field.Name) {
@@ -132,6 +175,21 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 		}
 	}
 
+	firstCall := a.curGroup == nil
+	// curGroup is a slice that holds the group values for an index of the
+	// groupByFields it is done so that we can access group values without
+	// hashing by the field name.
+	curGroup := make([]any, len(a.groupByFields))
+	if !firstCall {
+		// This is not the first call to callback. Initialize curGroup to the
+		// values stored in the curGroup map.
+		for i, f := range a.groupByFields {
+			curGroup[i] = a.curGroup[f.Name]
+		}
+	} else {
+		a.curGroup = make(map[string]any, len(a.groupByFields))
+	}
+
 	if !aggregateFieldFound {
 		return errors.New("aggregate field not found, aggregations are not possible without it")
 	}
@@ -139,83 +197,150 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 	// TODO(asubiotto): Explore a static schema in the execution engine, all
 	// this should be initialization code.
 	for i, field := range a.groupByFields {
-		if _, ok := a.groupByCols[field.Name]; !ok {
+		if _, ok := a.groupBuilders[field.Name]; !ok {
 			b := builder.NewBuilder(a.pool, field.Type)
-			a.groupByCols[field.Name] = b
-			// Append the first group value to use below.
-			v, err := arrowutils.GetValue(a.groupByArrays[i], 0)
-			if err != nil {
-				return err
+			a.groupBuilders[field.Name] = b
+			if firstCall {
+				// Append the first group value to use below.
+				v, err := arrowutils.GetValue(a.groupByArrays[i], 0)
+				if err != nil {
+					return err
+				}
+				switch concreteV := v.(type) {
+				case []byte:
+					// Safe copy.
+					a.curGroup[field.Name] = append([]byte(nil), concreteV...)
+				default:
+					a.curGroup[field.Name] = v
+				}
+				curGroup[i] = v
 			}
-			a.curGroup[i] = v
 		}
 	}
 
-	groupRanges, setRanges, err := a.getGroupsAndOrderedSetRanges()
+	groupRanges, wrappedSetRanges, lastGroup, err := arrowutils.GetGroupsAndOrderedSetRanges(
+		curGroup,
+		a.groupByArrays,
+	)
 	if err != nil {
 		return err
 	}
+	// Don't update curGroup to lastGroup yet, given that the end of the
+	// curGroup from the last record might have been found at the zeroth index
+	// and we need to know what values to append to the group builders.
+	defer func() {
+		for i, v := range lastGroup {
+			a.curGroup[a.groupByFields[i].Name] = v
+		}
+	}()
 
-	if setRanges.Len() > 0 {
-		panic("ordered sets not yet implemented")
-	}
+	setRanges := wrappedSetRanges.Unwrap(a.scratch.indexes)
 
 	// Aggregate the values for all groups found.
 	arraysToAggregate := make([]arrow.Array, 0, groupRanges.Len())
-	groupStart := int64(0)
-	for {
-		groupEnd, groupOk := popNextNotEqual(groupRanges, groupStart)
+
+	// arraysToAggregateSetIdxs keeps track of the idxs in arraysToAggregate
+	// that represent new ordered sets. This is essentially a "conversion" of
+	// the setRanges which refer to ranges of individual values in the input
+	// record while arraysToAggregateSetIdxs refer to ranges of groups.
+	var arraysToAggregateSetIdxs []int64
+	for groupStart, setCursor := int64(-1), 0; ; {
+		groupEnd, groupOk := groupRanges.PopNextNotEqual(groupStart)
+		// groupStart is initialized to -1 to not ignore groupEnd == 0, after
+		// the first pop, it should now be set to 0.
+		if groupStart == -1 {
+			groupStart = 0
+		}
 		if !groupOk {
 			// All groups have been processed.
+			// The values corresponding to the last group need to be carried
+			// over to the next aggregation since we can't determine that the
+			// last group is closed until we know the first value of the next
+			// record passed to Callback.
+			// Note that the current group values should already be set in
+			// a.curGroup.
+			// TODO(asubiotto): We don't handle NULL values in aggregation
+			// columns in aggregation functions so disregard them here as well
+			// for now. We should eventually care about this.
+			// TODO(asubiotto): Instead of doing this copy, what would the
+			// performance difference be if we just merged the aggregation?
+			if err := builder.AppendArray(
+				a.arrayToAggCarry,
+				array.NewSlice(columnToAggregate, groupStart, int64(columnToAggregate.Len())),
+			); err != nil {
+				return err
+			}
 			break
 		}
 
 		// Append the values to aggregate.
-		toAgg := array.NewSlice(columnToAggregate, groupStart, groupEnd)
-		if a.arrayToAggCarry.Len() > 0 {
-			if err := builder.AppendArray(a.arrayToAggCarry, toAgg); err != nil {
-				return err
-			}
+		var toAgg arrow.Array
+		if groupEnd == 0 {
+			// End of the group found in the last record, the only data to
+			// aggregate was carried over.
 			toAgg = a.arrayToAggCarry.NewArray()
+		} else {
+			toAgg = array.NewSlice(columnToAggregate, groupStart, groupEnd)
+			if a.arrayToAggCarry.Len() > 0 {
+				if err := builder.AppendArray(a.arrayToAggCarry, toAgg); err != nil {
+					return err
+				}
+				toAgg = a.arrayToAggCarry.NewArray()
+			}
 		}
 		arraysToAggregate = append(arraysToAggregate, toAgg)
 
+		// Here's a way to try out to solve th logic: Instead of consifering a new
+		// ordered set the current group, we could check groupEnd == setRanges
+		// This should indicate that the current group is the last one of the
+		// ordered set. This means that we would basically append to builders
+		// and then if newOrderedSet, we will flush to group results
+		//
+
 		// Append the groups.
+		newOrderedSet := false
+		if len(setRanges) > 0 && setCursor < len(setRanges) && setRanges[setCursor] == groupEnd {
+			setCursor++
+			newOrderedSet = true
+			arraysToAggregateSetIdxs = append(arraysToAggregateSetIdxs, int64(len(arraysToAggregate)))
+		}
 		for i, field := range a.groupByFields {
 			var (
 				v   any
 				err error
 			)
-			if v, err = arrowutils.GetValue(a.groupByArrays[i], int(groupStart)); err != nil {
-				return err
+			if groupEnd == 0 {
+				// End of the current group of the last record.
+				v = a.curGroup[field.Name]
+			} else {
+				if v, err = arrowutils.GetValue(a.groupByArrays[i], int(groupStart)); err != nil {
+					return err
+				}
 			}
 			if err := builder.AppendGoValue(
-				a.groupByCols[field.Name],
+				a.groupBuilders[field.Name],
 				v,
 			); err != nil {
 				return err
+			}
+
+			if newOrderedSet {
+				// This group is the last one of the current ordered set. Flush
+				// it to the results. The corresponding aggregation results are
+				// flushed in a loop below.
+				a.groupResults = append(a.groupResults, nil)
+				n := len(a.groupResults) - 1
+				for _, field := range a.groupByFields {
+					a.groupResults[n] = append(a.groupResults[n], a.groupBuilders[field.Name].NewArray())
+				}
 			}
 		}
 
 		groupStart = groupEnd
 	}
 
-	// The values corresponding to the last group need to be carried over to the
-	// next aggregation since we can't determine that the last group is closed
-	// until we know the first value of the next record passed to Callback.
-	// Note that the current group values should already be set in a.curGroup.
-	// TODO(asubiotto): We don't handle NULL values in aggregation columns
-	// in aggregation functions so disregard them here as well for now. We
-	// should eventually care about this.
-	if err := builder.AppendArray(
-		a.arrayToAggCarry,
-		array.NewSlice(columnToAggregate, groupStart, int64(columnToAggregate.Len())),
-	); err != nil {
-		return err
-	}
-
 	if len(arraysToAggregate) == 0 {
-		// No new groups were found, carry on.
+		// No new groups or sets were found, carry on.
 		return nil
 	}
 
@@ -224,7 +349,30 @@ func (a *OrderedAggregate) Callback(ctx context.Context, r arrow.Record) error {
 		return err
 	}
 
-	return a.flushToNext(ctx, results)
+	// Supporting partial ordering implies the need to accumulate all the
+	// results since any group might reoccur at any point in future records.
+	// If we can determine that the ordering is global at plan time, we could
+	// directly flush the results.
+	setStart := int64(0)
+	for _, setEnd := range arraysToAggregateSetIdxs {
+		set := array.NewSlice(results, setStart, setEnd)
+		if a.aggResultBuilder.Len() > 0 {
+			// This is the end of an ordered set that started in the last
+			// record.
+			a.aggResultBuilder.Add(set)
+			var err error
+			set, err = a.aggResultBuilder.NewArray(a.pool)
+			if err != nil {
+				return err
+			}
+		}
+		a.aggregationResults = append(a.aggregationResults, set)
+		setStart = setEnd
+	}
+	// The last ordered set cannot be determined to close within this
+	// record, so carry it over.
+	a.aggResultBuilder.Add(array.NewSlice(results, setStart, int64(results.Len())))
+	return nil
 }
 
 func (a *OrderedAggregate) Finish(ctx context.Context) error {
@@ -233,13 +381,16 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 
 	if a.arrayToAggCarry.Len() > 0 {
 		// Aggregate the last group.
-		for i, field := range a.groupByFields {
-			b := a.groupByCols[field.Name]
+		a.groupResults = append(a.groupResults, nil)
+		n := len(a.groupResults) - 1
+		for _, field := range a.groupByFields {
+			b := a.groupBuilders[field.Name]
 			if err := builder.AppendGoValue(
-				b, a.curGroup[i],
+				b, a.curGroup[field.Name],
 			); err != nil {
 				return err
 			}
+			a.groupResults[n] = append(a.groupResults[n], b.NewArray())
 		}
 
 		results, err := a.aggregationFunction.Aggregate(
@@ -250,7 +401,117 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 			return err
 		}
 
-		if err := a.flushToNext(ctx, results); err != nil {
+		var lastResults arrow.Array
+		if a.aggResultBuilder.Len() > 0 {
+			// Append the results to the last ordered set.
+			a.aggResultBuilder.Add(results)
+			var err error
+			lastResults, err = a.aggResultBuilder.NewArray(a.pool)
+			if err != nil {
+				return err
+			}
+		} else {
+			lastResults = results
+		}
+		a.aggregationResults = append(a.aggregationResults, lastResults)
+	}
+
+	schema := arrow.NewSchema(
+		append(
+			a.groupByFields,
+			arrow.Field{Name: a.getResultColumnName(), Type: a.aggregationResults[0].DataType()},
+		),
+		nil,
+	)
+
+	records := make([]arrow.Record, 0, len(a.groupResults))
+	for i := range a.groupResults {
+		records = append(
+			records,
+			array.NewRecord(
+				schema,
+				append(
+					a.groupResults[i],
+					a.aggregationResults[i],
+				),
+				int64(a.aggregationResults[i].Len()),
+			),
+		)
+	}
+
+	if len(records) == 1 {
+		// TODO(asubiotto): This can probably be simplified (i.e. have a record
+		// var that is set either to records[0] or the merged records.
+		if err := a.next.Callback(ctx, records[0]); err != nil {
+			return err
+		}
+	} else {
+		// The aggregation results must be merged.
+		orderByCols := make([]int, len(a.groupByFields))
+		for i := range orderByCols {
+			orderByCols[i] = i
+		}
+		mergedRecord, err := arrowutils.MergeRecords(a.pool, records, orderByCols)
+		if err != nil {
+			return err
+		}
+		firstGroup := make([]any, len(a.groupByFields))
+		groupArrs := mergedRecord.Columns()[:len(a.groupByFields)]
+		for i, arr := range groupArrs {
+			v, err := arrowutils.GetValue(arr, 0)
+			if err != nil {
+				return err
+			}
+			firstGroup[i] = v
+		}
+		wrappedGroupRanges, _, _, err := arrowutils.GetGroupsAndOrderedSetRanges(firstGroup, groupArrs)
+		if err != nil {
+			return err
+		}
+		groupRanges := wrappedGroupRanges.Unwrap(a.scratch.indexes)
+		// Close the last range to iterate over all groupResults.
+		groupRanges = append(groupRanges, mergedRecord.NumRows())
+
+		// For better performance, the result is built a column at a time.
+		for i, field := range a.groupByFields {
+			start := int64(0)
+			for _, end := range groupRanges {
+				if err := builder.AppendValue(
+					a.groupBuilders[field.Name], mergedRecord.Column(i), int(start),
+				); err != nil {
+					return err
+				}
+				start = end
+			}
+		}
+
+		// The array of aggregation values is the first column index after the
+		// group fields.
+		aggregationVals := mergedRecord.Columns()[len(a.groupByFields)]
+		start := int64(0)
+		toAggregate := make([]arrow.Array, 0, len(groupRanges))
+		for _, end := range groupRanges {
+			toAggregate = append(toAggregate, array.NewSlice(aggregationVals, start, end))
+			start = end
+		}
+
+		result, err := runAggregation(true, a.aggregationFunction, a.pool, toAggregate)
+		if err != nil {
+			return err
+		}
+
+		groups := make([]arrow.Array, 0, len(a.groupBuilders))
+		for _, field := range a.groupByFields {
+			groups = append(groups, a.groupBuilders[field.Name].NewArray())
+		}
+		if err := a.next.Callback(
+			ctx,
+			array.NewRecord(
+				schema,
+				append(groups, result),
+				int64(result.Len()),
+			),
+		); err != nil {
 			return err
 		}
 	}
@@ -258,215 +519,10 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 	return a.next.Finish(ctx)
 }
 
-func (a *OrderedAggregate) flushToNext(ctx context.Context, results arrow.Array) error {
-	groups := make([]arrow.Array, 0, len(a.groupByCols))
-	for _, v := range a.groupByCols {
-		groups = append(groups, v.NewArray())
-	}
-
+func (a *OrderedAggregate) getResultColumnName() string {
 	fieldName := a.columnToAggregate.Name()
 	if a.finalStage {
 		fieldName = a.resultColumnName
 	}
-
-	nrows := int64(results.Len())
-	return a.next.Callback(ctx, array.NewRecord(
-		arrow.NewSchema(
-			append(
-				a.groupByFields,
-				arrow.Field{Name: fieldName, Type: results.DataType()},
-			),
-			nil,
-		),
-		append(groups, results),
-		nrows,
-	))
-}
-
-// getGroupsAndOrderedSetRanges returns a min-heap of group ranges and ordered
-// set ranges in that order. The ranges are determined by iterating over the
-// group by arrays and comparing to the current group value for each column.
-func (a *OrderedAggregate) getGroupsAndOrderedSetRanges() (*int64Heap, *int64Heap, error) {
-	// groupRanges keeps track of the bounds of the group by columns.
-	groupRanges := &int64Heap{}
-	heap.Init(groupRanges)
-	// setRanges keeps track of the bounds of ordered sets. i.e. in the
-	// following slice, (a, a, b, c) is an ordered set of three groups. The
-	// second ordered set is (a, e): [a, a, b, c, a, e]
-	setRanges := &int64Heap{}
-	heap.Init(setRanges)
-
-	// handleCmpResult is a closure that encapsulates the handling of the result
-	// of comparing a current grouping column with a value in a group array.
-	handleCmpResult := func(cmp, column int, t arrow.Array, j int) error {
-		switch cmp {
-		case -1:
-			// New group, append range index.
-			heap.Push(groupRanges, int64(j))
-
-			// And update the current group.
-			v, err := arrowutils.GetValue(t, j)
-			if err != nil {
-				return err
-			}
-			a.curGroup[column] = v
-		case 0:
-			// Equal to group, do nothing.
-		case 1:
-			// New ordered set encountered.
-			heap.Push(setRanges, int64(j))
-			heap.Push(groupRanges, int64(j))
-		}
-		return nil
-	}
-	for i, arr := range a.groupByArrays {
-		switch t := arr.(type) {
-		case *array.Binary:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup []byte
-				if a.curGroup[i] != nil {
-					curGroup = a.curGroup[i].([]byte)
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = bytes.Compare(curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return nil, nil, err
-				}
-			}
-		case *array.String:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *string
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(string)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = strings.Compare(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return nil, nil, err
-				}
-			}
-		case *array.Int64:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *int64
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(int64)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = compareInt64(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return nil, nil, err
-				}
-			}
-		case *array.Boolean:
-			for j := 0; j < arr.Len(); j++ {
-				var curGroup *bool
-				if a.curGroup[i] != nil {
-					g := a.curGroup[i].(bool)
-					curGroup = &g
-				}
-				vIsNull := t.IsNull(j)
-				cmp, ok := nullGroupComparison(curGroup == nil, vIsNull)
-				if !ok {
-					cmp = compareBools(*curGroup, t.Value(j))
-				}
-				if err := handleCmpResult(cmp, i, t, j); err != nil {
-					return nil, nil, err
-				}
-			}
-		default:
-			panic("unsupported type")
-		}
-	}
-	return groupRanges, setRanges, nil
-}
-
-// nullComparison encapsulates null comparison when scanning groups in the
-// ordered aggregator. leftNull is whether the current group is null, and
-// rightNull is whether the value we're comparing against is null. Note that
-// this function observes default SQL semantics as well as our own, i.e. nulls
-// sort first.
-// The comparison integer is returned, as well as whether either value was null.
-// If the returned boolean is false, the comparison should be disregarded.
-func nullGroupComparison(leftNull, rightNull bool) (int, bool) {
-	if !leftNull && !rightNull {
-		// Both are null, this implies that the null comparison should be
-		// disregarded.
-		return 0, false
-	}
-
-	if leftNull {
-		if !rightNull {
-			return -1, true
-		}
-		return 0, true
-	}
-	return 1, true
-}
-
-func compareInt64(a, b int64) int {
-	if a < b {
-		return -1
-	}
-	if a > b {
-		return 1
-	}
-	return 0
-}
-
-func compareBools(a, b bool) int {
-	if a == b {
-		return 0
-	}
-
-	if !a {
-		return -1
-	}
-	return 1
-}
-
-type int64Heap []int64
-
-func (h int64Heap) Len() int {
-	return len(h)
-}
-
-func (h int64Heap) Less(i, j int) bool {
-	return h[i] < h[j]
-}
-
-func (h int64Heap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-}
-
-func (h *int64Heap) Push(x any) {
-	*h = append(*h, x.(int64))
-}
-
-func (h *int64Heap) Pop() any {
-	old := *h
-	n := len(old)
-	x := old[n-1]
-	*h = old[0 : n-1]
-	return x
-}
-
-func popNextNotEqual(h *int64Heap, compare int64) (int64, bool) {
-	for h.Len() > 0 {
-		v := heap.Pop(h).(int64)
-		if v != compare {
-			return v, true
-		}
-	}
-	return 0, false
+	return fieldName
 }


### PR DESCRIPTION
This PR adds the missing partial ordering support to the OrderedAggregate.
Instead of returning a record on each call to Callback as was previously done,
the OrderedAggregate now buffers the aggregation results and groups for each
ordered set and then merges the results on Finish.

A bunch of incidental bugfixes and test flake fixes have also been included. The first couple of commits also introduce some helper code used by the last (main) commit.

Closes #287 

The ordered aggregate is still not ready for production usage since it doesn't handle columns appearing/disappearing from the input. However, I want to take a different approach (starting down the static schema route I mentioned) to solve this, so would rather merge a complete working version (at least from the unit test perspective) of the OrderedAggregate before working on these edge cases.

In terms of performance difference, as expected, the OrderedAggregate doesn't perform much better than the HashAggregate for QueryMerge (it provides a small 3% perf improvement) given the large number of groups and the new requirement that all data must be buffered in order to merge partially ordered sets. This is expected, and there are some performance angles that can be worked on to improve this (e.g. plan time settings, reducing unnecessary allocations).