### PR TITLE
*: call closeInternal on db startup error rather than Close

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1623,6 +1623,31 @@ func TestDBRecover(t *testing.T) {
 		require.NoError(t, err)
 		newWriteAndExpectWALRecord(t, db, table)
 	})
+
+	// NoProgress verifies that an error is returned if the WAL's last index
+	// does not match up with the last valid snapshot txn. Since DB writes
+	// resume from the snapshot txn, the WAL's last index must match that txn
+	// otherwise no records will ever be logged.
+	t.Run("NoProgress", func(t *testing.T) {
+		dir := setup(t, false)
+
+		// Nuke the WAL.
+		walPath := filepath.Join(dir, "databases", dbAndTableName, "wal")
+		require.NoError(t, os.RemoveAll(walPath))
+
+		bucket, err := filesystem.NewBucket(t.TempDir())
+		require.NoError(t, err)
+		_, err = New(
+			WithLogger(newTestLogger(t)),
+			WithStoragePath(dir),
+			WithWAL(),
+			WithSnapshotTriggerSize(1),
+			// Add buckets storage here since it forces a snapshot on Close,
+			// which previously caused a panic due to half-set fields.
+			WithBucketStorage(bucket),
+		)
+		require.Error(t, err)
+	})
 }
 
 func Test_DB_WalReplayTableConfig(t *testing.T) {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -2,6 +2,7 @@ package frostdb
 
 import (
 	"context"
+	"math"
 	"os"
 	"strconv"
 	"testing"
@@ -26,6 +27,7 @@ func TestSnapshot(t *testing.T) {
 		c, err := New(
 			WithStoragePath(t.TempDir()),
 			WithWAL(),
+			WithSnapshotTriggerSize(math.MaxInt64),
 		)
 		require.NoError(t, err)
 		defer c.Close()
@@ -45,6 +47,7 @@ func TestSnapshot(t *testing.T) {
 		c, err := New(
 			WithStoragePath(t.TempDir()),
 			WithWAL(),
+			WithSnapshotTriggerSize(math.MaxInt64),
 		)
 		require.NoError(t, err)
 		defer c.Close()
@@ -141,6 +144,7 @@ func TestSnapshot(t *testing.T) {
 		c, err := New(
 			WithStoragePath(t.TempDir()),
 			WithWAL(),
+			WithSnapshotTriggerSize(math.MaxInt64),
 		)
 		require.NoError(t, err)
 		defer c.Close()


### PR DESCRIPTION
Close expects some fields to be non-nil (e.g. metrics when triggering a snapshot on close), so this commit introduces a lighter-weight closeInternal that is called on a db setup error, which is all that is needed. Not doing so was causing a nil pointer exception.