### PR TITLE
physicalplan: add OrderedSynchronizer

### DIFF
--- a/query/physicalplan/main_test.go
+++ b/query/physicalplan/main_test.go
@@ -1,0 +1,12 @@
+package physicalplan
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain runs all the tests in this package with a goroutine leak detector.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/query/physicalplan/ordered_synchronizer.go
+++ b/query/physicalplan/ordered_synchronizer.go
@@ -1,1 +1,103 @@
 package physicalplan
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
+)
+
+// OrderedSynchronizer implements synchronizing ordered input from multiple
+// goroutines. The strategy used is that any input that calls Callback must wait
+// for all the other inputs to call Callback, since an ordered result cannot
+// be produced until all inputs have pushed data. Another strategy would be to
+// store the pushed records, but that requires fully copying all the data for
+// safety.
+type OrderedSynchronizer struct {
+	pool        memory.Allocator
+	inputs      int
+	orderByCols []int
+	running     atomic.Int64
+
+	records struct {
+		mtx  sync.Mutex
+		data []arrow.Record
+	}
+	wait chan struct{}
+	// pendingInputs is the number of inputs that are yet to call Callback.
+	pendingInputs atomic.Int64
+	next          PhysicalPlan
+}
+
+func NewOrderedSynchronizer(pool memory.Allocator, inputs int, orderByCols []int) *OrderedSynchronizer {
+	o := &OrderedSynchronizer{
+		pool:        pool,
+		inputs:      inputs,
+		orderByCols: orderByCols,
+		wait:        make(chan struct{}),
+	}
+	o.running.Add(int64(inputs))
+	o.pendingInputs.Add(int64(inputs))
+	return o
+}
+
+func (o *OrderedSynchronizer) Callback(ctx context.Context, r arrow.Record) error {
+	o.records.mtx.Lock()
+	o.records.data = append(o.records.data, r)
+	o.records.mtx.Unlock()
+
+	if o.pendingInputs.Add(-1) != 0 {
+		select {
+		case <-o.wait:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// This is the last input to call Callback, merge the records.
+	o.records.mtx.Lock()
+	defer o.records.mtx.Unlock()
+	mergedRecord, err := arrowutils.MergeRecords(o.pool, o.records.data, o.orderByCols)
+	if err != nil {
+		return err
+	}
+	// Now that the records have been merged, we can wake up the other input
+	// goroutines. Since we have exactly o.inputs-1 waiting on the
+	// channel, send the corresponding number of messages. Since we are also
+	// holding the records mutex during this broadcast, fast inputs won't be
+	// able to re-enter Callback until the mutex is released, so won't
+	// mistakenly read another input's signal.
+	for i := 0; i < o.inputs-1; i++ {
+		o.wait <- struct{}{}
+	}
+	// Reset pendingInputs.
+	o.pendingInputs.Store(int64(o.inputs))
+	o.records.data = o.records.data[:0]
+
+	return o.next.Callback(ctx, mergedRecord)
+}
+
+func (o *OrderedSynchronizer) Finish(ctx context.Context) error {
+	running := o.running.Add(-1)
+	if running < 0 {
+		return errors.New("too many OrderedSynchronizer Finish calls")
+	}
+	if running > 0 {
+		return nil
+	}
+	return o.next.Finish(ctx)
+}
+
+func (o *OrderedSynchronizer) SetNext(next PhysicalPlan) {
+	o.next = next
+}
+
+func (o *OrderedSynchronizer) Draw() *Diagram {
+	return &Diagram{}
+}

--- a/query/physicalplan/ordered_synchronizer.go
+++ b/query/physicalplan/ordered_synchronizer.go
@@ -1,0 +1,1 @@
+package physicalplan

--- a/query/physicalplan/ordered_synchronizer_test.go
+++ b/query/physicalplan/ordered_synchronizer_test.go
@@ -1,1 +1,76 @@
 package physicalplan
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
+	"github.com/apache/arrow/go/v8/arrow/memory"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/polarsignals/frostdb/pqarrow/builder"
+)
+
+func TestOrderedSynchronizer(t *testing.T) {
+	var (
+		sourceMtx    sync.Mutex
+		sourceCursor atomic.Int64
+	)
+	source := make([]int64, 10000)
+	for i := range source {
+		source[i] = int64(i)
+	}
+	// Initialize sourceCursor to -1 so that the first increment is 0.
+	sourceCursor.Store(-1)
+	const inputs = 8
+	osync := NewOrderedSynchronizer(memory.DefaultAllocator, inputs, []int{0})
+	expected := int64(0)
+	osync.SetNext(&OutputPlan{
+		callback: func(_ context.Context, r arrow.Record) error {
+			// This is where the result records will be pushed.
+			arr := r.Column(0).(*array.Int64)
+			for i := 0; i < arr.Len(); i++ {
+				require.Equal(t, expected, arr.Value(i))
+				expected++
+			}
+			return nil
+		},
+	})
+	ctx := context.Background()
+	var errg errgroup.Group
+	for i := 0; i < inputs; i++ {
+		errg.Go(func() error {
+			b := builder.NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
+			for {
+				cursor := sourceCursor.Add(1)
+				if int(cursor) >= len(source) {
+					break
+				}
+				sourceMtx.Lock()
+				b.Append(source[cursor])
+				sourceMtx.Unlock()
+				arr := b.NewArray()
+				if err := osync.Callback(
+					ctx,
+					array.NewRecord(
+						arrow.NewSchema(
+							[]arrow.Field{{Type: arr.DataType()}}, nil,
+						),
+						[]arrow.Array{arr},
+						1,
+					),
+				); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	require.NoError(t, errg.Wait())
+	// This last check verifies that we read all data.
+	require.Equal(t, int(expected), len(source))
+}

--- a/query/physicalplan/ordered_synchronizer_test.go
+++ b/query/physicalplan/ordered_synchronizer_test.go
@@ -1,0 +1,1 @@
+package physicalplan


### PR DESCRIPTION
This commit adds an OrderedSynchronizer component that merges ordered records
pushed from many concurrent inputs and pushes the merged record to a single
output.

The strategy this commit implements is to block the inputs until all inputs
have pushed a record. This is the most straightforward strategy since the other
option is to store the pushed records, but that requires copying all data which
might be more expensive.