### PR TITLE
dynparquet: create comparison rows according to sorting schema

### DIFF
--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -63,14 +63,18 @@ func (s *Schema) Cmp(a, b *DynamicRow) int {
 	if err != nil {
 		panic(fmt.Sprintf("unexpected schema state: %v", err))
 	}
-	// Iterate over all the sorting columns to prepare the rows for comparison.
+
+	// Iterate over all the schema columns to prepare the rows for comparison.
 	// The main reason we can't directly pass in {a,b}.Row is that they might
 	// not have explicit values for dynamic columns we want to compare. These
 	// columns need to be populated with a NULL value.
-	rowA := make(parquet.Row, 0, len(a.fields))
-	rowB := make(parquet.Row, 0, len(b.fields))
-	for _, col := range cols {
-		name := col.Path()[0] // Currently we only support flat schemas.
+	// Additionally, parquet imposes its column indexes when creating the
+	// sorting schema, so these need to be respected.
+	schemaCols := sortingSchema.Columns()
+	rowA := make(parquet.Row, 0, len(schemaCols))
+	rowB := make(parquet.Row, 0, len(schemaCols))
+	for _, path := range schemaCols {
+		name := path[0] // Currently we only support flat schemas.
 
 		aIndex := FindChildIndex(a.fields, name)
 		bIndex := FindChildIndex(b.fields, name)


### PR DESCRIPTION
When comparing two rows, the comparison code needs to merge the dynamic columns found in each row and create a copy of each row with the union of both dynamic column sets. These new row values were previously created in the same order as the sorting column names. However parquet assigns column indexes to each column name and this index does not necessarily correspond to the index into the slice of sorting columns. Therefore, the parquet comparison code could compare a value at an incorrect column index.

This commit iterates over the merged schema so that parquet comparison code lookups work successfully.