### PR TITLE
wal: add batch to log message when encountering write error

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -196,7 +196,7 @@ func (w *FileWAL) Run(ctx context.Context) {
 			err := w.log.WriteBatch(walBatch)
 			if err != nil {
 				w.metrics.failedLogs.Add(float64(len(batch)))
-				level.Error(w.logger).Log("msg", "failed to write WAL batch", "err", err)
+				level.Error(w.logger).Log("msg", "failed to write WAL batch", "err", err, "batch", walBatch)
 			} else {
 				w.metrics.recordsLogged.Add(float64(len(batch)))
 			}


### PR DESCRIPTION
tidwall/wal can refuse to write a batch due to out of order indexes, but it's hard to tell the underlying cause just from the error message. Printing the batch that we attempted to write will help diagnosing the cause. The log message will be very verbose, but since it is only logged on error, that should be fine.