### PR TITLE
new granules atomic pointer

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -458,7 +458,7 @@ func (t *TableBlock) compactGranule(granule *Granule, cfg *CompactionConfig) (bo
 
 	// Set the newGranules pointer, so new writes will propogate into these new
 	// granules.
-	granule.newGranules = newGranules
+	granule.newGranules.Store(&newGranules)
 
 	// Mark compaction complete in the granule; this will cause new writes to
 	// start using the newGranules pointer. Iterate over the resulting part


### PR DESCRIPTION
New granules is concurrently accessed, it's written by the compaction routine, and it's accessed by both reads and writes to propagate after compactions. 

Due to this it should be an atomic pointer so that access is thread safe. 