### PR TITLE
parquet-tool: Print column encoding

### DIFF
--- a/cmd/parquet-tool/main.go
+++ b/cmd/parquet-tool/main.go
@@ -38,13 +38,14 @@ func main() {
 		fmt.Println("\t\t Row size:", humanize.Bytes(uint64(rg.TotalByteSize)))
 		fmt.Println("\t\t Columns:")
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Col", "Type", "NumVal", "TotalCompressedSize", "TotalUncompressedSize", "Compression", "%"})
+		table.SetHeader([]string{"Col", "Type", "NumVal", "Encoding", "TotalCompressedSize", "TotalUncompressedSize", "Compression", "%"})
 		for _, ds := range rg.Columns {
 			table.Append(
 				[]string{
 					strings.Join(ds.MetaData.PathInSchema, "/"),
 					ds.MetaData.Type.String(),
 					fmt.Sprintf("%d", ds.MetaData.NumValues),
+					fmt.Sprintf("%s", ds.MetaData.Encoding),
 					humanize.Bytes(uint64(ds.MetaData.TotalCompressedSize)),
 					humanize.Bytes(uint64(ds.MetaData.TotalUncompressedSize)),
 					fmt.Sprintf("%.2f", float64(ds.MetaData.TotalUncompressedSize-ds.MetaData.TotalCompressedSize)/float64(ds.MetaData.TotalCompressedSize)*100),


### PR DESCRIPTION
This commit modifies parquet-tool to also print an `Encoding` column in the output table for a parquet file.