### PR TITLE
Expect `io.EOF` at the end of files

### DIFF
--- a/storage/bucket.go
+++ b/storage/bucket.go
@@ -7,6 +7,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
@@ -60,10 +61,10 @@ func (b *FileReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		n, err = rc.Read(p[total:])
 		total += n
 		if err != nil {
-		    if errors.Is(err, io.EOF) {
-		        // If io.EOF is returned it means we read the end of the file and simply return the total.
-		        break
-		    }
+			if errors.Is(err, io.EOF) {
+				// If io.EOF is returned it means we read the end of the file and simply return the total.
+				break
+			}
 			return total, err
 		}
 	}


### PR DESCRIPTION
We expect an io.EOF at the end of files and in that case return total bytes read.

This is not an issue for the header of ranges within the file, however, especially when reading the parquet footer we read until the end of the file and this would previously return io.EOF even though it's expected.