### PR TITLE
Enforce row group size

### DIFF
--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -264,6 +264,27 @@ func NewTestSamples() Samples {
 	}
 }
 
+func GenerateTestSamples(n int) Samples {
+	s := Samples{}
+	for i := 0; i < n; i++ {
+		s = append(s,
+			Sample{
+				ExampleType: "cpu",
+				Labels: []Label{{
+					Name:  "node",
+					Value: "test3",
+				}},
+				Stacktrace: []uuid.UUID{
+					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2},
+				},
+				Timestamp: int64(i),
+				Value:     int64(i),
+			})
+	}
+	return s
+}
+
 func NestedListDef(name string, layout *schemav2pb.StorageLayout) *schemav2pb.Node_Group {
 	return &schemav2pb.Node_Group{
 		Group: &schemav2pb.Group{

--- a/table.go
+++ b/table.go
@@ -1534,6 +1534,10 @@ func (t *TableBlock) rowWriter(writer io.Writer, dynCols map[string][]string, op
 func (p *parquetRowWriter) writeRows(rows parquet.Rows) (int, error) {
 	written := 0
 	for p.maxNumRows == 0 || p.totalRowsWritten < p.maxNumRows {
+		if p.rowGroupSize > 0 && p.rowGroupRowsWritten+len(p.rowsBuf) > p.rowGroupSize {
+			// Read only as many rows as we need to complete the row group size limit.
+			p.rowsBuf = p.rowsBuf[:p.rowGroupSize-p.rowGroupRowsWritten]
+		}
 		if p.maxNumRows != 0 && p.totalRowsWritten+len(p.rowsBuf) > p.maxNumRows {
 			// Read only as many rows as we need to write if they would bring
 			// us over the limit.

--- a/table_test.go
+++ b/table_test.go
@@ -1358,3 +1358,59 @@ func Test_Serialize_DisparateDynamicColumns(t *testing.T) {
 	// Serialize the table
 	require.NoError(t, table.active.Serialize(io.Discard))
 }
+
+func Test_RowWriter(t *testing.T) {
+	config := NewTableConfig(
+		dynparquet.NewSampleSchema(),
+		WithRowGroupSize(5),
+	)
+
+	logger := newTestLogger(t)
+
+	c, err := New(WithLogger(logger))
+	require.NoError(t, err)
+
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+	defer c.Close()
+
+	b := &bytes.Buffer{}
+	rowWriter, err := table.ActiveBlock().rowWriter(b, map[string][]string{
+		"labels": {"node"},
+	})
+	require.NoError(t, err)
+
+	// Write 17(8,9) rows, expect 3 row groups of 5 rows and 1 row group of 2 rows
+	samples := dynparquet.GenerateTestSamples(8)
+	buf, err := samples.ToBuffer(table.Schema())
+	require.NoError(t, err)
+	rows := buf.Rows()
+	_, err = rowWriter.writeRows(rows)
+	require.NoError(t, err)
+	require.NoError(t, rows.Close())
+
+	samples = dynparquet.GenerateTestSamples(9)
+	buf, err = samples.ToBuffer(table.Schema())
+	require.NoError(t, err)
+	rows = buf.Rows()
+	_, err = rowWriter.writeRows(rows)
+	require.NoError(t, err)
+	require.NoError(t, rows.Close())
+
+	require.NoError(t, rowWriter.close())
+
+	f, err := parquet.OpenFile(bytes.NewReader(b.Bytes()), int64(b.Len()))
+	require.NoError(t, err)
+
+	require.Equal(t, 4, len(f.Metadata().RowGroups))
+	for i, rg := range f.Metadata().RowGroups {
+		switch i {
+		case 3:
+			require.Equal(t, int64(2), rg.NumRows)
+		default:
+			require.Equal(t, int64(5), rg.NumRows)
+		}
+	}
+}


### PR DESCRIPTION
The `rowWriter` had been writing row groups in a "fuzzy" manner, in that if you passed a set of rows that exceeded the row group size, it would write them all into the current row group.

This fixes that fuzziness by correctly truncating the row group to only include the specified number of rows.