### PR TITLE
update cols after updating aggregates

### DIFF
--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -423,10 +423,6 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 
 		tuple, ok := a.hashToAggregate[hash]
 		if !ok {
-			// insert new row into columns grouped by and create new aggregate array to append to.
-			if err := a.updateGroupByCols(i, groupByArrays, groupByFields); err != nil {
-				return err
-			}
 
 			aggregate = a.aggregates[len(a.aggregates)-1]
 			for j, col := range columnToAggregate {
@@ -439,6 +435,11 @@ func (a *HashAggregate) Callback(ctx context.Context, r arrow.Record) error {
 			}
 			a.hashToAggregate[hash] = tuple
 			aggregate.rowCount++
+
+			// insert new row into columns grouped by and create new aggregate array to append to.
+			if err := a.updateGroupByCols(i, groupByArrays, groupByFields); err != nil {
+				return err
+			}
 		}
 
 		for j, col := range columnToAggregate {


### PR DESCRIPTION
This fixes the disjointed label sets we were seeing with arrow ingestion. The refactor of the split-records moved the code that added nils to the arrays to be after the aggregate addition when it was supposed to be before. This undos that accidental part of the refactor. 