### PR TITLE
dynparquet: don't recompute dynamic column full name

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -347,3 +347,21 @@ func BenchmarkQuery(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkReplay(b *testing.B) {
+	b.Skip(skipReason)
+
+	for i := 0; i < b.N; i++ {
+		func() {
+			col, err := New(
+				WithWAL(),
+				WithStoragePath(storagePath),
+			)
+			require.NoError(b, err)
+			defer col.Close()
+			if err := col.ReplayWALs(context.Background()); err != nil {
+				b.Fatal(err)
+			}
+		}()
+	}
+}

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -70,8 +70,9 @@ func (nf nullsFirst) NullsFirst() bool { return true }
 
 func makeDynamicSortingColumn(dynamicColumnName string, sortingColumn SortingColumn) SortingColumn {
 	return dynamicSortingColumn{
-		dynamicColumnName: dynamicColumnName,
 		SortingColumn:     sortingColumn,
+		dynamicColumnName: dynamicColumnName,
+		fullName:          sortingColumn.ColumnName() + "." + dynamicColumnName,
 	}
 }
 
@@ -79,6 +80,7 @@ func makeDynamicSortingColumn(dynamicColumnName string, sortingColumn SortingCol
 type dynamicSortingColumn struct {
 	SortingColumn
 	dynamicColumnName string
+	fullName          string
 }
 
 func (dyn dynamicSortingColumn) String() string {
@@ -86,7 +88,7 @@ func (dyn dynamicSortingColumn) String() string {
 }
 
 func (dyn dynamicSortingColumn) ColumnName() string {
-	return dyn.SortingColumn.ColumnName() + "." + dyn.dynamicColumnName
+	return dyn.fullName
 }
 
 func (dyn dynamicSortingColumn) Path() []string { return []string{dyn.ColumnName()} }


### PR DESCRIPTION
This was a hot path during WAL replay. Computing the full name only once
provides an improvement when replaying production WALs:

```
name      old time/op    new time/op    delta
Replay-8     32.3s ± 2%     28.1s ± 9%  -13.02%  (p=0.000 n=9+10)

name      old alloc/op   new alloc/op   delta
Replay-8    81.5GB ± 1%    75.1GB ± 2%   -7.79%  (p=0.000 n=9+10)

name      old allocs/op  new allocs/op  delta
Replay-8      704M ± 2%      532M ± 4%  -24.51%  (p=0.000 n=9+10)
```