### PR TITLE
373 fix arrow panic

### DIFF
--- a/db.go
+++ b/db.go
@@ -536,7 +536,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 				// already been persisted.
 				db.mtx.Lock()
 				if table, ok := db.tables[e.TableBlockPersisted.TableName]; ok {
-					table.ActiveBlock().index.Store(btree.New(table.db.columnStore.indexDegree))
+					table.ActiveBlock().index.Store(NewIndex(btree.New(table.db.columnStore.indexDegree)))
 				}
 				db.mtx.Unlock()
 			}

--- a/table_test.go
+++ b/table_test.go
@@ -182,8 +182,10 @@ func TestTable(t *testing.T) {
 	uuid2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
 
 	// One granule with 3 parts
-	require.Equal(t, 1, table.active.Index().Len())
-	require.Equal(t, 3, table.active.Index().Min().(*Granule).parts.Total())
+	index, done := table.active.Index()
+	defer done()
+	require.Equal(t, 1, index.Len())
+	require.Equal(t, 3, index.Min().(*Granule).parts.Total())
 	require.Equal(t, parquet.Row{
 		parquet.ValueOf("test").Level(0, 0, 0),
 		parquet.ValueOf("value1").Level(0, 1, 1),
@@ -193,8 +195,8 @@ func TestTable(t *testing.T) {
 		parquet.ValueOf(append(uuid1[:], uuid2[:]...)).Level(0, 0, 5),
 		parquet.ValueOf(1).Level(0, 0, 6),
 		parquet.ValueOf(1).Level(0, 0, 7),
-	}, (*dynparquet.DynamicRow)(table.active.Index().Min().(*Granule).metadata.least).Row)
-	require.Equal(t, 1, table.active.Index().Len())
+	}, (*dynparquet.DynamicRow)(index.Min().(*Granule).metadata.least).Row)
+	require.Equal(t, 1, index.Len())
 }
 
 // This test issues concurrent writes to the database, and expects all of them to be recorded successfully.
@@ -1266,7 +1268,9 @@ func Test_Table_InsertLeast(t *testing.T) {
 	_, err = table.InsertBuffer(ctx, buf)
 	require.NoError(t, err)
 
-	before := table.active.Index().Len()
+	index, done := table.active.Index()
+	defer done()
+	before := index.Len()
 
 	samples = dynparquet.Samples{{
 		ExampleType: "test",
@@ -1287,7 +1291,9 @@ func Test_Table_InsertLeast(t *testing.T) {
 	_, err = table.InsertBuffer(ctx, buf)
 	require.NoError(t, err)
 
-	require.Equal(t, before+1, table.active.Index().Len())
+	index, done = table.active.Index()
+	defer done()
+	require.Equal(t, before+1, index.Len())
 }
 
 func Test_Serialize_DisparateDynamicColumns(t *testing.T) {


### PR DESCRIPTION
Closes #373  This changes the table's index to be a btree wrapped by a reference counter. 

Previously it was possible for any number of writes to have read a historical index.
While these read indices existed it was possible for the table to persist the block. On persistence it would walk the index and deprecate the reference counters for all arrow records found in the index. 

This would cause a problem when this reference deprecation happened before those reads completed, since they could then reference a record that's memory had been released. There was no way to determine if there were outstanding reads. The reference counter is incremented every time the `Index()` function is used, and returns a `done` function to decrement the reference after usage of the index is complete.  

This also could have been implemented with a waitgroup, and I'm on the fence on whether I should replace it with one?

earmarks: I refactored all the places where we swap the btree index with a new one into a single `replaceIndex` function.