### PR TITLE
unit test: read only table queries

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1384,3 +1384,64 @@ func Test_DB_TableWrite_ArrowRecord(t *testing.T) {
 		})
 	}
 }
+
+func Test_DB_ReadOnlyQuery(t *testing.T) {
+	config := NewTableConfig(
+		dynparquet.NewSampleSchema(),
+	)
+
+	logger := newTestLogger(t)
+
+	dir := t.TempDir()
+	bucket, err := filesystem.NewBucket(dir)
+	require.NoError(t, err)
+
+	c, err := New(
+		WithLogger(logger),
+		WithWAL(),
+		WithStoragePath(dir),
+		WithBucketStorage(bucket),
+		WithActiveMemorySize(100*1024),
+	)
+	require.NoError(t, err)
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	samples := dynparquet.NewTestSamples()
+
+	ctx := context.Background()
+	for i := 0; i < 100; i++ {
+		buf, err := samples.ToBuffer(table.Schema())
+		require.NoError(t, err)
+		_, err = table.InsertBuffer(ctx, buf)
+		require.NoError(t, err)
+	}
+	require.NoError(t, table.EnsureCompaction())
+	require.NoError(t, c.Close())
+
+	c, err = New(
+		WithLogger(logger),
+		WithWAL(),
+		WithStoragePath(dir),
+		WithBucketStorage(bucket),
+		WithActiveMemorySize(100*1024),
+	)
+	require.NoError(t, err)
+	defer c.Close()
+	require.NoError(t, c.ReplayWALs(context.Background()))
+
+	// Query with an aggregat query
+	pool := memory.NewGoAllocator()
+	engine := query.NewEngine(pool, db.TableProvider())
+	err = engine.ScanTable(t.Name()).
+		Aggregate(
+			[]logicalplan.Expr{logicalplan.Sum(logicalplan.Col("value"))},
+			[]logicalplan.Expr{logicalplan.Col("labels.label2")},
+		).
+		Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+			return nil
+		})
+	require.NoError(t, err)
+}

--- a/db_test.go
+++ b/db_test.go
@@ -1435,7 +1435,7 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 	// Query with an aggregat query
 	pool := memory.NewGoAllocator()
 	engine := query.NewEngine(pool, db.TableProvider())
-	err = engine.ScanTable(t.Name()).
+	err = engine.ScanTable("test").
 		Aggregate(
 			[]logicalplan.Expr{logicalplan.Sum(logicalplan.Col("value"))},
 			[]logicalplan.Expr{logicalplan.Col("labels.label2")},

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -647,6 +647,10 @@ func (a *CountAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) 
 // the set of values. It is aware of the final stage and chooses the aggregation
 // function appropriately.
 func runAggregation(finalStage bool, fn logicalplan.AggFunc, pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error) {
+	if len(arrs) == 0 {
+		return array.NewInt64Builder(pool).NewArray(), nil
+	}
+
 	aggFunc, err := chooseAggregationFunction(fn, arrs[0].DataType())
 	if err != nil {
 		return nil, err

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/apache/arrow/go/v10/arrow/memory"
 	"github.com/apache/arrow/go/v10/arrow/scalar"
 	"github.com/dgryski/go-metro"
-	"github.com/segmentio/parquet-go"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/polarsignals/frostdb/pqarrow/builder"
@@ -23,7 +22,6 @@ import (
 func Aggregate(
 	pool memory.Allocator,
 	tracer trace.Tracer,
-	s *parquet.Schema,
 	agg *logicalplan.Aggregation,
 	final bool,
 	ordered bool,
@@ -58,18 +56,8 @@ func Aggregate(
 			return nil, errors.New("aggregation column not found")
 		}
 
-		dataType, err := expr.DataType(s)
-		if err != nil {
-			return nil, err
-		}
-
-		f, err := chooseAggregationFunction(aggFunc, dataType)
-		if err != nil {
-			return nil, err
-		}
-
 		aggregation.resultName = expr.Name()
-		aggregation.function = f
+		aggregation.function = aggFunc
 
 		aggregations = append(aggregations, aggregation)
 	}
@@ -137,7 +125,7 @@ func chooseAggregationFunction(
 type Aggregation struct {
 	expr       logicalplan.Expr
 	resultName string
-	function   AggregationFunction
+	function   logicalplan.AggFunc
 	arrays     []builder.ColumnBuilder // TODO: These can actually live outside this struct and be shared. Only at the very end will they be read by each column and then aggregated separately.
 }
 
@@ -658,16 +646,16 @@ func (a *CountAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) 
 // runAggregation is a helper to run the given aggregation function given
 // the set of values. It is aware of the final stage and chooses the aggregation
 // function appropriately.
-func runAggregation(
-	finalStage bool,
-	fn AggregationFunction,
-	pool memory.Allocator,
-	arrs []arrow.Array,
-) (arrow.Array, error) {
-	if _, ok := fn.(*CountAggregation); ok && finalStage {
+func runAggregation(finalStage bool, fn logicalplan.AggFunc, pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error) {
+	aggFunc, err := chooseAggregationFunction(fn, arrs[0].DataType())
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := aggFunc.(*CountAggregation); ok && finalStage {
 		// The final stage of aggregation needs to sum up all the counts of the
 		// previous steps, instead of counting the previous counts.
 		return (&Int64SumAggregation{}).Aggregate(pool, arrs)
 	}
-	return fn.Aggregate(pool, arrs)
+	return aggFunc.Aggregate(pool, arrs)
 }

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -46,7 +46,7 @@ type OrderedAggregate struct {
 	tracer                trace.Tracer
 	resultColumnName      string
 	groupByColumnMatchers []logicalplan.Expr
-	aggregationFunction   AggregationFunction
+	aggregationFunction   logicalplan.AggFunc
 	next                  PhysicalPlan
 	columnToAggregate     logicalplan.Expr
 	// Indicate is this is the last aggregation or if this is an aggregation

--- a/query/physicalplan/ordered_aggregate_test.go
+++ b/query/physicalplan/ordered_aggregate_test.go
@@ -169,7 +169,7 @@ func TestOrderedAggregate(t *testing.T) {
 				Aggregation{
 					expr:       logicalplan.Col(valColName),
 					resultName: "result",
-					function:   &Int64SumAggregation{},
+					function:   logicalplan.AggFuncSum,
 				},
 				groupCols,
 				true,
@@ -275,7 +275,7 @@ func TestOrderedAggregateDynCols(t *testing.T) {
 		trace.NewNoopTracerProvider().Tracer(""),
 		Aggregation{
 			expr:     logicalplan.Col(valColName),
-			function: &Int64SumAggregation{},
+			function: logicalplan.AggFuncSum,
 		},
 		[]logicalplan.Expr{
 			logicalplan.DynCol(dynColName),

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -373,7 +373,7 @@ func Build(
 				}
 			}
 			for i := 0; i < len(prev); i++ {
-				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, sync == nil, ordered)
+				a, err := Aggregate(pool, tracer, plan.Aggregation, sync == nil, ordered)
 				if err != nil {
 					visitErr = err
 					return false
@@ -387,7 +387,7 @@ func Build(
 			if sync != nil {
 				// Plan an aggregate operator to run an aggregation on all the
 				// aggregations.
-				a, err := Aggregate(pool, tracer, schema, plan.Aggregation, true, ordered)
+				a, err := Aggregate(pool, tracer, plan.Aggregation, true, ordered)
 				if err != nil {
 					visitErr = err
 					return false

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -353,11 +353,6 @@ func Build(
 			oInfo.applyFilter(plan.Filter.Expr)
 			oInfo.nodeMaintainsOrdering()
 		case plan.Aggregation != nil:
-			schema := s.ParquetSchema()
-			if schema == nil {
-				visitErr = fmt.Errorf("aggregation got empty schema")
-				return false
-			}
 			ordered, err := shouldPlanOrderedAggregate(execOpts, oInfo, plan.Aggregation)
 			if err != nil {
 				// TODO(asubiotto): Log the error.


### PR DESCRIPTION
Performs an aggregation read on a read only table. Aggregations require a schema, and this causes a panic as read only tables do not have a schema set.