### PR TITLE
*: fix ReadRows usage

### DIFF
--- a/table.go
+++ b/table.go
@@ -971,6 +971,9 @@ func (t *TableBlock) Insert(ctx context.Context, tx uint64, buf *dynparquet.Seri
 	n := 0
 	for int64(n) < numRows {
 		readN, err := rows.ReadRows(rowBuf[n:])
+		for i := n; i < n+readN; i++ {
+			rowBuf[i] = rowBuf[i].Clone()
+		}
 		n += readN
 		if err != nil {
 			if err == io.EOF {


### PR DESCRIPTION
Rows read using ReadRows are not safe to reuse after a subsequent call to ReadRows. This commit changes calls to either use the rows right after the ReadRows call or calls Clone on the rows. Calling Clone has a slight perf hit on simple insert benchmarks:

```
name            old time/op    new time/op    delta
InsertSimple-8    15.7ms ± 1%    16.3ms ± 2%  +3.84%  (p=0.000 n=9+10)

name            old alloc/op   new alloc/op   delta
InsertSimple-8    13.5MB ± 1%    14.2MB ± 1%  +5.25%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
InsertSimple-8      150k ± 0%      164k ± 0%  +9.35%  (p=0.000 n=10+10)
```

But improves things when replaying a production WAL.

```
name      old time/op    new time/op    delta
Replay-8     65.6s ± 3%     60.6s ± 2%  -7.68%  (p=0.008 n=5+5)

name      old alloc/op   new alloc/op   delta
Replay-8    90.6GB ± 0%    87.3GB ± 1%  -3.70%  (p=0.008 n=5+5)

name      old allocs/op  new allocs/op  delta
Replay-8     1.18G ± 0%     1.10G ± 0%  -6.83%  (p=0.008 n=5+5)
```

This is because rows will actually be in sorted order, making it more efficient to insert into a b-tree when the insert batch is large.