### PR TITLE
Replay wal on open

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -38,17 +38,13 @@ const (
 func newDBForBenchmarks(ctx context.Context, b testing.TB) (*ColumnStore, *DB, error) {
 	b.Helper()
 
+	b.Logf("replaying WAL")
+	start := time.Now()
 	col, err := New(
 		WithWAL(),
 		WithStoragePath(storagePath),
 	)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	b.Logf("replaying WAL")
-	start := time.Now()
-	if err := col.ReplayWALs(ctx); err != nil {
 		return nil, nil, err
 	}
 	b.Logf("replayed WAL in %s", time.Since(start))
@@ -363,9 +359,6 @@ func BenchmarkReplay(b *testing.B) {
 			)
 			require.NoError(b, err)
 			defer col.Close()
-			if err := col.ReplayWALs(context.Background()); err != nil {
-				b.Fatal(err)
-			}
 		}()
 	}
 }

--- a/db.go
+++ b/db.go
@@ -259,11 +259,11 @@ func (s *ColumnStore) ReplayWALs(ctx context.Context) error {
 	for _, f := range files {
 		databaseName := f.Name()
 		g.Go(func() error {
-			db, err := s.DB(ctx, databaseName)
+			_, err := s.DB(ctx, databaseName)
 			if err != nil {
 				return err
 			}
-			return db.recover(ctx)
+			return nil
 		})
 	}
 
@@ -350,14 +350,6 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 		db.bucket = storage.NewPrefixedBucket(s.bucket, db.name)
 	}
 
-	if s.enableWAL {
-		var err error
-		db.wal, err = db.openWAL()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if dbSetupErr := func() error {
 		db.txPool = NewTxPool(db.highWatermark)
 		db.compactorPool = newCompactorPool(db, s.compactionConfig)
@@ -372,6 +364,20 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 				return nil
 			}); err != nil {
 				return fmt.Errorf("bucket iter on database open: %w", err)
+			}
+		}
+
+		if s.enableWAL {
+			snapshotTx, err := db.loadLatestSnapshot(ctx)
+			if err != nil {
+				level.Debug(s.logger).Log(
+					"msg", "failed to load latest snapshot", "db", db.name, "err", err,
+				)
+				snapshotTx = 0
+			}
+			db.wal, err = db.openWAL(ctx, snapshotTx)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -404,12 +410,26 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 	return db, nil
 }
 
-func (db *DB) openWAL() (WAL, error) {
-	return wal.Open(
+func (db *DB) openWAL(ctx context.Context, firstIndex uint64) (WAL, error) {
+	// persistedTables is a map from a table name to the last transaction
+	// persisted.
+	persistedTables := map[string]uint64{}
+	lastTx := uint64(0)
+	wal, err := wal.Open(
 		db.logger,
 		db.reg,
 		db.walDir(),
+		wal.WithFirstIndex(firstIndex),
+		wal.WithReplayFunc(2, db.recover(ctx, persistedTables, &lastTx)),
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	db.tx.Store(lastTx)
+	db.highWatermark.Store(lastTx)
+
+	return wal, nil
 }
 
 func (db *DB) walDir() string {
@@ -422,7 +442,7 @@ func (db *DB) snapshotsDir() string {
 
 // recover attempts to recover database state from a combination of snapshots
 // and the WAL.
-func (db *DB) recover(ctx context.Context) error {
+func (db *DB) recover(ctx context.Context, persistedTables map[string]uint64, lastTx *uint64) wal.ReplayHandlerFunc {
 	level.Info(db.logger).Log("msg", "recovering db")
 	snapshotLoadStart := time.Now()
 	snapshotTx, err := db.loadLatestSnapshot(ctx)
@@ -456,7 +476,9 @@ func (db *DB) recover(ctx context.Context) error {
 
 	firstIndex, err := db.wal.FirstIndex()
 	if err != nil {
-		return err
+		level.Info(db.logger).Log(
+			"msg", "failed to get WAL first index",
+			"err", err)
 	}
 
 	if snapshotTx > firstIndex {
@@ -477,190 +499,177 @@ func (db *DB) recover(ctx context.Context) error {
 		}
 	}
 
-	start := time.Now()
-	// persistedTables is a map from a table name to the last transaction
-	// persisted.
-	persistedTables := map[string]uint64{}
-	if err := db.wal.Replay(snapshotTx, func(tx uint64, record *walpb.Record) error {
-		switch e := record.Entry.EntryType.(type) {
-		case *walpb.Entry_TableBlockPersisted_:
-			persistedTables[e.TableBlockPersisted.TableName] = tx
-			if tx > snapshotTx {
-				// The loaded snapshot has data in a table that has been
-				// persisted. Delete all data in this table, since it has
-				// already been persisted.
-				db.mtx.Lock()
-				if table, ok := db.tables[e.TableBlockPersisted.TableName]; ok {
-					table.ActiveBlock().index.Store(btree.New(table.db.columnStore.indexDegree))
+	return func(i int, tx uint64, record *walpb.Record) error {
+		switch i {
+		case 0:
+			switch e := record.Entry.EntryType.(type) {
+			case *walpb.Entry_TableBlockPersisted_:
+				persistedTables[e.TableBlockPersisted.TableName] = tx
+				if tx > snapshotTx {
+					// The loaded snapshot has data in a table that has been
+					// persisted. Delete all data in this table, since it has
+					// already been persisted.
+					db.mtx.Lock()
+					if table, ok := db.tables[e.TableBlockPersisted.TableName]; ok {
+						table.ActiveBlock().index.Store(btree.New(table.db.columnStore.indexDegree))
+					}
+					db.mtx.Unlock()
 				}
-				db.mtx.Unlock()
 			}
-		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("first WAL replay: %w", err)
-	}
+			return nil
+		case 1:
+			*lastTx = tx
+			switch e := record.Entry.EntryType.(type) {
+			case *walpb.Entry_NewTableBlock_:
+				entry := e.NewTableBlock
+				var schema proto.Message
+				switch v := entry.Schema.(type) {
+				case *walpb.Entry_NewTableBlock_DeprecatedSchema:
+					schema = v.DeprecatedSchema
+				case *walpb.Entry_NewTableBlock_SchemaV2:
+					schema = v.SchemaV2
+				default:
+					return fmt.Errorf("unhandled schema type: %T", v)
+				}
 
-	lastTx := uint64(0)
-	if err := db.wal.Replay(firstIndex, func(tx uint64, record *walpb.Record) error {
-		lastTx = tx
-		switch e := record.Entry.EntryType.(type) {
-		case *walpb.Entry_NewTableBlock_:
-			entry := e.NewTableBlock
-			var schema proto.Message
-			switch v := entry.Schema.(type) {
-			case *walpb.Entry_NewTableBlock_DeprecatedSchema:
-				schema = v.DeprecatedSchema
-			case *walpb.Entry_NewTableBlock_SchemaV2:
-				schema = v.SchemaV2
-			default:
-				return fmt.Errorf("unhandled schema type: %T", v)
-			}
+				var id ulid.ULID
+				if err := id.UnmarshalBinary(entry.BlockId); err != nil {
+					return err
+				}
 
-			var id ulid.ULID
-			if err := id.UnmarshalBinary(entry.BlockId); err != nil {
-				return err
-			}
+				if lastPersistedTx, ok := persistedTables[entry.TableName]; ok && tx < lastPersistedTx {
+					// This block has already been successfully persisted, so we can
+					// skip it.
+					return nil
+				}
 
-			if lastPersistedTx, ok := persistedTables[entry.TableName]; ok && tx < lastPersistedTx {
-				// This block has already been successfully persisted, so we can
-				// skip it.
-				return nil
-			}
+				tableName := entry.TableName
+				table, err := db.GetTable(tableName)
+				var tableErr ErrTableNotFound
+				if errors.As(err, &tableErr) {
+					schema, err := dynparquet.SchemaFromDefinition(schema)
+					if err != nil {
+						return fmt.Errorf("initialize schema: %w", err)
+					}
+					config := NewTableConfig(schema)
+					// TODO: May be we should acquire mutux lock when mutating d.roTables and d.tables?
+					// s.DB creates read only Table instance when BucketStore is configured.
+					// Make sure to use the existing Table instace instead of creating new one to avoid dangling instance.
+					table, ok := db.roTables[tableName]
+					if ok {
+						delete(db.roTables, tableName)
+						table.config = config
+					} else {
+						table, err = newTable(
+							db,
+							tableName,
+							config,
+							db.reg,
+							db.logger,
+							db.tracer,
+							db.wal,
+						)
+					}
+					if err != nil {
+						return fmt.Errorf("instantiate table: %w", err)
+					}
 
-			tableName := entry.TableName
-			table, err := db.GetTable(tableName)
-			var tableErr ErrTableNotFound
-			if errors.As(err, &tableErr) {
-				schema, err := dynparquet.SchemaFromDefinition(schema)
+					table.active, err = newTableBlock(table, 0, tx, id)
+					if err != nil {
+						return err
+					}
+					db.mtx.Lock()
+					db.tables[tableName] = table
+					db.mtx.Unlock()
+					return nil
+				}
 				if err != nil {
-					return fmt.Errorf("initialize schema: %w", err)
-				}
-				config := NewTableConfig(schema)
-				// TODO: May be we should acquire mutux lock when mutating d.roTables and d.tables?
-				// s.DB creates read only Table instance when BucketStore is configured.
-				// Make sure to use the existing Table instace instead of creating new one to avoid dangling instance.
-				table, ok := db.roTables[tableName]
-				if ok {
-					delete(db.roTables, tableName)
-					table.config = config
-				} else {
-					table, err = newTable(
-						db,
-						tableName,
-						config,
-						db.reg,
-						db.logger,
-						db.tracer,
-						db.wal,
-					)
-				}
-				if err != nil {
-					return fmt.Errorf("instantiate table: %w", err)
+					return fmt.Errorf("get table: %w", err)
 				}
 
-				table.active, err = newTableBlock(table, 0, tx, id)
+				// If we get to this point it means a block was finished but did
+				// not get persisted.
+				table.pendingBlocks[table.active] = struct{}{}
+				go table.writeBlock(ctx, table.active)
+
+				if !proto.Equal(schema, table.config.schema.Definition()) {
+					// If schemas are identical from block to block we should we
+					// reuse the previous schema in order to retain pooled memory
+					// for it.
+					schema, err := dynparquet.SchemaFromDefinition(schema)
+					if err != nil {
+						return fmt.Errorf("initialize schema: %w", err)
+					}
+
+					table.config.schema = schema
+				}
+
+				table.active, err = newTableBlock(table, table.active.minTx, tx, id)
 				if err != nil {
 					return err
 				}
-				db.mtx.Lock()
-				db.tables[tableName] = table
-				db.mtx.Unlock()
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("get table: %w", err)
-			}
+			case *walpb.Entry_Write_:
+				entry := e.Write
+				tableName := entry.TableName
+				if lastPersistedTx, ok := persistedTables[tableName]; ok && tx < lastPersistedTx {
+					// This write has already been successfully persisted, so we can
+					// skip it.
+					return nil
+				}
 
-			// If we get to this point it means a block was finished but did
-			// not get persisted.
-			table.pendingBlocks[table.active] = struct{}{}
-			go table.writeBlock(ctx, table.active)
-
-			if !proto.Equal(schema, table.config.schema.Definition()) {
-				// If schemas are identical from block to block we should we
-				// reuse the previous schema in order to retain pooled memory
-				// for it.
-				schema, err := dynparquet.SchemaFromDefinition(schema)
+				table, err := db.GetTable(tableName)
+				var tableErr ErrTableNotFound
+				if errors.As(err, &tableErr) {
+					// This means the WAL was truncated at a point where this write
+					// was already successfully persisted to disk in more optimized
+					// form than the WAL.
+					return nil
+				}
 				if err != nil {
-					return fmt.Errorf("initialize schema: %w", err)
+					return fmt.Errorf("get table: %w", err)
 				}
 
-				table.config.schema = schema
-			}
+				switch e.Write.Arrow {
+				case true:
+					reader, err := ipc.NewReader(bytes.NewReader(entry.Data))
+					if err != nil {
+						return fmt.Errorf("create ipc reader: %w", err)
+					}
+					record, err := reader.Read()
+					if err != nil {
+						return fmt.Errorf("read record: %w", err)
+					}
 
-			table.active, err = newTableBlock(table, table.active.minTx, tx, id)
-			if err != nil {
-				return err
-			}
-		case *walpb.Entry_Write_:
-			entry := e.Write
-			tableName := entry.TableName
-			if lastPersistedTx, ok := persistedTables[tableName]; ok && tx < lastPersistedTx {
-				// This write has already been successfully persisted, so we can
-				// skip it.
+					if err := table.active.InsertRecord(ctx, tx, record); err != nil {
+						return fmt.Errorf("insert record into block: %w", err)
+					}
+				default:
+					serBuf, err := dynparquet.ReaderFromBytes(entry.Data)
+					if err != nil {
+						return fmt.Errorf("deserialize buffer: %w", err)
+					}
+
+					if err := table.active.Insert(ctx, tx, serBuf); err != nil {
+						return fmt.Errorf("insert buffer into block: %w", err)
+					}
+				}
+
+				// After every insert we're setting the tx and highWatermark to the replayed tx.
+				// This allows the block's compaction to start working on the inserted data.
+				db.tx.Store(tx)
+				db.highWatermark.Store(tx)
+			case *walpb.Entry_TableBlockPersisted_:
 				return nil
-			}
-
-			table, err := db.GetTable(tableName)
-			var tableErr ErrTableNotFound
-			if errors.As(err, &tableErr) {
-				// This means the WAL was truncated at a point where this write
-				// was already successfully persisted to disk in more optimized
-				// form than the WAL.
+			case *walpb.Entry_Snapshot_:
 				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("get table: %w", err)
-			}
-
-			switch e.Write.Arrow {
-			case true:
-				reader, err := ipc.NewReader(bytes.NewReader(entry.Data))
-				if err != nil {
-					return fmt.Errorf("create ipc reader: %w", err)
-				}
-				record, err := reader.Read()
-				if err != nil {
-					return fmt.Errorf("read record: %w", err)
-				}
-
-				if err := table.active.InsertRecord(ctx, tx, record); err != nil {
-					return fmt.Errorf("insert record into block: %w", err)
-				}
 			default:
-				serBuf, err := dynparquet.ReaderFromBytes(entry.Data)
-				if err != nil {
-					return fmt.Errorf("deserialize buffer: %w", err)
-				}
-
-				if err := table.active.Insert(ctx, tx, serBuf); err != nil {
-					return fmt.Errorf("insert buffer into block: %w", err)
-				}
+				return fmt.Errorf("unexpected WAL entry type: %t", e)
 			}
-
-			// After every insert we're setting the tx and highWatermark to the replayed tx.
-			// This allows the block's compaction to start working on the inserted data.
-			db.tx.Store(tx)
-			db.highWatermark.Store(tx)
-		case *walpb.Entry_TableBlockPersisted_:
-			return nil
-		case *walpb.Entry_Snapshot_:
 			return nil
 		default:
-			return fmt.Errorf("unexpected WAL entry type: %t", e)
+			return fmt.Errorf("unexpected number of replay counts; expected 2, got %v", i)
 		}
-		return nil
-	}); err != nil {
-		return fmt.Errorf("second WAL replay: %w", err)
 	}
-
-	level.Info(db.logger).Log("msg", "replaying WAL completed", "duration", time.Since(start))
-
-	db.tx.Store(lastTx)
-	db.highWatermark.Store(lastTx)
-
-	return nil
 }
 
 func (db *DB) Close() error {

--- a/db.go
+++ b/db.go
@@ -103,6 +103,10 @@ func New(
 		return nil, fmt.Errorf("storage path must be configured if WAL is enabled")
 	}
 
+	if err := s.replayWALs(context.Background()); err != nil {
+		return nil, err
+	}
+
 	return s, nil
 }
 
@@ -236,7 +240,7 @@ func (s *ColumnStore) DatabasesDir() string {
 }
 
 // ReplayWALs replays the write-ahead log for each database.
-func (s *ColumnStore) ReplayWALs(ctx context.Context) error {
+func (s *ColumnStore) replayWALs(ctx context.Context) error {
 	if !s.enableWAL {
 		return nil
 	}

--- a/db.go
+++ b/db.go
@@ -420,6 +420,9 @@ func (db *DB) openWAL(ctx context.Context, firstIndex uint64) (WAL, error) {
 		db.reg,
 		db.walDir(),
 		wal.WithFirstIndex(firstIndex),
+		// NOTE: 2 is passed here because we require 2 passes through the WAL.
+		// Once to establish all the storage blocks that have rotated out, and a second pass to replay all the writes.
+		// This prevents us from replaying writes that have already been persisted/dropped by a block rotation.
 		wal.WithReplayFunc(2, db.recover(ctx, persistedTables, &lastTx)),
 	)
 	if err != nil {

--- a/db.go
+++ b/db.go
@@ -672,7 +672,6 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 			return fmt.Errorf("unexpected WAL entry type: %t", e)
 		}
 		return nil
-
 	}); err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -413,6 +413,7 @@ func (s *ColumnStore) DB(ctx context.Context, name string) (*DB, error) {
 func (db *DB) openWAL(ctx context.Context, firstIndex uint64) (WAL, error) {
 	// persistedTables is a map from a table name to the last transaction
 	// persisted.
+	start := time.Now()
 	persistedTables := map[string]uint64{}
 	lastTx := uint64(0)
 	wal, err := wal.Open(
@@ -428,6 +429,7 @@ func (db *DB) openWAL(ctx context.Context, firstIndex uint64) (WAL, error) {
 	if err != nil {
 		return nil, err
 	}
+	level.Info(db.logger).Log("msg", "replaying WAL completed", "duration", time.Since(start))
 
 	db.tx.Store(lastTx)
 	db.highWatermark.Store(lastTx)

--- a/db_test.go
+++ b/db_test.go
@@ -72,7 +72,6 @@ func TestDBWithWALAndBucket(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer c.Close()
-	require.NoError(t, c.ReplayWALs(context.Background()))
 }
 
 func TestDBWithWAL(t *testing.T) {
@@ -251,8 +250,6 @@ func TestDBWithWAL(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer c.Close()
-
-		require.NoError(t, c.ReplayWALs(context.Background()))
 
 		db, err = c.DB(context.Background(), "test")
 		require.NoError(t, err)
@@ -1258,13 +1255,10 @@ func Test_DB_TableNotExist(t *testing.T) {
 }
 
 func TestReplayBackwardsCompatibility(t *testing.T) {
-	ctx := context.Background()
 	const storagePath = "testdata/oldwal"
 	c, err := New(WithWAL(), WithStoragePath(storagePath))
 	require.NoError(t, err)
 	defer c.Close()
-
-	require.NoError(t, c.ReplayWALs(ctx))
 }
 
 func Test_DB_TableWrite_ArrowRecord(t *testing.T) {
@@ -1431,7 +1425,6 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer c.Close()
-	require.NoError(t, c.ReplayWALs(context.Background()))
 
 	// Query with an aggregat query
 	pool := memory.NewGoAllocator()

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -356,8 +356,6 @@ func TestSnapshotWithWAL(t *testing.T) {
 	// insert.
 	require.NoError(t, verifyDB.wal.Truncate(snapshotTx+1))
 
-	require.NoError(t, verifyC.ReplayWALs(ctx))
-
 	engine := query.NewEngine(memory.DefaultAllocator, verifyDB.TableProvider())
 	require.NoError(
 		t,

--- a/table.go
+++ b/table.go
@@ -142,11 +142,6 @@ type WAL interface {
 	Close() error
 	Log(tx uint64, record *walpb.Record) error
 	LogRecord(tx uint64, table string, record arrow.Record) error
-	// Replay replays WAL records from the given first index. If firstIndex is
-	// 0, the first index read from the WAL is used (i.e. given a truncation,
-	// using 0 is still valid). If the given firstIndex is less than the WAL's
-	// first index on disk, the replay happens from the first index on disk.
-	Replay(firstIndex uint64, handler func(tx uint64, record *walpb.Record) error) error
 	Truncate(tx uint64) error
 	FirstIndex() (uint64, error)
 }

--- a/table.go
+++ b/table.go
@@ -143,6 +143,10 @@ type WAL interface {
 	Close() error
 	Log(tx uint64, record *walpb.Record) error
 	LogRecord(tx uint64, table string, record arrow.Record) error
+	// Replay replays WAL records from the given first index. If firstIndex is
+	// 0, the first index read from the WAL is used (i.e. given a truncation,
+	// using 0 is still valid). If the given firstIndex is less than the WAL's
+	// first index on disk, the replay happens from the first index on disk.
 	Replay(tx uint64, handler wal.ReplayHandlerFunc) error
 	Truncate(tx uint64) error
 	FirstIndex() (uint64, error)

--- a/table.go
+++ b/table.go
@@ -41,6 +41,7 @@ import (
 	"github.com/polarsignals/frostdb/parts"
 	"github.com/polarsignals/frostdb/pqarrow"
 	"github.com/polarsignals/frostdb/query/logicalplan"
+	"github.com/polarsignals/frostdb/wal"
 	walpkg "github.com/polarsignals/frostdb/wal"
 )
 
@@ -142,6 +143,7 @@ type WAL interface {
 	Close() error
 	Log(tx uint64, record *walpb.Record) error
 	LogRecord(tx uint64, table string, record arrow.Record) error
+	Replay(tx uint64, handler wal.ReplayHandlerFunc) error
 	Truncate(tx uint64) error
 	FirstIndex() (uint64, error)
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -449,7 +449,7 @@ func (w *FileWAL) replay(count int, firstIndex uint64, handler ReplayHandlerFunc
 		defer func() {
 			// recover a panic of reading a transaction. Truncate the wal to the last valid transaction.
 			if r := recover(); r != nil {
-				level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
+				level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "offending_index", tx, "err", err)
 				if err = w.log.TruncateBack(tx - 1); err != nil {
 					return
 				}

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -22,6 +22,32 @@ import (
 	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
 )
 
+type replayOptions struct {
+	// count is the number of times to replay against the handler
+	count      int
+	handler    ReplayHandlerFunc
+	firstIndex uint64
+}
+
+type ReplayOption func(o *replayOptions)
+
+// WithReplayFunc sets the replay function and the number of times to run it.
+func WithReplayFunc(count int, handler ReplayHandlerFunc) ReplayOption {
+	return func(o *replayOptions) {
+		o.count = count
+		o.handler = handler
+	}
+}
+
+// WithFirstIndex sets the index to start replay at.
+func WithFirstIndex(firstIndex uint64) ReplayOption {
+	return func(o *replayOptions) {
+		o.firstIndex = firstIndex
+	}
+}
+
+type ReplayHandlerFunc func(i int, tx uint64, record *walpb.Record) error
+
 type NopWAL struct{}
 
 func (w *NopWAL) Close() error {
@@ -33,10 +59,6 @@ func (w *NopWAL) Log(tx uint64, record *walpb.Record) error {
 }
 
 func (w *NopWAL) LogRecord(tx uint64, table string, record arrow.Record) error {
-	return nil
-}
-
-func (w *NopWAL) Replay(firstIndex uint64, handler func(tx uint64, record *walpb.Record) error) error {
 	return nil
 }
 
@@ -106,7 +128,13 @@ func Open(
 	logger log.Logger,
 	reg prometheus.Registerer,
 	path string,
+	options ...ReplayOption,
 ) (*FileWAL, error) {
+	o := &replayOptions{}
+	for _, option := range options {
+		option(o)
+	}
+
 	log, err := wal.Open(path, wal.DefaultOptions)
 	if err != nil {
 		if !errors.Is(err, wal.ErrCorrupt) {
@@ -166,6 +194,10 @@ func Open(
 			}),
 		},
 		shutdownCh: make(chan struct{}),
+	}
+
+	if err := w.replay(o.count, o.firstIndex, o.handler); err != nil {
+		return nil, err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -387,60 +419,67 @@ func (w *FileWAL) LastIndex() (uint64, error) {
 	return w.log.LastIndex()
 }
 
-func (w *FileWAL) Replay(firstIndex uint64, handler func(tx uint64, record *walpb.Record) error) (err error) {
-	logFirstIndex, err := w.log.FirstIndex()
-	if err != nil {
-		return fmt.Errorf("read first index: %w", err)
-	}
-	if firstIndex == 0 || firstIndex < logFirstIndex {
-		firstIndex = logFirstIndex
-	}
-
-	lastIndex, err := w.log.LastIndex()
-	if err != nil {
-		return fmt.Errorf("read last index: %w", err)
-	}
-
-	// FirstIndex and LastIndex returns zero when there is no WAL files.
-	if firstIndex == 0 || lastIndex == 0 {
+func (w *FileWAL) replay(count int, firstIndex uint64, handler ReplayHandlerFunc) (err error) {
+	if handler == nil { // no handler provided
 		return nil
 	}
 
-	level.Debug(w.logger).Log("msg", "replaying WAL", "first_index", firstIndex, "last_index", lastIndex)
-
-	tx := firstIndex
-	defer func() {
-		// recover a panic of reading a transaction. Truncate the wal to the last valid transaction.
-		if r := recover(); r != nil {
-			level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
-			if err = w.log.TruncateBack(tx - 1); err != nil {
-				return
-			}
-			w.txmtx.Lock()
-			w.nextTx = tx
-			w.txmtx.Unlock()
-		}
-	}()
-
-	for ; tx <= lastIndex; tx++ {
-		level.Debug(w.logger).Log("msg", "replaying WAL record", "tx", tx)
-		data, err := w.log.Read(tx)
+	for i := 0; i < count; i++ {
+		logFirstIndex, err := w.log.FirstIndex()
 		if err != nil {
-			return fmt.Errorf("read index %d: %w", tx, err)
+			return fmt.Errorf("read first index: %w", err)
+		}
+		if firstIndex == 0 || firstIndex < logFirstIndex {
+			firstIndex = logFirstIndex
 		}
 
-		record := &walpb.Record{}
-		if err := record.UnmarshalVT(data); err != nil {
-			return fmt.Errorf("unmarshal WAL record: %w", err)
+		lastIndex, err := w.log.LastIndex()
+		if err != nil {
+			return fmt.Errorf("read last index: %w", err)
 		}
 
-		if err := handler(tx, record); err != nil {
-			return fmt.Errorf("call replay handler: %w", err)
+		// FirstIndex and LastIndex returns zero when there is no WAL files.
+		if firstIndex == 0 || lastIndex == 0 {
+			return nil
 		}
+
+		level.Debug(w.logger).Log("msg", "replaying WAL", "first_index", firstIndex, "last_index", lastIndex)
+
+		tx := firstIndex
+		defer func() {
+			// recover a panic of reading a transaction. Truncate the wal to the last valid transaction.
+			if r := recover(); r != nil {
+				level.Error(w.logger).Log("msg", "replaying WAL failed", "path", w.path, "first_index", firstIndex, "last_index", lastIndex, "err", err)
+				if err = w.log.TruncateBack(tx - 1); err != nil {
+					return
+				}
+				w.txmtx.Lock()
+				w.nextTx = tx
+				w.txmtx.Unlock()
+			}
+		}()
+
+		for ; tx <= lastIndex; tx++ {
+			level.Debug(w.logger).Log("msg", "replaying WAL record", "tx", tx)
+			data, err := w.log.Read(tx)
+			if err != nil {
+				return fmt.Errorf("read index %d: %w", tx, err)
+			}
+
+			record := &walpb.Record{}
+			if err := record.UnmarshalVT(data); err != nil {
+				return fmt.Errorf("unmarshal WAL record: %w", err)
+			}
+
+			if err := handler(i, tx, record); err != nil {
+				return fmt.Errorf("call replay handler: %w", err)
+			}
+		}
+
+		w.txmtx.Lock()
+		w.nextTx = lastIndex + 1
+		w.txmtx.Unlock()
 	}
 
-	w.txmtx.Lock()
-	w.nextTx = lastIndex + 1
-	w.txmtx.Unlock()
 	return nil
 }

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -34,6 +34,10 @@ func (w *NopWAL) Log(tx uint64, record *walpb.Record) error {
 	return nil
 }
 
+func (w *NopWAL) Replay(tx uint64, handler ReplayHandlerFunc) error {
+	return nil
+}
+
 func (w *NopWAL) LogRecord(tx uint64, table string, record arrow.Record) error {
 	return nil
 }
@@ -444,8 +448,8 @@ func (w *FileWAL) Replay(firstIndex uint64, handler ReplayHandlerFunc) (err erro
 	return nil
 }
 
-func (w *FileWAL) RunAsync(ctx context.Context) {
-	ctx, cancel := context.WithCancel(ctx)
+func (w *FileWAL) RunAsync() {
+	ctx, cancel := context.WithCancel(context.Background())
 	w.cancel = cancel
 	go func() {
 		w.run(ctx)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -1,7 +1,6 @@
 package wal
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,6 @@ import (
 )
 
 func TestWAL(t *testing.T) {
-	ctx := context.Background()
 	dir := t.TempDir()
 	w, err := Open(
 		log.NewNopLogger(),
@@ -22,7 +20,7 @@ func TestWAL(t *testing.T) {
 		dir,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 
 	require.NoError(t, w.Log(1, &walpb.Record{
 		Entry: &walpb.Entry{
@@ -43,7 +41,7 @@ func TestWAL(t *testing.T) {
 		dir,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 
 	w.Replay(0, func(tx uint64, r *walpb.Record) error {
 		require.Equal(t, uint64(1), tx)
@@ -74,12 +72,11 @@ func TestWAL(t *testing.T) {
 		dir,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 	defer w.Close()
 }
 
 func TestCorruptWAL(t *testing.T) {
-	ctx := context.Background()
 	path := t.TempDir()
 
 	w, err := Open(
@@ -88,7 +85,7 @@ func TestCorruptWAL(t *testing.T) {
 		path,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 
 	require.NoError(t, w.Log(1, &walpb.Record{
 		Entry: &walpb.Entry{
@@ -112,7 +109,7 @@ func TestCorruptWAL(t *testing.T) {
 		path,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 	defer w.Close()
 
 	lastIdx, err := w.LastIndex()
@@ -125,7 +122,6 @@ func TestCorruptWAL(t *testing.T) {
 // we should protect the WAL from getting into a deadlock. This test is likely
 // to fail due to timeout.
 func TestUnexpectedTxn(t *testing.T) {
-	ctx := context.Background()
 	walDir := t.TempDir()
 	func() {
 		w, err := Open(
@@ -134,7 +130,7 @@ func TestUnexpectedTxn(t *testing.T) {
 			walDir,
 		)
 		require.NoError(t, err)
-		w.RunAsync(ctx)
+		w.RunAsync()
 		defer w.Close()
 
 		emptyRecord := &walpb.Record{}
@@ -153,7 +149,7 @@ func TestUnexpectedTxn(t *testing.T) {
 		walDir,
 	)
 	require.NoError(t, err)
-	w.RunAsync(ctx)
+	w.RunAsync()
 	defer w.Close()
 	lastIndex, err := w.LastIndex()
 	require.NoError(t, err)

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -43,7 +43,7 @@ func TestWAL(t *testing.T) {
 	require.NoError(t, err)
 	w.RunAsync()
 
-	w.Replay(0, func(tx uint64, r *walpb.Record) error {
+	err = w.Replay(0, func(tx uint64, r *walpb.Record) error {
 		require.Equal(t, uint64(1), tx)
 		require.Equal(t, []byte("test-data"), r.Entry.GetWrite().Data)
 		require.Equal(t, "test-table", r.Entry.GetWrite().TableName)


### PR DESCRIPTION
In efforts to make the WAL/replay more robust I've added two things here:

- On wal read panics instead of continuing the panic we instead truncate the WAL up to the last good tx. Using some corrupted wals from production this works really well.
- On DB open (and wal open) replay the WAL. This is mostly a refactor, but it does remove some weird footguns where you could open a DB with a WAL and not replay it, or write to it while you were replaying it.

Closes #328 