### PR TITLE
Unblock compaction by setting tx during WAL replay

### DIFF
--- a/db.go
+++ b/db.go
@@ -519,6 +519,11 @@ func (db *DB) replayWAL(ctx context.Context) error {
 			if err := table.active.Insert(ctx, tx, serBuf); err != nil {
 				return fmt.Errorf("insert buffer into block: %w", err)
 			}
+
+			// After every insert we're setting the tx and highWatermark to the replayed tx.
+			// This allows the block's compaction to start working on the inserted data.
+			db.tx.Store(tx)
+			db.highWatermark.Store(tx)
 		case *walpb.Entry_TableBlockPersisted_:
 			return nil
 		default:


### PR DESCRIPTION
This is an idea for #317 

Sadly the bytes on the heap read from the runtime don't seem to significantly improve with this approach. :thinking: 

![Screenshot from 2023-01-26 16-25-10](https://user-images.githubusercontent.com/872251/214876014-883d86ec-2e14-4a45-9fcb-107378d96d58.png)

_This chart shows the memory heap in bytes every 128 inserts_ 