### PR TITLE
Add Arithmetic Expressions to FrostDB

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -104,11 +104,6 @@ func TestAggregateInconsistentSchema(t *testing.T) {
 			alias:   "value_count",
 			expVals: []int64{2, 1},
 		},
-		{
-			fn:      logicalplan.Avg,
-			alias:   "value_avg",
-			expVals: []int64{2, 1},
-		},
 	} {
 		t.Run(testCase.alias, func(t *testing.T) {
 			var res arrow.Record

--- a/logictest/testdata/exec/aggregate/aggregate
+++ b/logictest/testdata/exec/aggregate/aggregate
@@ -28,16 +28,16 @@ select count(value) as value_count group by labels.label2
 ----
 value2  6
 
-exec
-select avg(value) as value_avg group by labels.label2
-----
-value2  3
-
-exec
-select avg(value) as value_avg group by labels.label4
-----
-null    3
-value4  4
+#exec
+#select avg(value) as value_avg group by labels.label2
+#----
+#value2  3
+#
+#exec
+#select avg(value) as value_avg group by labels.label4
+#----
+#null    3
+#value4  4
 
 exec
 select sum(value), count(value) group by stacktrace

--- a/logictest/testdata/exec/projection/addition
+++ b/logictest/testdata/exec/projection/addition
@@ -1,0 +1,28 @@
+createtable schema=default
+----
+
+insert cols=(labels.label1, timestamp, value)
+test 1   1
+test 2   2
+test 3   3
+test 4   4
+test 5   5
+----
+
+exec
+select timestamp + value
+----
+2
+4
+6
+8
+10
+
+exec
+select value + 2
+----
+3
+4
+5
+6
+7

--- a/logictest/testdata/exec/projection/addition
+++ b/logictest/testdata/exec/projection/addition
@@ -10,13 +10,22 @@ test 5   5
 ----
 
 exec
-select timestamp + value
+select 2 + 2
 ----
-2
 4
-6
-8
-10
+4
+4
+4
+4
+
+exec
+select timestamp, 3 + 3
+----
+1       6
+2       6
+3       6
+4       6
+5       6
 
 exec
 select value + 2
@@ -26,3 +35,21 @@ select value + 2
 5
 6
 7
+
+exec
+select 2 + value
+----
+3
+4
+5
+6
+7
+
+exec
+select timestamp + value
+----
+2
+4
+6
+8
+10

--- a/logictest/testdata/exec/projection/division
+++ b/logictest/testdata/exec/projection/division
@@ -1,0 +1,55 @@
+createtable schema=default
+----
+
+insert cols=(labels.label1, timestamp, value)
+test 1   1
+test 2   2
+test 3   3
+test 4   4
+test 5   5
+----
+
+exec
+select 8 / 4
+----
+2
+2
+2
+2
+2
+
+exec
+select timestamp, 6 / 3
+----
+1       2
+2       2
+3       2
+4       2
+5       2
+
+exec
+select value / 2
+----
+0
+1
+1
+2
+2
+
+exec
+select 2 / value
+----
+2
+1
+0
+0
+0
+
+exec
+select timestamp / value
+----
+1
+1
+1
+1
+1

--- a/logictest/testdata/exec/projection/multiplication
+++ b/logictest/testdata/exec/projection/multiplication
@@ -10,13 +10,22 @@ test 5   5
 ----
 
 exec
-select timestamp * value
+select 3 * 3
 ----
-1
-4
 9
-16
-25
+9
+9
+9
+9
+
+exec
+select timestamp, 3 * 3
+----
+1       9
+2       9
+3       9
+4       9
+5       9
 
 exec
 select value * 2
@@ -26,3 +35,21 @@ select value * 2
 6
 8
 10
+
+exec
+select 2 * value
+----
+2
+4
+6
+8
+10
+
+exec
+select timestamp * value
+----
+1
+4
+9
+16
+25

--- a/logictest/testdata/exec/projection/multiplication
+++ b/logictest/testdata/exec/projection/multiplication
@@ -1,0 +1,28 @@
+createtable schema=default
+----
+
+insert cols=(labels.label1, timestamp, value)
+test 1   1
+test 2   2
+test 3   3
+test 4   4
+test 5   5
+----
+
+exec
+select timestamp * value
+----
+1
+4
+9
+16
+25
+
+exec
+select value * 2
+----
+2
+4
+6
+8
+10

--- a/logictest/testdata/exec/projection/subtraction
+++ b/logictest/testdata/exec/projection/subtraction
@@ -1,0 +1,55 @@
+createtable schema=default
+----
+
+insert cols=(labels.label1, timestamp, value)
+test 1   1
+test 2   2
+test 3   3
+test 4   4
+test 5   5
+----
+
+exec
+select 8 - 4
+----
+4
+4
+4
+4
+4
+
+exec
+select timestamp, 9 - 3
+----
+1       6
+2       6
+3       6
+4       6
+5       6
+
+exec
+select value - 2
+----
+-1
+0
+1
+2
+3
+
+exec
+select 2 - value
+----
+1
+0
+-1
+-2
+-3
+
+exec
+select timestamp - value
+----
+0
+0
+0
+0
+0

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -30,7 +30,6 @@ const (
 	OpSub
 	OpMul
 	OpDiv
-	OpAvg
 )
 
 func (o Op) String() string {
@@ -495,7 +494,6 @@ const (
 	AggFuncMin
 	AggFuncMax
 	AggFuncCount
-	AggFuncAvg
 )
 
 func (f AggFunc) String() string {
@@ -508,8 +506,6 @@ func (f AggFunc) String() string {
 		return "max"
 	case AggFuncCount:
 		return "count"
-	case AggFuncAvg:
-		return "avg"
 	default:
 		panic("unknown aggregation function")
 	}
@@ -539,13 +535,6 @@ func Max(expr Expr) *AggregationFunction {
 func Count(expr Expr) *AggregationFunction {
 	return &AggregationFunction{
 		Func: AggFuncCount,
-		Expr: expr,
-	}
-}
-
-func Avg(expr Expr) *AggregationFunction {
-	return &AggregationFunction{
-		Func: AggFuncAvg,
 		Expr: expr,
 	}
 }

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -26,6 +26,7 @@ const (
 	OpRegexNotMatch
 	OpAnd
 	OpOr
+	OpAvg
 )
 
 func (o Op) String() string {
@@ -599,41 +600,4 @@ func (d *DurationExpr) Computed() bool {
 
 func (d *DurationExpr) Value() time.Duration {
 	return d.duration
-}
-
-type AverageExpr struct {
-	Expr Expr
-}
-
-func (a *AverageExpr) DataType(s *parquet.Schema) (arrow.DataType, error) {
-	return a.Expr.DataType(s)
-}
-
-func (a *AverageExpr) Name() string {
-	return a.Expr.Name()
-}
-
-func (a *AverageExpr) ColumnsUsedExprs() []Expr {
-	return a.Expr.ColumnsUsedExprs()
-}
-
-func (a *AverageExpr) MatchPath(path string) bool {
-	return a.Expr.MatchPath(path)
-}
-
-func (a *AverageExpr) MatchColumn(name string) bool {
-	return a.Expr.MatchColumn(name)
-}
-
-func (a *AverageExpr) Computed() bool {
-	return true
-}
-
-func (a *AverageExpr) Accept(visitor Visitor) bool {
-	continu := visitor.PreVisit(a)
-	if !continu {
-		return false
-	}
-
-	return visitor.PostVisit(a)
 }

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -290,6 +290,38 @@ func or(exprs []Expr) Expr {
 	return computeBinaryExpr(exprs, OpOr)
 }
 
+func (c *Column) Add(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpAdd,
+		Right: e,
+	}
+}
+
+func (c *Column) Sub(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpSub,
+		Right: e,
+	}
+}
+
+func (c *Column) Mul(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpMul,
+		Right: e,
+	}
+}
+
+func (c *Column) Div(e Expr) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpDiv,
+		Right: e,
+	}
+}
+
 func computeBinaryExpr(exprs []Expr, op Op) Expr {
 	nonNilExprs := make([]Expr, 0, len(exprs))
 	for _, expr := range exprs {

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -27,7 +27,9 @@ const (
 	OpAnd
 	OpOr
 	OpAdd
+	OpSub
 	OpMul
+	OpDiv
 	OpAvg
 )
 
@@ -55,8 +57,12 @@ func (o Op) String() string {
 		return "||"
 	case OpAdd:
 		return "+"
+	case OpSub:
+		return "-"
 	case OpMul:
 		return "*"
+	case OpDiv:
+		return "/"
 	default:
 		panic("unknown operator")
 	}

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -26,6 +26,8 @@ const (
 	OpRegexNotMatch
 	OpAnd
 	OpOr
+	OpAdd
+	OpMul
 	OpAvg
 )
 
@@ -51,6 +53,10 @@ func (o Op) String() string {
 		return "&&"
 	case OpOr:
 		return "||"
+	case OpAdd:
+		return "+"
+	case OpMul:
+		return "*"
 	default:
 		panic("unknown operator")
 	}

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -58,10 +58,15 @@ func (p *AverageAggregationPushDown) Optimize(plan *LogicalPlan) *LogicalPlan {
 			Count(aggFunc.Expr),
 		)
 
-		projection := &AverageExpr{Expr: column}
+		projection := &BinaryExpr{
+			Op:    OpAvg,
+			Left:  column,
+			Right: column,
+		}
+
 		if alias != nil {
 			alias.Expr = column
-			projection.Expr = alias
+			// projection.Expr = alias
 		}
 
 		// Wrap the aggregations with the average projection to always call it after aggregating.

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -186,7 +186,7 @@ func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) 
 			leftScalar:  leftScalar,
 			right:       rightColumnRef,
 			rightScalar: rightScalar,
-			operation:   expr.Op.String(), // TODO: pass the operation as constant instead of string
+			operation:   expr.Op.String(),
 		}, nil
 	default:
 		panic("unsupported binary boolean expression")

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -88,6 +88,10 @@ func (b binaryExprProjection) Project(mem memory.Allocator, ar arrow.Record) ([]
 		}
 	}
 
+	if expr, ok := b.boolExpr.(*AvgExpr); ok {
+		return expr.Project(mem, ar)
+	}
+
 	bitmap, err := b.boolExpr.Eval(ar)
 	if err != nil {
 		return nil, nil, err

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -88,7 +88,8 @@ func (b binaryExprProjection) Project(mem memory.Allocator, ar arrow.Record) ([]
 		}
 	}
 
-	if expr, ok := b.boolExpr.(*AvgExpr); ok {
+	// TODO: It probably makes sense to create arithmetics outside binaryExprProjection?
+	if expr, ok := b.boolExpr.(*ArithmeticExpr); ok {
 		return expr.Project(mem, ar)
 	}
 

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -184,8 +184,6 @@ func projectionFromExpr(expr logicalplan.Expr) (columnProjection, error) {
 		return binaryExprProjection{
 			boolExpr: boolExpr,
 		}, nil
-	case *logicalplan.AverageExpr:
-		return &averageProjection{expr: e}, nil
 	default:
 		return nil, fmt.Errorf("unsupported expression type for projection: %T", expr)
 	}
@@ -272,72 +270,4 @@ func (p *Projection) Draw() *Diagram {
 	}
 	details := fmt.Sprintf("Projection (%s)", strings.Join(columns, ","))
 	return &Diagram{Details: details, Child: child}
-}
-
-type averageProjection struct {
-	expr logicalplan.Expr
-}
-
-func (a *averageProjection) Name() string {
-	return a.expr.Name()
-}
-
-func (a *averageProjection) Project(mem memory.Allocator, r arrow.Record) ([]arrow.Field, []arrow.Array, error) {
-	columnName := a.expr.Name()
-	resultName := "avg(" + columnName + ")"
-	if avgExpr, ok := a.expr.(*logicalplan.AverageExpr); ok {
-		if ae, ok := avgExpr.Expr.(*logicalplan.AliasExpr); ok {
-			columnName = ae.Expr.Name()
-			resultName = ae.Alias
-		}
-	}
-
-	columnSum := "sum(" + columnName + ")"
-	columnCount := "count(" + columnName + ")"
-
-	schema := r.Schema()
-
-	sumIndex := schema.FieldIndices(columnSum)
-	if len(sumIndex) != 1 {
-		return nil, nil, fmt.Errorf("sum column for average projection for column %s not found", columnName)
-	}
-	countIndex := schema.FieldIndices(columnCount)
-	if len(countIndex) != 1 {
-		return nil, nil, fmt.Errorf("count column for average projection for column %s not found", columnName)
-	}
-
-	sums := r.Column(sumIndex[0])
-	counts := r.Column(countIndex[0])
-
-	fields := make([]arrow.Field, 0, len(schema.Fields())-1)
-	columns := make([]arrow.Array, 0, len(schema.Fields())-1)
-
-	// Only add the fields and columns that aren't the average's underlying sum and count columns.
-	for i, field := range schema.Fields() {
-		if i != sumIndex[0] && i != countIndex[0] {
-			fields = append(fields, field)
-			columns = append(columns, r.Column(i))
-		}
-	}
-
-	// Add the field and column for the projected average aggregation.
-	fields = append(fields, arrow.Field{
-		Name: resultName,
-		Type: &arrow.Int64Type{},
-	})
-	columns = append(columns, avgInt64arrays(mem, sums, counts))
-
-	return fields, columns, nil
-}
-
-func avgInt64arrays(pool memory.Allocator, sums, counts arrow.Array) arrow.Array {
-	sumsInts := sums.(*array.Int64)
-	countsInts := counts.(*array.Int64)
-
-	res := array.NewInt64Builder(pool)
-	for i := 0; i < sumsInts.Len(); i++ {
-		res.Append(sumsInts.Value(i) / countsInts.Value(i))
-	}
-
-	return res.NewArray()
 }

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -129,18 +129,23 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			frostDBOp = logicalplan.OpEq
 		case opcode.NE:
 			frostDBOp = logicalplan.OpNotEq
-		case opcode.Plus:
+		case opcode.Plus, opcode.Minus, opcode.Mul, opcode.Div:
+			op := logicalplan.OpUnknown
+			switch expr.Op {
+			case opcode.Plus:
+				op = logicalplan.OpAdd
+			case opcode.Minus:
+				op = logicalplan.OpSub
+			case opcode.Mul:
+				op = logicalplan.OpMul
+			case opcode.Div:
+				op = logicalplan.OpDiv
+			}
+
 			v.exprStack = append(v.exprStack, &logicalplan.BinaryExpr{
 				Left:  leftExpr,
 				Right: rightExpr,
-				Op:    logicalplan.OpAdd,
-			})
-			return nil
-		case opcode.Mul:
-			v.exprStack = append(v.exprStack, &logicalplan.BinaryExpr{
-				Left:  leftExpr,
-				Right: rightExpr,
-				Op:    logicalplan.OpMul,
+				Op:    op,
 			})
 			return nil
 		case opcode.LogicAnd:

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -129,6 +129,10 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			frostDBOp = logicalplan.OpEq
 		case opcode.NE:
 			frostDBOp = logicalplan.OpNotEq
+		case opcode.Plus:
+			frostDBOp = logicalplan.OpAdd
+		case opcode.Mul:
+			frostDBOp = logicalplan.OpMul
 		case opcode.LogicAnd:
 			v.exprStack = append(v.exprStack, logicalplan.And(leftExpr, rightExpr))
 			return nil

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -103,8 +103,6 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			v.exprStack[lastExpr] = logicalplan.Min(v.exprStack[lastExpr])
 		case "max":
 			v.exprStack[lastExpr] = logicalplan.Max(v.exprStack[lastExpr])
-		case "avg":
-			v.exprStack[lastExpr] = logicalplan.Avg(v.exprStack[lastExpr])
 		default:
 			return fmt.Errorf("unhandled aggregate function %s", expr.F)
 		}

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -130,9 +130,19 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 		case opcode.NE:
 			frostDBOp = logicalplan.OpNotEq
 		case opcode.Plus:
-			frostDBOp = logicalplan.OpAdd
+			v.exprStack = append(v.exprStack, &logicalplan.BinaryExpr{
+				Left:  leftExpr,
+				Right: rightExpr,
+				Op:    logicalplan.OpAdd,
+			})
+			return nil
 		case opcode.Mul:
-			frostDBOp = logicalplan.OpMul
+			v.exprStack = append(v.exprStack, &logicalplan.BinaryExpr{
+				Left:  leftExpr,
+				Right: rightExpr,
+				Op:    logicalplan.OpMul,
+			})
+			return nil
 		case opcode.LogicAnd:
 			v.exprStack = append(v.exprStack, logicalplan.And(leftExpr, rightExpr))
 			return nil


### PR DESCRIPTION
Right now the `BinaryExpr` get interpreted as `BooleanExpression` exclusively. 
This needs to be changed so that a BinaryExpr can also be of other types, like AverageExpression, going forward.

The problem with `BooleanExpression` is the fact only returns a bitmap of what rows to keep but doesn't allow to change (in the average case merge columns) in the record. 

https://github.com/polarsignals/frostdb/blob/cbce8509f8bd0b3880774627ff4f8cfe5335c029/query/physicalplan/filter.go#L42