### PR TITLE
Add info logs for starting and finishing WAL replays

### DIFF
--- a/db.go
+++ b/db.go
@@ -394,6 +394,8 @@ func (db *DB) snapshotsDir() string {
 }
 
 func (db *DB) replayWAL(ctx context.Context) error {
+	level.Info(db.logger).Log("msg", "replaying WAL")
+	start := time.Now()
 	// persistedTables is a map from a table name to the last transaction
 	// persisted.
 	persistedTables := map[string]uint64{}
@@ -558,6 +560,8 @@ func (db *DB) replayWAL(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("second WAL replay: %w", err)
 	}
+
+	level.Info(db.logger).Log("msg", "replaying WAL completed", "duration", time.Since(start))
 
 	db.tx.Store(lastTx)
 	db.highWatermark.Store(lastTx)


### PR DESCRIPTION
As discussed we want to have some more insight into replaying WAL that's not super detailed debug logs but when it starts and stops.

```
...
level=info db=parca name=parca ts=2023-03-07T12:46:12.961225674Z caller=db.go:397 msg="replaying WAL"
level=info db=parca name=parca ts=2023-03-07T12:46:26.226864676Z caller=db.go:564 msg="replaying WAL completed" duration=13.265576152s
...
```