### PR TITLE
*: improve insert performance

### DIFF
--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -13,6 +13,17 @@ type DynamicRows struct {
 	fields         []parquet.Field
 }
 
+func NewDynamicRows(
+	rows []parquet.Row, schema *parquet.Schema, dynamicColumns map[string][]string, fields []parquet.Field,
+) *DynamicRows {
+	return &DynamicRows{
+		Schema:         schema,
+		DynamicColumns: dynamicColumns,
+		Rows:           rows,
+		fields:         fields,
+	}
+}
+
 func (r *DynamicRows) Get(i int) *DynamicRow {
 	return &DynamicRow{
 		Schema:         r.Schema,


### PR DESCRIPTION
Previously in the insert path, the rows to insert were iterated over once to determine the granule that each row belonged to and a second time to perform the insert. This commit improves performance by reading all the rows to insert once.

```
name            old time/op    new time/op    delta
InsertSimple-8    17.0ms ± 2%    15.1ms ± 2%  -11.15%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
InsertSimple-8    16.6MB ± 0%    13.5MB ± 1%  -18.51%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
InsertSimple-8      156k ± 0%      151k ± 0%   -3.23%  (p=0.000 n=10+10)
```