### PR TITLE
concurrency: Use GOMAXPROCS instead of NumCPU

### DIFF
--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TODO: Make this smarter.
-var concurrencyHardcoded = runtime.NumCPU()
+var concurrencyHardcoded = runtime.GOMAXPROCS(0)
 
 type PhysicalPlan interface {
 	Callback(ctx context.Context, r arrow.Record) error

--- a/table.go
+++ b/table.go
@@ -92,7 +92,7 @@ func NewTableConfig(
 ) *TableConfig {
 	t := &TableConfig{
 		schema:           schema,
-		blockReaderLimit: runtime.NumCPU(),
+		blockReaderLimit: runtime.GOMAXPROCS(0),
 	}
 
 	for _, opt := range options {


### PR DESCRIPTION
By default, `runtime.GOMAXPROCS(0)` returns the same value as `runtime.NumCPU()`, but it will allow the user to configure the concurrency with the `GOMAXPROCS` environment variable (and potentially [go.uber.org/automaxprocs](https://pkg.go.dev/go.uber.org/automaxprocs) to follow the cgroup limit)

This unifies the handling of the concurrency value in FrostDB where half the code base was already doing so:

```console
$ rg GOMAXPROCS
compaction.go
37:             concurrency: runtime.GOMAXPROCS(0),

query/physicalplan/physicalplan.go
19:var concurrencyHardcoded = runtime.GOMAXPROCS(0)

table.go
95:             blockReaderLimit: runtime.GOMAXPROCS(0),

db.go
211:    errg.SetLimit(runtime.GOMAXPROCS(0))
```