### PR TITLE
use option pattern for iteropts

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -276,7 +276,6 @@ func TestDBWithWAL(t *testing.T) {
 				ctx,
 				tx,
 				pool,
-				logicalplan.IterOptions{},
 				[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 					ar.Retain()
 					records = append(records, ar)

--- a/query/logicalplan/logicalplan_test.go
+++ b/query/logicalplan/logicalplan_test.go
@@ -26,8 +26,8 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts IterOptions,
 	callbacks []Callback,
+	iterOpts ...Option,
 ) error {
 	return nil
 }
@@ -36,8 +36,8 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts IterOptions,
 	callbacks []Callback,
+	iterOpts ...Option,
 ) error {
 	return nil
 }

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -124,13 +124,11 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{
-				PhysicalProjection: s.options.PhysicalProjection,
-				Projection:         s.options.Projection,
-				Filter:             s.options.Filter,
-				DistinctColumns:    s.options.Distinct,
-			},
 			callbacks,
+			logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
+			logicalplan.WithProjection(s.options.Projection...),
+			logicalplan.WithFilter(s.options.Filter),
+			logicalplan.WithDistinctColumns(s.options.Distinct...),
 		)
 	})
 	if err != nil {
@@ -179,13 +177,11 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{
-				PhysicalProjection: s.options.PhysicalProjection,
-				Projection:         s.options.Projection,
-				Filter:             s.options.Filter,
-				DistinctColumns:    s.options.Distinct,
-			},
 			callbacks,
+			logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
+			logicalplan.WithProjection(s.options.Projection...),
+			logicalplan.WithFilter(s.options.Filter),
+			logicalplan.WithDistinctColumns(s.options.Distinct...),
 		)
 	})
 	if err != nil {

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -29,8 +29,8 @@ func (m *mockTableReader) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts logicalplan.IterOptions,
 	callbacks []logicalplan.Callback,
+	iterOpts ...logicalplan.Option,
 ) error {
 	return nil
 }
@@ -39,8 +39,8 @@ func (m *mockTableReader) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts logicalplan.IterOptions,
 	callbacks []logicalplan.Callback,
+	iterOpts ...logicalplan.Option,
 ) error {
 	return nil
 }

--- a/table.go
+++ b/table.go
@@ -711,9 +711,13 @@ func (t *Table) Iterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts logicalplan.IterOptions,
 	callbacks []logicalplan.Callback,
+	options ...logicalplan.Option,
 ) error {
+	iterOpts := &logicalplan.IterOptions{}
+	for _, opt := range options {
+		opt(iterOpts)
+	}
 	ctx, span := t.tracer.Start(ctx, "Table/Iterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))
 	span.SetAttributes(attribute.Int("projections", len(iterOpts.Projection)))
@@ -739,7 +743,7 @@ func (t *Table) Iterator(
 	for _, callback := range callbacks {
 		callback := callback
 		errg.Go(func() error {
-			converter := pqarrow.NewParquetConverter(pool, iterOpts)
+			converter := pqarrow.NewParquetConverter(pool, *iterOpts)
 			defer converter.Close()
 
 			var rgSchema *parquet.Schema
@@ -811,9 +815,13 @@ func (t *Table) SchemaIterator(
 	ctx context.Context,
 	tx uint64,
 	pool memory.Allocator,
-	iterOpts logicalplan.IterOptions,
 	callbacks []logicalplan.Callback,
+	options ...logicalplan.Option,
 ) error {
+	iterOpts := &logicalplan.IterOptions{}
+	for _, opt := range options {
+		opt(iterOpts)
+	}
 	ctx, span := t.tracer.Start(ctx, "Table/SchemaIterator")
 	span.SetAttributes(attribute.Int("physicalProjections", len(iterOpts.PhysicalProjection)))
 	span.SetAttributes(attribute.Int("projections", len(iterOpts.Projection)))

--- a/table_test.go
+++ b/table_test.go
@@ -169,7 +169,6 @@ func TestTable(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				t.Log(ar)
 				defer ar.Release()
@@ -286,7 +285,6 @@ func Test_Table_Concurrency(t *testing.T) {
 					ctx,
 					tx,
 					pool,
-					logicalplan.IterOptions{},
 					[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 						totalrows += ar.NumRows()
 						defer ar.Release()
@@ -415,7 +413,6 @@ func benchmarkTableInserts(b *testing.B, rows, iterations, writers int) {
 				ctx,
 				tx,
 				pool,
-				logicalplan.IterOptions{},
 				[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 					defer ar.Release()
 					totalrows += ar.NumRows()
@@ -515,7 +512,6 @@ func Test_Table_ReadIsolation(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				rows += ar.NumRows()
 				defer ar.Release()
@@ -539,7 +535,6 @@ func Test_Table_ReadIsolation(t *testing.T) {
 			ctx,
 			table.db.highWatermark.Load(),
 			pool,
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				rows += ar.NumRows()
 				defer ar.Release()
@@ -710,7 +705,6 @@ func Test_Table_Filter(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{Filter: filterExpr},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				defer ar.Release()
 
@@ -718,6 +712,7 @@ func Test_Table_Filter(t *testing.T) {
 
 				return nil
 			}},
+			logicalplan.WithFilter(filterExpr),
 		)
 		require.NoError(t, err)
 		require.False(t, iterated)
@@ -788,12 +783,12 @@ func Test_Table_Bloomfilter(t *testing.T) {
 			context.Background(),
 			tx,
 			pool,
-			logicalplan.IterOptions{Filter: logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4"))},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				defer ar.Release()
 				iterations++
 				return nil
 			}},
+			logicalplan.WithFilter(logicalplan.Col("labels.label4").Eq(logicalplan.Literal("value4"))),
 		))
 		return nil
 	})
@@ -866,7 +861,6 @@ func Test_DoubleTable(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				defer ar.Release()
 				require.Equal(t, value, ar.Column(1).(*array.Float64).Value(0))
@@ -958,16 +952,14 @@ func Test_Table_EmptyRowGroup(t *testing.T) {
 			tx,
 			pool,
 			// Select all distinct values for the label1 column.
-			logicalplan.IterOptions{
-				Projection:      []logicalplan.Expr{&logicalplan.DynamicColumn{ColumnName: "label1"}},
-				DistinctColumns: []logicalplan.Expr{&logicalplan.DynamicColumn{ColumnName: "label1"}},
-			},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				rows += ar.NumRows()
 				defer ar.Release()
 
 				return nil
 			}},
+			logicalplan.WithProjection(&logicalplan.DynamicColumn{ColumnName: "label1"}),
+			logicalplan.WithDistinctColumns(&logicalplan.DynamicColumn{ColumnName: "label1"}),
 		)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), rows)
@@ -1022,7 +1014,6 @@ func Test_Table_NestedSchema(t *testing.T) {
 			tx,
 			pool,
 			// Select all distinct values for the label1 column.
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				records++
 				require.Equal(t, int64(1), ar.NumRows())
@@ -1155,7 +1146,6 @@ func Test_L0Query(t *testing.T) {
 			ctx,
 			tx,
 			pool,
-			logicalplan.IterOptions{},
 			[]logicalplan.Callback{func(ctx context.Context, ar arrow.Record) error {
 				records++
 				require.Equal(t, int64(3), ar.NumRows())


### PR DESCRIPTION
Refactored the `IterOptions` in the table interface to consume the option pattern to prevent having to pass empty structs for lots of unit testing.