### PR TITLE
db: check table creation error inside if statement

### DIFF
--- a/db.go
+++ b/db.go
@@ -596,9 +596,9 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 						db.tracer,
 						wal,
 					)
-				}
-				if err != nil {
-					return fmt.Errorf("instantiate table: %w", err)
+					if err != nil {
+						return fmt.Errorf("instantiate table: %w", err)
+					}
 				}
 
 				table.active, err = newTableBlock(table, 0, tx, id)


### PR DESCRIPTION
This error check was at the wrong level of indentation, causing an error if tables were only read from object storage.