### PR TITLE
physicalplan: plan ordered aggregations

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1146,8 +1146,17 @@ func mergeStrings(str [][]string) []string {
 			}
 		}
 	}
-	sort.Strings(result)
-	return result
+	return MergeDeduplicatedDynCols(result)
+}
+
+// MergeDeduplicatedDynCols is a light wrapper over sorting the deduplicated
+// dynamic column names provided in dyn. It is extracted as a public method
+// since this merging determines the order in which dynamic columns are stored
+// and components from other packages sometimes need to figure out the physical
+// sort order between dynamic columns.
+func MergeDeduplicatedDynCols(dyn []string) []string {
+	sort.Strings(dyn)
+	return dyn
 }
 
 // NewDynamicRowGroupMergeAdapter returns a *DynamicRowGroupMergeAdapter, which

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -569,6 +569,14 @@ func (s *Schema) Columns() []ColumnDefinition {
 	return s.columns
 }
 
+func (s *Schema) SortingColumns() []ColumnDefinition {
+	sCols := make([]ColumnDefinition, len(s.sortingColumns))
+	for i, col := range s.sortingColumns {
+		sCols[i] = s.columns[s.columnIndexes[col.ColumnName()]]
+	}
+	return sCols
+}
+
 func (s *Schema) ParquetSchema() *parquet.Schema {
 	switch schema := s.def.(type) {
 	case *schemav2pb.Schema:

--- a/logictest/logic_test.go
+++ b/logictest/logic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/polarsignals/frostdb"
 	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/query"
+	"github.com/polarsignals/frostdb/query/physicalplan"
 
 	schemapb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha1"
 )
@@ -29,6 +30,9 @@ func (db frostDB) ScanTable(name string) query.Builder {
 	queryEngine := query.NewEngine(
 		memory.NewGoAllocator(),
 		db.DB.TableProvider(),
+		query.WithPhysicalplanOptions(
+			physicalplan.WithOrderedAggregations(),
+		),
 	)
 	return queryEngine.ScanTable(name)
 }

--- a/logictest/testdata/exec/aggregate/ordered_aggregate
+++ b/logictest/testdata/exec/aggregate/ordered_aggregate
@@ -26,19 +26,28 @@ type2   value3  1   1
 ----
 
 exec
-select sum(value) as value_sum group by (example_type, labels.label1)
-----
-type1   null    4
-type2   null    2
-type1   value1  4
-type2   value1  2
-
-exec
 select sum(value) as value_sum group by (example_type, labels)
 ----
-type1   value1  4
-type1   value2  2
-type1   value3  2
-type2   value1  2
-type2   value2  1
-type2   value3  1
+type1   null    null    value3  2
+type1   null    value2  null    2
+type1   value1  null    null    4
+type2   null    null    value3  1
+type2   null    value2  null    1
+type2   value1  null    null    2
+
+exec
+select sum(value) as value_sum where example_type = 'type1' group by (labels)
+----
+null    null    value3  2
+null    value2  null    2
+value1  null    null    4
+
+exec
+select sum(value) as value_sum where example_type = 'type1' group by (labels, timestamp)
+----
+null    null    value3  1       1
+null    null    value3  2       1
+null    value2  null    1       1
+null    value2  null    2       1
+value1  null    null    1       2
+value1  null    null    2       2

--- a/logictest/testdata/exec/aggregate/ordered_aggregate
+++ b/logictest/testdata/exec/aggregate/ordered_aggregate
@@ -1,0 +1,44 @@
+createtable schema=default
+----
+
+insert cols=(example_type, labels.label1, timestamp, value)
+type1   value1  1   1
+type1   value1  2   1
+type2   value1  1   1
+----
+
+insert cols=(example_type, labels.label1, timestamp, value)
+type1   value1  1   1
+type1   value1  2   1
+type2   value1  1   1
+----
+
+insert cols=(example_type, labels.label2, timestamp, value)
+type1   value2  1   1
+type1   value2  2   1
+type2   value2  1   1
+----
+
+insert cols=(example_type, labels.label3, timestamp, value)
+type1   value3  1   1
+type1   value3  2   1
+type2   value3  1   1
+----
+
+exec
+select sum(value) as value_sum group by (example_type, labels.label1)
+----
+type1   null    4
+type2   null    2
+type1   value1  4
+type2   value1  2
+
+exec
+select sum(value) as value_sum group by (example_type, labels)
+----
+type1   value1  4
+type1   value2  2
+type1   value3  2
+type2   value1  2
+type2   value2  1
+type2   value3  1

--- a/logictest/testdata/plan/aggregate/aggregate
+++ b/logictest/testdata/plan/aggregate/aggregate
@@ -15,6 +15,13 @@ explain select sum(value) as value_sum group by (example_type, labels)
 ----
 TableScan [concurrent] - OrderedAggregate (value by example_type,labels) - OrderedSynchronizer - OrderedAggregate (value by example_type,labels)
 
+# A hash aggregation is planned in the case that the group by columns are inverted. TODO(asubiotto): We could probably
+# plan an ordered aggregation in this case, but let's not do so unless necessary.
+exec
+explain select sum(value) as value_sum group by (labels, example_type)
+----
+TableScan [concurrent] - HashAggregate (value_sum by labels,example_type) - Synchronizer - HashAggregate (value_sum by labels,example_type)
+
 # A hash aggregation should be planned in this case because we are not grouping by example_type, so the group by columns
 # are not a prefix of the sorting columns.
 exec
@@ -28,6 +35,11 @@ exec
 explain select sum(value) as value_sum where example_type = 'some_value' group by (labels)
 ----
 TableScan [concurrent] - PredicateFilter (example_type == some_value) - OrderedAggregate (value by labels) - OrderedSynchronizer - OrderedAggregate (value by labels)
+
+exec
+explain select sum(value) as value_sum where example_type = 'some_value' group by (labels, timestamp)
+----
+TableScan [concurrent] - PredicateFilter (example_type == some_value) - OrderedAggregate (value by labels,timestamp) - OrderedSynchronizer - OrderedAggregate (value by labels,timestamp)
 
 # The above only applies to equality filters of course.
 exec

--- a/logictest/testdata/plan/aggregate/aggregate
+++ b/logictest/testdata/plan/aggregate/aggregate
@@ -1,11 +1,41 @@
 createtable schema=default
 ----
 
+# It might be a bit surprising that the hash aggregate is planned in this case but this is expected, since we're only
+# grouping by one concrete column of the dynamic column schema. Consider, for example, if there was another column,
+# labels.label0 that sorted physically before labels.label1.
 exec
 explain select sum(value) as value_sum group by (example_type, labels.label1)
 ----
 TableScan [concurrent] - HashAggregate (value_sum by example_type,labels.label1) - Synchronizer - HashAggregate (value_sum by example_type,labels.label1)
 
+# An ordered aggregation should be planned in this case because the full set of dynamic columns is specified.
+exec
+explain select sum(value) as value_sum group by (example_type, labels)
+----
+TableScan [concurrent] - OrderedAggregate (value by example_type,labels) - OrderedSynchronizer - OrderedAggregate (value by example_type,labels)
+
+# A hash aggregation should be planned in this case because we are not grouping by example_type, so the group by columns
+# are not a prefix of the sorting columns.
+exec
+explain select sum(value) as value_sum group by (labels)
+----
+TableScan [concurrent] - HashAggregate (value_sum by labels) - Synchronizer - HashAggregate (value_sum by labels)
+
+# If however, the prefix that is not contained by the grouping columns is covered by an equality filter, an ordered
+# aggregation can be planned since we "fix" a prefix of the sorting columns to a given value.
+exec
+explain select sum(value) as value_sum where example_type = 'some_value' group by (labels)
+----
+TableScan [concurrent] - PredicateFilter (example_type == some_value) - OrderedAggregate (value by labels) - OrderedSynchronizer - OrderedAggregate (value by labels)
+
+# The above only applies to equality filters of course.
+exec
+explain select sum(value) as value_sum where example_type > 'some_value' group by (labels)
+----
+TableScan [concurrent] - PredicateFilter (example_type > some_value) - HashAggregate (value_sum by labels) - Synchronizer - HashAggregate (value_sum by labels)
+
+# And here's a hash aggregation with a filter on another column.
 exec
 explain select sum(value) as value_sum where timestamp >= 1 group by labels.label1
 ----

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -110,10 +110,6 @@ func NewOrderedAggregate(
 	groupByColumnMatchers []logicalplan.Expr,
 	finalStage bool,
 ) *OrderedAggregate {
-	if !finalStage {
-		panic("non-final stage ordered aggregation is not supported yet")
-	}
-
 	o := &OrderedAggregate{
 		pool:              pool,
 		tracer:            tracer,
@@ -384,7 +380,7 @@ func (a *OrderedAggregate) Callback(_ context.Context, r arrow.Record) error {
 		return nil
 	}
 
-	results, err := a.aggregationFunction.Aggregate(a.pool, arraysToAggregate)
+	results, err := runAggregation(a.finalStage, a.aggregationFunction, a.pool, arraysToAggregate)
 	if err != nil {
 		return err
 	}
@@ -433,9 +429,8 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 			a.groupResults[n] = append(a.groupResults[n], b.NewArray())
 		}
 
-		results, err := a.aggregationFunction.Aggregate(
-			a.pool,
-			[]arrow.Array{a.arrayToAggCarry.NewArray()},
+		results, err := runAggregation(
+			a.finalStage, a.aggregationFunction, a.pool, []arrow.Array{a.arrayToAggCarry.NewArray()},
 		)
 		if err != nil {
 			return err

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -415,6 +415,11 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 	ctx, span := a.tracer.Start(ctx, "OrderedAggregate/Finish")
 	defer span.End()
 
+	if !a.notFirstCall {
+		// Callback was never called, simply call Finish.
+		return a.next.Finish(ctx)
+	}
+
 	if a.arrayToAggCarry.Len() > 0 {
 		// Aggregate the last group.
 		a.groupResults = append(a.groupResults, nil)

--- a/query/physicalplan/ordered_synchronizer.go
+++ b/query/physicalplan/ordered_synchronizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/apache/arrow/go/v8/arrow"
 	"github.com/apache/arrow/go/v8/arrow/memory"
@@ -20,38 +19,42 @@ import (
 // safety.
 type OrderedSynchronizer struct {
 	pool        memory.Allocator
-	inputs      int
 	orderByCols []int
-	running     atomic.Int64
 
-	records struct {
+	sync struct {
 		mtx  sync.Mutex
 		data []arrow.Record
+		// inputsWaiting is an integer that keeps track of the number of inputs
+		// waiting on the wait channel. It cannot be an atomic because it
+		// sometimes needs to be compared to inputsRunning.
+		inputsWaiting int
+		// inputsRunning is an integer that keeps track of the number of inputs
+		// that have not called Finish yet.
+		inputsRunning int
 	}
 	wait chan struct{}
-	// pendingInputs is the number of inputs that are yet to call Callback.
-	pendingInputs atomic.Int64
-	next          PhysicalPlan
+	next PhysicalPlan
 }
 
 func NewOrderedSynchronizer(pool memory.Allocator, inputs int, orderByCols []int) *OrderedSynchronizer {
 	o := &OrderedSynchronizer{
 		pool:        pool,
-		inputs:      inputs,
 		orderByCols: orderByCols,
 		wait:        make(chan struct{}),
 	}
-	o.running.Add(int64(inputs))
-	o.pendingInputs.Add(int64(inputs))
+	o.sync.inputsRunning = inputs
 	return o
 }
 
 func (o *OrderedSynchronizer) Callback(ctx context.Context, r arrow.Record) error {
-	o.records.mtx.Lock()
-	o.records.data = append(o.records.data, r)
-	o.records.mtx.Unlock()
+	o.sync.mtx.Lock()
+	o.sync.data = append(o.sync.data, r)
+	o.sync.inputsWaiting++
+	inputsWaiting := o.sync.inputsWaiting
+	inputsRunning := o.sync.inputsRunning
+	o.sync.mtx.Unlock()
 
-	if o.pendingInputs.Add(-1) != 0 {
+	if inputsWaiting != inputsRunning {
 		select {
 		case <-o.wait:
 			return nil
@@ -60,31 +63,35 @@ func (o *OrderedSynchronizer) Callback(ctx context.Context, r arrow.Record) erro
 		}
 	}
 
+	o.sync.mtx.Lock()
+	defer o.sync.mtx.Unlock()
+	o.sync.inputsWaiting--
 	// This is the last input to call Callback, merge the records.
-	o.records.mtx.Lock()
-	defer o.records.mtx.Unlock()
-	mergedRecord, err := arrowutils.MergeRecords(o.pool, o.records.data, o.orderByCols)
+	mergedRecord, err := o.mergeRecordsLocked()
 	if err != nil {
 		return err
 	}
-	// Now that the records have been merged, we can wake up the other input
-	// goroutines. Since we have exactly o.inputs-1 waiting on the
-	// channel, send the corresponding number of messages. Since we are also
-	// holding the records mutex during this broadcast, fast inputs won't be
-	// able to re-enter Callback until the mutex is released, so won't
-	// mistakenly read another input's signal.
-	for i := 0; i < o.inputs-1; i++ {
-		o.wait <- struct{}{}
-	}
-	// Reset pendingInputs.
-	o.pendingInputs.Store(int64(o.inputs))
-	o.records.data = o.records.data[:0]
 
+	// Note that we hold the mutex while calling Callback because we want to
+	// ensure that Callback is called in an ordered fashion since we could race
+	// with a call to Callback in Finish.
 	return o.next.Callback(ctx, mergedRecord)
 }
 
 func (o *OrderedSynchronizer) Finish(ctx context.Context) error {
-	running := o.running.Add(-1)
+	o.sync.mtx.Lock()
+	defer o.sync.mtx.Unlock()
+	o.sync.inputsRunning--
+	running := o.sync.inputsRunning
+	if running > 0 && running == o.sync.inputsWaiting {
+		// All other goroutines are currently waiting to be woken up. We need to
+		// merge the records.
+		mergedRecord, err := o.mergeRecordsLocked()
+		if err != nil {
+			return err
+		}
+		return o.next.Callback(ctx, mergedRecord)
+	}
 	if running < 0 {
 		return errors.New("too many OrderedSynchronizer Finish calls")
 	}
@@ -92,6 +99,28 @@ func (o *OrderedSynchronizer) Finish(ctx context.Context) error {
 		return nil
 	}
 	return o.next.Finish(ctx)
+}
+
+// mergeRecordsLocked must be called while holding o.sync.mtx. It merges the
+// records found in o.sync.data and unblocks all the inputs waiting on o.wait.
+func (o *OrderedSynchronizer) mergeRecordsLocked() (arrow.Record, error) {
+	mergedRecord, err := arrowutils.MergeRecords(o.pool, o.sync.data, o.orderByCols)
+	if err != nil {
+		return nil, err
+	}
+	// Now that the records have been merged, we can wake up the other input
+	// goroutines. Since we have exactly o.sync.inputsWaiting waiting on the
+	// channel, send the corresponding number of messages. Since we are also
+	// holding the records mutex during this broadcast, fast inputs won't be
+	// able to re-enter Callback until the mutex is released, so won't
+	// mistakenly read another input's signal.
+	for i := 0; i < o.sync.inputsWaiting; i++ {
+		o.wait <- struct{}{}
+	}
+	// Reset inputsWaiting.
+	o.sync.inputsWaiting = 0
+	o.sync.data = o.sync.data[:0]
+	return mergedRecord, nil
 }
 
 func (o *OrderedSynchronizer) SetNext(next PhysicalPlan) {

--- a/query/physicalplan/ordered_synchronizer.go
+++ b/query/physicalplan/ordered_synchronizer.go
@@ -128,5 +128,5 @@ func (o *OrderedSynchronizer) SetNext(next PhysicalPlan) {
 }
 
 func (o *OrderedSynchronizer) Draw() *Diagram {
-	return &Diagram{}
+	return &Diagram{Details: "OrderedSynchronizer", Child: o.next.Draw()}
 }

--- a/query/physicalplan/ordered_synchronizer.go
+++ b/query/physicalplan/ordered_synchronizer.go
@@ -3,12 +3,16 @@ package physicalplan
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/apache/arrow/go/v8/arrow"
+	"github.com/apache/arrow/go/v8/arrow/array"
 	"github.com/apache/arrow/go/v8/arrow/memory"
 
+	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
+	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 // OrderedSynchronizer implements synchronizing ordered input from multiple
@@ -18,12 +22,14 @@ import (
 // store the pushed records, but that requires fully copying all the data for
 // safety.
 type OrderedSynchronizer struct {
-	pool        memory.Allocator
-	orderByCols []int
+	pool         memory.Allocator
+	orderByExprs []logicalplan.Expr
+	orderByCols  []int
 
 	sync struct {
-		mtx  sync.Mutex
-		data []arrow.Record
+		mtx        sync.Mutex
+		lastSchema *arrow.Schema
+		data       []arrow.Record
 		// inputsWaiting is an integer that keeps track of the number of inputs
 		// waiting on the wait channel. It cannot be an atomic because it
 		// sometimes needs to be compared to inputsRunning.
@@ -36,11 +42,11 @@ type OrderedSynchronizer struct {
 	next PhysicalPlan
 }
 
-func NewOrderedSynchronizer(pool memory.Allocator, inputs int, orderByCols []int) *OrderedSynchronizer {
+func NewOrderedSynchronizer(pool memory.Allocator, inputs int, orderByExprs []logicalplan.Expr) *OrderedSynchronizer {
 	o := &OrderedSynchronizer{
-		pool:        pool,
-		orderByCols: orderByCols,
-		wait:        make(chan struct{}),
+		pool:         pool,
+		orderByExprs: orderByExprs,
+		wait:         make(chan struct{}),
 	}
 	o.sync.inputsRunning = inputs
 	return o
@@ -104,6 +110,9 @@ func (o *OrderedSynchronizer) Finish(ctx context.Context) error {
 // mergeRecordsLocked must be called while holding o.sync.mtx. It merges the
 // records found in o.sync.data and unblocks all the inputs waiting on o.wait.
 func (o *OrderedSynchronizer) mergeRecordsLocked() (arrow.Record, error) {
+	if err := o.ensureSameSchema(o.sync.data); err != nil {
+		return nil, err
+	}
 	mergedRecord, err := arrowutils.MergeRecords(o.pool, o.sync.data, o.orderByCols)
 	if err != nil {
 		return nil, err
@@ -121,6 +130,108 @@ func (o *OrderedSynchronizer) mergeRecordsLocked() (arrow.Record, error) {
 	o.sync.inputsWaiting = 0
 	o.sync.data = o.sync.data[:0]
 	return mergedRecord, nil
+}
+
+// ensureSameSchema ensures that all the records have the same schema. In cases
+// where the schema is not equal, virtual null columns are inserted in the
+// records with the missing column. When we have static schemas in the execution
+// engine, steps like these should be unnecessary.
+func (o *OrderedSynchronizer) ensureSameSchema(records []arrow.Record) error {
+	var needSchemaRecalculation bool
+	for i := range records {
+		if !records[i].Schema().Equal(o.sync.lastSchema) {
+			needSchemaRecalculation = true
+			break
+		}
+	}
+	if !needSchemaRecalculation {
+		return nil
+	}
+
+	orderCols := make([]map[string]arrow.Field, len(o.orderByExprs))
+	leftoverCols := make(map[string]arrow.Field)
+	for i, orderCol := range o.orderByExprs {
+		orderCols[i] = make(map[string]arrow.Field)
+		for _, r := range records {
+			for _, field := range r.Schema().Fields() {
+				if ok := orderCol.MatchColumn(field.Name); ok {
+					orderCols[i][field.Name] = field
+				} else {
+					leftoverCols[field.Name] = field
+				}
+			}
+		}
+	}
+
+	newFields := make([]arrow.Field, 0, len(orderCols))
+	for _, colsFound := range orderCols {
+		if len(colsFound) == 0 {
+			// An expected order by field is missing from the records, this
+			// field will just be considered to be null.
+			continue
+		}
+
+		if len(colsFound) == 1 {
+			for _, field := range colsFound {
+				newFields = append(newFields, field)
+			}
+			continue
+		}
+		// These columns are dynamic columns and should be merged to follow
+		// the physical sort order.
+		colNames := make([]string, 0, len(colsFound))
+		for name := range colsFound {
+			colNames = append(colNames, name)
+		}
+		// MergeDeduplicatedDynCols will return the dynamic column names in
+		// the order that they sort physically.
+		for _, name := range dynparquet.MergeDeduplicatedDynCols(colNames) {
+			newFields = append(newFields, colsFound[name])
+		}
+	}
+
+	o.orderByCols = o.orderByCols[:0]
+	for i := range newFields {
+		o.orderByCols = append(o.orderByCols, i)
+	}
+
+	for _, field := range leftoverCols {
+		newFields = append(newFields, field)
+	}
+
+	// This is the schema that all records must respect in order to be merged.
+	schema := arrow.NewSchema(newFields, nil)
+
+	for i := range records {
+		otherSchema := records[i].Schema()
+		if schema.Equal(records[i].Schema()) {
+			continue
+		}
+
+		var columns []arrow.Array
+		for _, field := range schema.Fields() {
+			if otherFields := otherSchema.FieldIndices(field.Name); otherFields != nil {
+				if len(otherFields) > 1 {
+					fieldsFound, _ := otherSchema.FieldsByName(field.Name)
+					return fmt.Errorf(
+						"found multiple fields %v for name %s",
+						fieldsFound,
+						field.Name,
+					)
+				}
+				columns = append(columns, records[i].Column(otherFields[0]))
+			} else {
+				// Note that this VirtualNullArray will be read from, but the
+				// merged output will be a physical null array, so there is no
+				// virtual->physical conversion necessary before we return data.
+				columns = append(columns, arrowutils.MakeVirtualNullArray(field.Type, int(records[i].NumRows())))
+			}
+		}
+
+		records[i] = array.NewRecord(schema, columns, records[i].NumRows())
+	}
+	o.sync.lastSchema = schema
+	return nil
 }
 
 func (o *OrderedSynchronizer) SetNext(next PhysicalPlan) {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -237,7 +237,17 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 		prev     []PhysicalPlan
 	)
 
+	oInfo := &planOrderingInfo{
+		state: planOrderingInfoStateInit,
+	}
+	if s != nil {
+		// TODO(asubiotto): There are cases in which the schema can be nil.
+		// Eradicate these.
+		oInfo.sortingCols = s.SortingColumns()
+	}
+
 	plan.Accept(PostPlanVisitorFunc(func(plan *logicalplan.LogicalPlan) bool {
+		oInfo.newNode()
 		switch {
 		case plan.SchemaScan != nil:
 			// Create noop operators since we don't know what to push the scan
@@ -267,6 +277,7 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 				plans:   plans,
 			}
 			prev = append(prev[:0], plans...)
+			oInfo.nodeMaintainsOrdering()
 		case plan.Projection != nil:
 			// For each previous physical plan create one Projection
 			for i := range prev {
@@ -313,15 +324,39 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 				prev[i].SetNext(f)
 				prev[i] = f
 			}
+			oInfo.applyFilter(plan.Filter.Expr)
+			oInfo.nodeMaintainsOrdering()
 		case plan.Aggregation != nil:
 			schema := s.ParquetSchema()
-			var sync *Synchronizer
+			ordered, err := shouldPlanOrderedAggregate(oInfo, plan.Aggregation)
+			if err != nil {
+				// TODO(asubiotto): Log the error.
+				ordered = false
+			}
+			var sync PhysicalPlan
 			if len(prev) > 1 {
 				// These aggregate operators need to be synchronized.
-				sync = Synchronize(len(prev))
+				if ordered {
+					// The group columns are known to be the first groupExpr
+					// columns. This might be a bit brittle though because group
+					// columns are not necessarily output in the input order.
+					// However, we don't know the group column output ordering
+					// until execution.
+					// TODO(asubiotto): Fix this. We can enforce group column
+					// output in the ordered aggregator (minus dynamic
+					// columns?). Maybe we can use column name matching as
+					// elsewhere.
+					orderCols := make([]int, len(plan.Aggregation.GroupExprs))
+					for i := range orderCols {
+						orderCols[i] = i
+					}
+					sync = NewOrderedSynchronizer(pool, len(prev), orderCols)
+				} else {
+					sync = Synchronize(len(prev))
+				}
 			}
 			for i := 0; i < len(prev); i++ {
-				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, sync == nil)
+				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, sync == nil, ordered)
 				if err != nil {
 					visitErr = err
 					return false
@@ -335,7 +370,7 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 			if sync != nil {
 				// Plan an aggregate operator to run an aggregation on all the
 				// aggregations.
-				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, true)
+				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, true, ordered)
 				if err != nil {
 					visitErr = err
 					return false
@@ -343,6 +378,9 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 				sync.SetNext(a)
 				prev = prev[0:1]
 				prev[0] = a
+			}
+			if ordered {
+				oInfo.nodeMaintainsOrdering()
 			}
 		default:
 			panic("Unsupported plan")
@@ -368,6 +406,40 @@ func Build(ctx context.Context, pool memory.Allocator, tracer trace.Tracer, s *d
 	}
 
 	return outputPlan, nil
+}
+
+func shouldPlanOrderedAggregate(oInfo *planOrderingInfo, agg *logicalplan.Aggregation) (bool, error) {
+	if len(agg.AggExprs) > 1 {
+		// More than one aggregation is not yet supported.
+		return false, nil
+	}
+	if !oInfo.orderingMaintained() {
+		return false, nil
+	}
+	groupExprs := agg.GroupExprs
+	ordering := oInfo.getNonCoveringOrdering()
+	for _, expr := range groupExprs {
+		groupCols := expr.ColumnsUsedExprs()
+		if len(groupCols) > 1 {
+			return false, fmt.Errorf("expected only one group column but found %v", groupCols)
+		}
+		if len(ordering) == 0 {
+			return false, nil
+		}
+		orderCol := ordering[0]
+		ordering = ordering[1:]
+		orderColName := orderCol.Name
+		if orderCol.Dynamic {
+			// TODO(asubiotto): Appending a "." is necessary for the MatchColumn
+			// call below to work for dynamic columns. Not sure if there's a
+			// better way to do this.
+			orderColName += "."
+		}
+		if !groupCols[0].MatchColumn(orderColName) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 type Diagram struct {

--- a/query/physicalplan/planordering.go
+++ b/query/physicalplan/planordering.go
@@ -1,1 +1,113 @@
 package physicalplan
+
+import (
+	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/polarsignals/frostdb/query/logicalplan"
+)
+
+type planOrderingInfoState int
+
+const (
+	planOrderingInfoStateInit planOrderingInfoState = iota
+	planOrderingInfoStateNewNode
+	planOrderingInfoStateMaintained
+	planOrderingInfoStateInvalidated
+)
+
+// planOrderingInfo is a helper struct that stores the ordering that an operator
+// can expect from its input stream.
+type planOrderingInfo struct {
+	// state stores the ordering info state. This is a little more complex than
+	// a boolean because we want a visit to a logical plan node to explicitly
+	// validate the ordering to avoid programming errors in the future. This
+	// requires notifying that a new node visit will occur, and invalidating the
+	// ordering if a node visit does not explicitly call nodeMaintainsOrdering
+	// in between node visits.
+	state       planOrderingInfoState
+	sortingCols []dynparquet.ColumnDefinition
+	// filterCoverIdx is an index into sortingCols that specifies the first
+	// column that is not "covered" by a filter. What this means is best
+	// explained by an example:
+	// Say that our ordering consists of columns a, b, c, d. At some point
+	// during planning, we apply a filter that has binary equality expressions
+	// on columns a and b. This means that a and b are covered by this filter
+	// so don't really matter for ordering purposes given that all values after
+	// the filter will be the same. This is helpful to operators downstream that
+	// can only perform optimizations if they expect some ordering on c and d
+	// only.
+	filterCoverIdx int
+}
+
+// newNode should be called when visiting a new node in the logical plan.
+func (i *planOrderingInfo) newNode() {
+	if i.state == planOrderingInfoStateNewNode {
+		// If newNode is called twice in a row, the previous node did not
+		// maintain ordering, so invalidate the ordering.
+		i.state = planOrderingInfoStateInvalidated
+		return
+	}
+	i.state = planOrderingInfoStateNewNode
+}
+
+// nodeMaintainsOrdering should be called when a logical plan node maintains
+// input ordering.
+func (i *planOrderingInfo) nodeMaintainsOrdering() {
+	if i.state == planOrderingInfoStateNewNode {
+		i.state = planOrderingInfoStateMaintained
+		return
+	}
+}
+
+func (i *planOrderingInfo) orderingMaintained() bool {
+	return i.state != planOrderingInfoStateInvalidated
+}
+
+// preExprVisitorFunc is an expr visitor that returns true on PostVisit as well.
+// TODO(asubiotto): Remove this in favor of PreExprVisitorFunc, just that the
+// latter aborts visitation on post-visit.
+type preExprVisitorFunc func(expr logicalplan.Expr) bool
+
+func (f preExprVisitorFunc) PreVisit(expr logicalplan.Expr) bool {
+	return f(expr)
+}
+
+func (f preExprVisitorFunc) PostVisit(_ logicalplan.Expr) bool {
+	return true
+}
+
+func (i *planOrderingInfo) applyFilter(expr logicalplan.Expr) {
+	if i.state == planOrderingInfoStateInvalidated {
+		return
+	}
+	equalityColumns := make(map[string]struct{})
+	expr.Accept(preExprVisitorFunc(func(expr logicalplan.Expr) bool {
+		switch e := expr.(type) {
+		case *logicalplan.BinaryExpr:
+			switch e.Op {
+			case logicalplan.OpAnd:
+				// Continue visiting.
+				return true
+			case logicalplan.OpEq:
+				if c, ok := e.Left.(*logicalplan.Column); ok {
+					equalityColumns[c.ColumnName] = struct{}{}
+				}
+			}
+		}
+		return true
+	}))
+	for _, col := range i.sortingCols {
+		if col.Dynamic {
+			// Equality filters on dynamic columns cannot be considered to
+			// be covering.
+			return
+		}
+		if _, ok := equalityColumns[col.Name]; !ok {
+			return
+		}
+		i.filterCoverIdx++
+	}
+}
+
+func (i *planOrderingInfo) getNonCoveringOrdering() []dynparquet.ColumnDefinition {
+	return i.sortingCols[i.filterCoverIdx:]
+}

--- a/query/physicalplan/planordering.go
+++ b/query/physicalplan/planordering.go
@@ -1,0 +1,1 @@
+package physicalplan


### PR DESCRIPTION
This PR is a bunch of commits with fixes and planning changes in order to plan ordered aggregations when the grouping columns are a prefix of ordering columns. This includes cases in which a filter "covers" a prefix of the ordering columns up to the group columns (e.g. when the order is "name, labels, timestamp" and we filter name="somename" and group by (labels,timestamp)). For more explicit information on what cases are and aren't covered, please refer to the `plan/aggregate` logic test which goes into more detail.

Ordered aggregations are disabled by default and can be enabled (as is done with logic tests) by calling `query.NewEngine` and adding the `WithOrderedAggregations` option given that there are most likely some latent bugs.

The performance improvement over hash aggregates is reasonable as expected and I believe that there is some more room for improvement. I want to write up a couple of issues with some ideas for perf improvements on the current state:
```
name           old time/op    new time/op    delta
Query/Range-8    4.82ms ± 1%    4.51ms ± 0%   -6.47%  (p=0.000 n=10+8)

name           old alloc/op   new alloc/op   delta
Query/Range-8    22.3MB ± 0%    21.4MB ± 0%   -4.32%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
Query/Range-8     9.55k ± 0%     7.58k ± 0%  -20.61%  (p=0.000 n=9+10)
```