### PR TITLE
query: Return error if schema is nil after building physical plan

### DIFF
--- a/query/engine.go
+++ b/query/engine.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/memory"
@@ -159,11 +160,16 @@ func (b LocalQueryBuilder) buildPhysical(ctx context.Context) (*physicalplan.Out
 		logicalPlan = optimizer.Optimize(logicalPlan)
 	}
 
+	schema := logicalPlan.InputSchema()
+	if schema == nil {
+		return nil, fmt.Errorf("logical plan schema is nil")
+	}
+
 	return physicalplan.Build(
 		ctx,
 		b.pool,
 		b.tracer,
-		logicalPlan.InputSchema(),
+		schema,
 		logicalPlan,
 		b.execOpts...,
 	)

--- a/query/engine.go
+++ b/query/engine.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/memory"
@@ -160,16 +159,11 @@ func (b LocalQueryBuilder) buildPhysical(ctx context.Context) (*physicalplan.Out
 		logicalPlan = optimizer.Optimize(logicalPlan)
 	}
 
-	schema := logicalPlan.InputSchema()
-	if schema == nil {
-		return nil, fmt.Errorf("logical plan schema is nil")
-	}
-
 	return physicalplan.Build(
 		ctx,
 		b.pool,
 		b.tracer,
-		schema,
+		logicalPlan.InputSchema(),
 		logicalPlan,
 		b.execOpts...,
 	)

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -354,6 +354,10 @@ func Build(
 			oInfo.nodeMaintainsOrdering()
 		case plan.Aggregation != nil:
 			schema := s.ParquetSchema()
+			if schema == nil {
+				visitErr = fmt.Errorf("aggregation got empty schema")
+				return false
+			}
 			ordered, err := shouldPlanOrderedAggregate(execOpts, oInfo, plan.Aggregation)
 			if err != nil {
 				// TODO(asubiotto): Log the error.


### PR DESCRIPTION
This will mostly likely occur in a distributed storage fashion and is less likely for Parca itself. 