### PR TITLE
wal: Recover panic when replaying WAL to print more context

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -410,8 +409,7 @@ func (w *FileWAL) Replay(handler func(tx uint64, record *walpb.Record) error) er
 		// recover the panic to print more context. Exit afterwards regardless.
 		if err := recover(); err != nil {
 			level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
-			debug.PrintStack()
-			os.Exit(2)
+			panic(err)
 		}
 	}()
 

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -409,6 +410,7 @@ func (w *FileWAL) Replay(handler func(tx uint64, record *walpb.Record) error) er
 		// recover the panic to print more context. Exit afterwards regardless.
 		if err := recover(); err != nil {
 			level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
+			debug.PrintStack()
 			os.Exit(2)
 		}
 	}()

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -405,6 +405,14 @@ func (w *FileWAL) Replay(handler func(tx uint64, record *walpb.Record) error) er
 
 	level.Debug(w.logger).Log("msg", "replaying WAL", "first_index", firstIndex, "last_index", lastIndex)
 
+	defer func() {
+		// recover the panic to print more context. Exit afterwards regardless.
+		if err := recover(); err != nil {
+			level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
+			os.Exit(2)
+		}
+	}()
+
 	for tx := firstIndex; tx <= lastIndex; tx++ {
 		level.Debug(w.logger).Log("msg", "replaying WAL record", "tx", tx)
 		data, err := w.log.Read(tx)


### PR DESCRIPTION
This should be super helpful when troubleshooting WAL replays. 
The `"path"` plus `"first_index"` should guide one directly to the corrupted file.

We still fail hard after recovering. We just have more context now. 