### PR TITLE
Serialize less memory

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -409,6 +409,7 @@ func Benchmark_Serialize(b *testing.B) {
 	// Insert 10k rows
 	samples := NewTestSamples(10000)
 	buf, err := samples.ToBuffer(schema)
+	require.NoError(b, err)
 
 	_, err = tbl.InsertBuffer(ctx, buf)
 	require.NoError(b, err)

--- a/bench_test.go
+++ b/bench_test.go
@@ -3,6 +3,8 @@ package frostdb
 import (
 	"context"
 	"errors"
+	"io"
+	"math/rand"
 	"sort"
 	"strings"
 	"testing"
@@ -11,8 +13,10 @@ import (
 	"github.com/apache/arrow/go/v10/arrow"
 	"github.com/apache/arrow/go/v10/arrow/array"
 	"github.com/apache/arrow/go/v10/arrow/memory"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/query"
 	"github.com/polarsignals/frostdb/query/logicalplan"
@@ -363,5 +367,55 @@ func BenchmarkReplay(b *testing.B) {
 				b.Fatal(err)
 			}
 		}()
+	}
+}
+
+func NewTestSamples(num int) dynparquet.Samples {
+	samples := make(dynparquet.Samples, 0, num)
+	for i := 0; i < num; i++ {
+		samples = append(samples,
+			dynparquet.Sample{
+				ExampleType: "cpu",
+				Labels: []dynparquet.Label{{
+					Name:  "node",
+					Value: "test3",
+				}},
+				Stacktrace: []uuid.UUID{
+					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+				},
+				Timestamp: rand.Int63n(100000),
+				Value:     rand.Int63(),
+			},
+		)
+	}
+	return samples
+}
+
+func Benchmark_Serialize(b *testing.B) {
+	ctx := context.Background()
+	schema := dynparquet.NewSampleSchema()
+
+	col, err := New()
+	require.NoError(b, err)
+	defer col.Close()
+
+	db, err := col.DB(ctx, "test")
+	require.NoError(b, err)
+
+	tbl, err := db.Table("test", NewTableConfig(schema))
+	require.NoError(b, err)
+
+	// Insert 10k rows
+	samples := NewTestSamples(10000)
+	buf, err := samples.ToBuffer(schema)
+
+	_, err = tbl.InsertBuffer(ctx, buf)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Serialize the table
+		require.NoError(b, tbl.active.Serialize(io.Discard))
 	}
 }

--- a/compaction.go
+++ b/compaction.go
@@ -593,12 +593,12 @@ func compactLevel0IntoLevel1(
 		for {
 			var mergedBytes bytes.Buffer
 			n, err := func() (int, error) {
-				writer, err := t.RowWriter(&mergedBytes, merged.DynamicColumns(), WithMaxRows(estimatedRowsPerPart))
+				writer, err := t.rowWriter(&mergedBytes, merged.DynamicColumns(), withMaxRows(estimatedRowsPerPart))
 				if err != nil {
 					return 0, err
 				}
-				defer writer.Close()
-				n, err := writer.WriteRows(rows)
+				defer writer.close()
+				n, err := writer.writeRows(rows)
 				if err != nil {
 					return 0, err
 				}

--- a/table.go
+++ b/table.go
@@ -1416,7 +1416,7 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 		}
 
 		// Merge the Granule row groups
-		merged, err := t.table.config.schema.MergeRowGroups(dynCols, rgs)
+		merged, err := t.table.config.schema.MergeDynamicRowGroups(rgs, dynparquet.WithDynamicCols(dynCols))
 		if err != nil {
 			ascendErr = err
 			return false

--- a/table.go
+++ b/table.go
@@ -1339,14 +1339,6 @@ func (t *TableBlock) abortCompaction(granule *Granule) {
 	}
 }
 
-func mergeDynCols(a, b map[string][]string) map[string][]string {
-	for key, vals := range b {
-		a[key] = append(a[key], vals...)
-	}
-
-	return bufutils.Dedupe(a)
-}
-
 // Serialize the table block into a single Parquet file.
 // The Serialize function will walk all Granules in the block, compact each Granule into a sorted set of Row groups, then write those
 // row groups to the final Parquet file, repeating for each Granule. This leverages the fact that the index has alreayd sorted the Granules
@@ -1457,21 +1449,6 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 	}
 
 	return nil
-}
-
-// writeRowGroups writes a set of dynamic row groups to a writer.
-func (t *TableBlock) writeRowGroups(writer io.Writer, rowGroups []dynparquet.DynamicRowGroup) error {
-	merged, err := t.table.config.schema.MergeDynamicRowGroups(rowGroups)
-	if err != nil {
-		return err
-	}
-
-	cols := merged.DynamicColumns()
-	rows := merged.Rows()
-	defer rows.Close()
-
-	_, err = t.writeRows(writer, rows, cols, 0)
-	return err
 }
 
 // writeRows writes the given rows to a writer. Up to maxNumRows will be


### PR DESCRIPTION
This updates the `Serialize` function 

Previously we were collecting all row groups in the entire table block, and using the parquet merge function to merge all the row groups into a single row group. This causes a large memory spike because we would load at least a page for every row group (or maybe 2 if we're async reading the pages) into memory to perform the heap sort of all the row groups.

Instead of doing that; we can leverage the fact that Granules are already sorted in relation to each other and instead merge each Granules row groups into a single one, and write that directly to the final file. The benchmark shows some considerable gains in memory, and speed.

```
thor@thors-MacBook-Pro frostdb % benchstat before.txt after.txt
name           old time/op    new time/op    delta
_Serialize-10    3.38ms ± 3%    1.42ms ± 0%  -58.13%  (p=0.008 n=5+5)

name           old alloc/op   new alloc/op   delta
_Serialize-10    3.94MB ± 0%    0.13MB ± 0%  -96.59%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
_Serialize-10     40.2k ± 0%      1.2k ± 0%  -97.04%  (p=0.008 n=5+5)
```