### PR TITLE
*: fix all lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,8 @@ linters:
 
 issues:
   exclude-rules:
-    - path: _test.go
-      linters:
-        - errcheck
+    - path: bench_test.go
+      text: 'is unused'
 
 linters-settings:
   depguard:
@@ -40,3 +39,9 @@ linters-settings:
     extra-rules: true
   misspell:
     locale: US
+  staticcheck:
+    checks:
+      - all
+      # TODO: This ignores deprecated warnings. We should slowly transition to
+      # the new APIs for these warnings and remove this exclusion.
+      - '-SA1019'

--- a/logictest/runner.go
+++ b/logictest/runner.go
@@ -394,7 +394,7 @@ func arrayToStringVals(a arrow.Array) ([]string, error) {
 					result[i] = nullString
 					continue
 				}
-				result[i] = fmt.Sprintf("%s", dict.Value(col.GetValueIndex(i)))
+				result[i] = string(dict.Value(col.GetValueIndex(i)))
 			}
 		default:
 			return nil, fmt.Errorf("unhandled dictionary type: %T", dict)

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -630,6 +630,7 @@ func rowBasedParquetRowGroupToArrowRecord(
 	rows := rg.Rows()
 	defer rows.Close()
 	rowBuf := rowBufPool.Get().([]parquet.Row)
+	//nolint:staticcheck
 	defer rowBufPool.Put(rowBuf[:cap(rowBuf)])
 
 	for {

--- a/pqarrow/convert/convert.go
+++ b/pqarrow/convert/convert.go
@@ -177,11 +177,7 @@ func hasListFields(n parquet.Node) bool {
 	}
 
 	element := list.Fields()[0]
-	if !(element.Required() || element.Optional()) {
-		return false
-	}
-
-	return true
+	return element.Required() || element.Optional()
 }
 
 func mapType(n parquet.Node) (arrow.DataType, error) {

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -316,9 +316,7 @@ func (p *DistinctPushDown) optimize(plan *LogicalPlan, distinctColumns []Expr) {
 			plan.TableScan.Distinct = distinctColumns
 		}
 	case plan.Distinct != nil:
-		for _, expr := range plan.Distinct.Exprs {
-			distinctColumns = append(distinctColumns, expr)
-		}
+		distinctColumns = append(distinctColumns, plan.Distinct.Exprs...)
 	}
 
 	if plan.Input != nil {

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -23,7 +23,7 @@ func (e *PlanValidationError) Error() string {
 	message := make([]string, 0)
 	message = append(message, e.message)
 	message = append(message, "\n")
-	message = append(message, fmt.Sprintf("%s", e.plan))
+	message = append(message, e.plan.String())
 
 	for _, child := range e.children {
 		message = append(message, "\n  -> invalid expression: ")

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -355,9 +355,9 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 				groupByFields = append(groupByFields, field)
 				groupByArrays = append(groupByArrays, r.Column(i))
 
-				switch matcher.(type) {
+				switch v := matcher.(type) {
 				case *logicalplan.DurationExpr:
-					duration := matcher.(*logicalplan.DurationExpr).Value()
+					duration := v.Value()
 					groupByFieldHashes = append(groupByFieldHashes,
 						&durationHashCombine{milliseconds: uint64(duration.Milliseconds())},
 					)

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -170,7 +170,7 @@ func DictionaryArrayScalarNotEqual(left *array.Dictionary, right scalar.Scalar) 
 
 		switch dict := left.Dictionary().(type) {
 		case *array.Binary:
-			if bytes.Compare(dict.Value(left.GetValueIndex(i)), data) != 0 {
+			if !bytes.Equal(dict.Value(left.GetValueIndex(i)), data) {
 				res.Add(uint32(i))
 			}
 		case *array.String:
@@ -200,7 +200,7 @@ func DictionaryArrayScalarEqual(left *array.Dictionary, right scalar.Scalar) (*B
 
 		switch dict := left.Dictionary().(type) {
 		case *array.Binary:
-			if bytes.Compare(dict.Value(left.GetValueIndex(i)), data) == 0 {
+			if bytes.Equal(dict.Value(left.GetValueIndex(i)), data) {
 				res.Add(uint32(i))
 			}
 		case *array.String:
@@ -219,7 +219,7 @@ func FixedSizeBinaryArrayScalarEqual(left *array.FixedSizeBinary, right *scalar.
 		if left.IsNull(i) {
 			continue
 		}
-		if bytes.Compare(left.Value(i), right.Data()) == 0 {
+		if bytes.Equal(left.Value(i), right.Data()) {
 			res.Add(uint32(i))
 		}
 	}
@@ -234,7 +234,7 @@ func FixedSizeBinaryArrayScalarNotEqual(left *array.FixedSizeBinary, right *scal
 			res.Add(uint32(i))
 			continue
 		}
-		if bytes.Compare(left.Value(i), right.Data()) != 0 {
+		if !bytes.Equal(left.Value(i), right.Data()) {
 			res.Add(uint32(i))
 		}
 	}

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -187,9 +187,7 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			// This is pretty hacky and only fine because it's in the test only.
 			left, right := pop(v.exprStack)
 			var exprStack []logicalplan.Expr
-			for _, expr := range right {
-				exprStack = append(exprStack, expr)
-			}
+			exprStack = append(exprStack, right...)
 			switch l := left.(type) {
 			case *logicalplan.LiteralExpr:
 				val := l.Value.(*scalar.Int64)

--- a/table_test.go
+++ b/table_test.go
@@ -599,6 +599,7 @@ func Test_Table_NewTableValidSplitSize(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 	db, err = c.DB(context.Background(), "test")
+	require.NoError(t, err)
 	_, err = db.Table("test", NewTableConfig(dynparquet.NewSampleSchema()))
 	require.NoError(t, err)
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -76,9 +76,8 @@ type FileWAL struct {
 }
 
 type logRequest struct {
-	tx    uint64
-	data  []byte
-	errCh chan error
+	tx   uint64
+	data []byte
 }
 
 // min-heap based priority queue to synchronize log requests to be in order of


### PR DESCRIPTION
This PR fixes all the lint issues reported by golangci-lint that have creeped into the codebase over time as well as ignoring lint issues that would take too long to fix.

My idea is to make passing golangci-lint a required step before merging, otherwise there doesn't seem to be much use in having a linter.