### PR TITLE
frostdb: add snapshot on block rotation

### DIFF
--- a/table.go
+++ b/table.go
@@ -412,6 +412,27 @@ func (t *Table) writeBlock(ctx context.Context, block *TableBlock) {
 	}
 	t.mtx.Unlock()
 	t.db.maintainWAL()
+	if t.db.columnStore.snapshotTriggerSize != 0 && t.db.columnStore.enableWAL {
+		func() {
+			if !t.db.snapshotInProgress.CompareAndSwap(false, true) {
+				// Snapshot already in progress. This could lead to duplicate
+				// data when replaying (refer to the snapshot design document),
+				// but discarding this data on recovery is better than a
+				// potential additional CPU spike caused by another snapshot.
+				return
+			}
+			defer t.db.snapshotInProgress.Store(false)
+			// This snapshot snapshots the new, active, table block. Refer to
+			// the snapshot design document for more details as to why this
+			// snapshot is necessary.
+			if err := t.db.snapshotAtTX(ctx, tx); err != nil {
+				level.Error(t.logger).Log(
+					"msg", "failed to write snapshot on block rotation",
+					"err", err,
+				)
+			}
+		}()
+	}
 }
 
 func (t *Table) RotateBlock(ctx context.Context, block *TableBlock) error {


### PR DESCRIPTION
From the snapshot design document:

Snapshot recovery in the presence of block rotations can be subtle. The situation we want to avoid is recovering from a snapshot that has data from a table block that has been rotated (i.e. persisted). If the aforementioned [snapshot intervals](#interval) and [recovery](#recovery) algorithms are followed without triggering a snapshot on block rotation, it is possible to load a snapshot at txn `n` when a block rotation happened at txn `n+k`. When serving queries, FrostDB could return duplicate data for writes with txn ids `<= n` since the same row could be both in-memory (originating from the snapshot) and in block storage (previously persisted).  Triggering snapshots on block rotation will not include the rotated block. When the snapshot is loaded during recovery, persisted data will not be reflected in the snapshot.

However, there might be cases where the latest snapshot loaded during recovery is at a txn less than the block rotation. For example, the vm might be preempted after persisting a block, but before a snapshot can be written to disk. To handle these cases, the WAL replay code will have take into account that the replay is happening against a non-empty database loaded from a snapshot at the same txn the WAL replay started at. Given a table block persistence WAL entry indicates successful persistence of the table block, it is safe to ignore the snapshot data for that table, so the active table block index will be reset, deleting all data in the in-memory table and inserting only the WAL records starting from the snapshot txn.
