### PR TITLE
Fix panic on nil cols

### DIFF
--- a/binaryscalarexpr.go
+++ b/binaryscalarexpr.go
@@ -111,7 +111,13 @@ func Min(chunk parquet.ColumnChunk) parquet.Value {
 	columnIndex := chunk.ColumnIndex()
 	min := columnIndex.MinValue(0)
 	for i := 1; i < columnIndex.NumPages(); i++ {
-		if v := columnIndex.MinValue(i); compare(min, v) == 1 {
+		v := columnIndex.MinValue(i)
+		if min.IsNull() {
+			min = v
+			continue
+		}
+
+		if compare(min, v) == 1 {
 			min = v
 		}
 	}
@@ -124,7 +130,13 @@ func Max(chunk parquet.ColumnChunk) parquet.Value {
 	columnIndex := chunk.ColumnIndex()
 	max := columnIndex.MaxValue(0)
 	for i := 1; i < columnIndex.NumPages(); i++ {
-		if v := columnIndex.MaxValue(i); compare(max, v) == -1 {
+		v := columnIndex.MaxValue(i)
+		if max.IsNull() {
+			max = v
+			continue
+		}
+
+		if compare(max, v) == -1 {
 			max = v
 		}
 	}

--- a/binaryscalarexpr_test.go
+++ b/binaryscalarexpr_test.go
@@ -1,0 +1,58 @@
+package frostdb
+
+import (
+	"testing"
+
+	"github.com/segmentio/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeColumnChunk struct {
+	index *FakeColumnIndex
+}
+
+func (f *FakeColumnChunk) Type() parquet.Type               { return nil }
+func (f *FakeColumnChunk) Column() int                      { return 0 }
+func (f *FakeColumnChunk) Pages() parquet.Pages             { return nil }
+func (f *FakeColumnChunk) ColumnIndex() parquet.ColumnIndex { return f.index }
+func (f *FakeColumnChunk) OffsetIndex() parquet.OffsetIndex { return nil }
+func (f *FakeColumnChunk) BloomFilter() parquet.BloomFilter { return nil }
+func (f *FakeColumnChunk) NumValues() int64                 { return 0 }
+
+type FakeColumnIndex struct {
+	numpages func() int
+}
+
+func (f *FakeColumnIndex) NumPages() int {
+	if f.numpages != nil {
+		return f.numpages()
+	}
+	return 0
+}
+func (f *FakeColumnIndex) NullCount(int) int64        { return 0 }
+func (f *FakeColumnIndex) NullPage(int) bool          { return false }
+func (f *FakeColumnIndex) MinValue(int) parquet.Value { return parquet.ValueOf(nil) }
+func (f *FakeColumnIndex) MaxValue(int) parquet.Value { return parquet.ValueOf(nil) }
+func (f *FakeColumnIndex) IsAscending() bool          { return false }
+func (f *FakeColumnIndex) IsDescending() bool         { return false }
+
+/*
+	This is a regression test that ensures the Min/Max functions return a null value (instead of panicing)
+	should they be passed a column chunk that only has null values.
+*/
+func Test_MinMax_EmptyColumnChunk(t *testing.T) {
+
+	fakeChunk := &FakeColumnChunk{
+		index: &FakeColumnIndex{
+			numpages: func() int {
+				return 10
+			},
+		},
+	}
+
+	v := Min(fakeChunk)
+	require.True(t, v.IsNull())
+
+	v = Max(fakeChunk)
+	require.True(t, v.IsNull())
+}

--- a/binaryscalarexpr_test.go
+++ b/binaryscalarexpr_test.go
@@ -41,7 +41,6 @@ func (f *FakeColumnIndex) IsDescending() bool         { return false }
 	should they be passed a column chunk that only has null values.
 */
 func Test_MinMax_EmptyColumnChunk(t *testing.T) {
-
 	fakeChunk := &FakeColumnChunk{
 		index: &FakeColumnIndex{
 			numpages: func() int {


### PR DESCRIPTION
The Min/Max functions could panic with 
```
panic: unsupported value comparison: Type(?) [recovered]
	panic: unsupported value comparison: Type(?)

goroutine 5 [running]:
testing.tRunner.func1.2({0x102a34080, 0x1400033b990})
	/usr/local/go/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1399 +0x378
panic({0x102a34080, 0x1400033b990})
	/usr/local/go/src/runtime/panic.go:884 +0x204
github.com/polarsignals/frostdb.compare({0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, {0x0, 0x0, 0x0, 0x0, ...})
	/Users/thor/go/src/github.com/polarsignals/frostdb/binaryscalarexpr.go:151 +0x320
```

When a column chunk had all null values. This adds a check to those functions to properly handle a empty column chunk.