### PR TITLE
Data sources and sinks

### DIFF
--- a/db.go
+++ b/db.go
@@ -163,14 +163,22 @@ func WithSplitSize(size int) Option {
 	}
 }
 
-func WithDataSource(ds DataSource) Option {
+func WithReadWriteStorage(ds DataSinkSource) Option {
+	return func(s *ColumnStore) error {
+		s.sources = append(s.sources, ds)
+		s.sinks = append(s.sinks, ds)
+		return nil
+	}
+}
+
+func WithReadOnlyStorage(ds DataSource) Option {
 	return func(s *ColumnStore) error {
 		s.sources = append(s.sources, ds)
 		return nil
 	}
 }
 
-func WithDataSink(ds DataSink) Option {
+func WithWriteOnlyStorage(ds DataSink) Option {
 	return func(s *ColumnStore) error {
 		s.sinks = append(s.sinks, ds)
 		return nil
@@ -306,6 +314,12 @@ type DB struct {
 	snapshotInProgress atomic.Bool
 
 	metrics *dbMetrics
+}
+
+// DataSinkSource is a convenience interface for a data source and sink.
+type DataSinkSource interface {
+	DataSink
+	DataSource
 }
 
 // DataSource is remote source of data that can be queried.

--- a/db.go
+++ b/db.go
@@ -288,6 +288,7 @@ type DB struct {
 	storagePath string
 	wal         WAL
 
+	// The database supports multiple data sources and sinks.
 	sources []DataSource
 	sinks   []DataSink
 
@@ -310,7 +311,7 @@ type DB struct {
 // DataSource is remote source of data that can be queried.
 type DataSource interface {
 	fmt.Stringer
-	Scan(ctx context.Context, prefix string, schema *dynparquet.Schema, filter logicalplan.Expr, lastBlockTimestamp uint64, stream chan<- any) error
+	Scan(ctx context.Context, prefix string, schema *dynparquet.Schema, filter logicalplan.Expr, lastBlockTimestamp uint64, callback func(context.Context, any) error) error
 	Prefixes(ctx context.Context, prefix string) ([]string, error)
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -35,11 +35,14 @@ func TestDBWithWALAndBucket(t *testing.T) {
 	dir := t.TempDir()
 	bucket := objstore.NewInMemBucket()
 
+	sinksource := NewDefaultObjstoreBucket(bucket)
+
 	c, err := New(
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithBucketStorage(bucket),
+		WithDataSource(sinksource),
+		WithDataSink(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -64,7 +67,8 @@ func TestDBWithWALAndBucket(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithBucketStorage(bucket),
+		WithDataSource(sinksource),
+		WithDataSink(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -305,11 +309,13 @@ func Test_DB_WithStorage(t *testing.T) {
 	)
 
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 
 	c, err := New(
 		WithLogger(logger),
-		WithBucketStorage(bucket),
+		WithDataSource(sinksource),
+		WithDataSink(sinksource),
 	)
 	require.NoError(t, err)
 
@@ -391,6 +397,7 @@ func Test_DB_ColdStart(t *testing.T) {
 	)
 
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 
 	tests := map[string]struct {
@@ -400,7 +407,8 @@ func Test_DB_ColdStart(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -410,7 +418,8 @@ func Test_DB_ColdStart(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 					WithWAL(),
 					WithStoragePath(t.TempDir()),
 				)
@@ -486,7 +495,8 @@ func Test_DB_ColdStart(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithBucketStorage(bucket),
+				WithDataSink(sinksource),
+				WithDataSource(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -561,11 +571,13 @@ func Test_DB_ColdStart_MissingColumn(t *testing.T) {
 
 	bucket := objstore.NewInMemBucket()
 
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 
 	c, err := New(
 		WithLogger(logger),
-		WithBucketStorage(bucket),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 	)
 	require.NoError(t, err)
 
@@ -605,7 +617,8 @@ func Test_DB_ColdStart_MissingColumn(t *testing.T) {
 	// Open a new database pointed to the same bucket storage
 	c, err = New(
 		WithLogger(logger),
-		WithBucketStorage(bucket),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()
@@ -650,6 +663,7 @@ func Test_DB_Filter_Block(t *testing.T) {
 	)
 
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 
 	tests := map[string]struct {
@@ -670,7 +684,8 @@ func Test_DB_Filter_Block(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -685,7 +700,8 @@ func Test_DB_Filter_Block(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -759,7 +775,8 @@ func Test_DB_Filter_Block(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithBucketStorage(bucket),
+				WithDataSink(sinksource),
+				WithDataSource(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -895,10 +912,12 @@ func Test_DB_OpenError(t *testing.T) {
 			return nil
 		},
 	}
+	sinksource := NewDefaultObjstoreBucket(e)
 
 	c, err := New(
 		WithLogger(logger),
-		WithBucketStorage(e),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()
@@ -924,6 +943,7 @@ func Test_DB_Block_Optimization(t *testing.T) {
 	)
 
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 
 	now := time.Now()
@@ -945,7 +965,8 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -959,7 +980,8 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithBucketStorage(bucket),
+					WithDataSink(sinksource),
+					WithDataSource(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -1033,7 +1055,8 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithBucketStorage(bucket),
+				WithDataSink(sinksource),
+				WithDataSource(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -1367,12 +1390,14 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 
 	dir := t.TempDir()
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 
 	c, err := New(
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithBucketStorage(bucket),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -1397,7 +1422,8 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithBucketStorage(bucket),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -1593,14 +1619,16 @@ func TestDBRecover(t *testing.T) {
 	// shutdown of a column store with bucket storage.
 	t.Run("WithBucket", func(t *testing.T) {
 		bucket := objstore.NewInMemBucket()
-		dir := setup(t, true, WithBucketStorage(bucket))
+		sinksource := NewDefaultObjstoreBucket(bucket)
+		dir := setup(t, true, WithDataSink(sinksource), WithDataSource(sinksource))
 
 		c, err := New(
 			WithLogger(newTestLogger(t)),
 			WithStoragePath(dir),
 			WithWAL(),
 			WithSnapshotTriggerSize(1),
-			WithBucketStorage(bucket),
+			WithDataSink(sinksource),
+			WithDataSource(sinksource),
 		)
 		require.NoError(t, err)
 		defer c.Close()

--- a/db_test.go
+++ b/db_test.go
@@ -289,7 +289,6 @@ func TestDBWithWAL(t *testing.T) {
 				[]logicalplan.Expr{logicalplan.Col("labels.label2")},
 			).
 			Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
-				fmt.Println(r)
 				return nil
 			})
 		require.NoError(t, err)

--- a/db_test.go
+++ b/db_test.go
@@ -41,8 +41,7 @@ func TestDBWithWALAndBucket(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithDataSource(sinksource),
-		WithDataSink(sinksource),
+		WithReadWriteStorage(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -67,8 +66,7 @@ func TestDBWithWALAndBucket(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithDataSource(sinksource),
-		WithDataSink(sinksource),
+		WithReadWriteStorage(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -313,8 +311,7 @@ func Test_DB_WithStorage(t *testing.T) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithDataSource(sinksource),
-		WithDataSink(sinksource),
+		WithReadWriteStorage(sinksource),
 	)
 	require.NoError(t, err)
 
@@ -406,8 +403,7 @@ func Test_DB_ColdStart(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -417,8 +413,7 @@ func Test_DB_ColdStart(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 					WithWAL(),
 					WithStoragePath(t.TempDir()),
 				)
@@ -494,8 +489,7 @@ func Test_DB_ColdStart(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithDataSink(sinksource),
-				WithDataSource(sinksource),
+				WithReadWriteStorage(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -575,8 +569,7 @@ func Test_DB_ColdStart_MissingColumn(t *testing.T) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 	)
 	require.NoError(t, err)
 
@@ -616,8 +609,7 @@ func Test_DB_ColdStart_MissingColumn(t *testing.T) {
 	// Open a new database pointed to the same bucket storage
 	c, err = New(
 		WithLogger(logger),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()
@@ -683,8 +675,7 @@ func Test_DB_Filter_Block(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -699,8 +690,7 @@ func Test_DB_Filter_Block(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -774,8 +764,7 @@ func Test_DB_Filter_Block(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithDataSink(sinksource),
-				WithDataSource(sinksource),
+				WithReadWriteStorage(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -915,8 +904,7 @@ func Test_DB_OpenError(t *testing.T) {
 
 	c, err := New(
 		WithLogger(logger),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()
@@ -964,8 +952,7 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -979,8 +966,7 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			newColumnstore: func(t *testing.T) *ColumnStore {
 				c, err := New(
 					WithLogger(logger),
-					WithDataSink(sinksource),
-					WithDataSource(sinksource),
+					WithReadWriteStorage(sinksource),
 				)
 				require.NoError(t, err)
 				return c
@@ -1054,8 +1040,7 @@ func Test_DB_Block_Optimization(t *testing.T) {
 			// Open a new database pointed to the same bucket storage
 			c, err = New(
 				WithLogger(logger),
-				WithDataSink(sinksource),
-				WithDataSource(sinksource),
+				WithReadWriteStorage(sinksource),
 			)
 			require.NoError(t, err)
 			defer c.Close()
@@ -1395,8 +1380,7 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -1421,8 +1405,7 @@ func Test_DB_ReadOnlyQuery(t *testing.T) {
 		WithLogger(logger),
 		WithWAL(),
 		WithStoragePath(dir),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 		WithActiveMemorySize(100*1024),
 	)
 	require.NoError(t, err)
@@ -1619,15 +1602,14 @@ func TestDBRecover(t *testing.T) {
 	t.Run("WithBucket", func(t *testing.T) {
 		bucket := objstore.NewInMemBucket()
 		sinksource := NewDefaultObjstoreBucket(bucket)
-		dir := setup(t, true, WithDataSink(sinksource), WithDataSource(sinksource))
+		dir := setup(t, true, WithReadWriteStorage(sinksource))
 
 		c, err := New(
 			WithLogger(newTestLogger(t)),
 			WithStoragePath(dir),
 			WithWAL(),
 			WithSnapshotTriggerSize(1),
-			WithDataSink(sinksource),
-			WithDataSource(sinksource),
+			WithReadWriteStorage(sinksource),
 		)
 		require.NoError(t, err)
 		defer c.Close()

--- a/filter.go
+++ b/filter.go
@@ -16,6 +16,10 @@ func (f PreExprVisitorFunc) PreVisit(expr logicalplan.Expr) bool {
 	return f(expr)
 }
 
+func (f PreExprVisitorFunc) Visit(expr logicalplan.Expr) bool {
+	return false
+}
+
 func (f PreExprVisitorFunc) PostVisit(expr logicalplan.Expr) bool {
 	return false
 }

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -852,6 +852,10 @@ func (f PreExprVisitorFunc) PreVisit(expr logicalplan.Expr) bool {
 	return f(expr)
 }
 
+func (f PreExprVisitorFunc) Visit(expr logicalplan.Expr) bool {
+	return false
+}
+
 func (f PreExprVisitorFunc) PostVisit(expr logicalplan.Expr) bool {
 	return false
 }

--- a/query/logicalplan/builder.go
+++ b/query/logicalplan/builder.go
@@ -52,6 +52,7 @@ func (b Builder) Project(
 
 type Visitor interface {
 	PreVisit(expr Expr) bool
+	Visit(expr Expr) bool
 	PostVisit(expr Expr) bool
 }
 

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -72,6 +72,11 @@ func (e *BinaryExpr) Accept(visitor Visitor) bool {
 		return false
 	}
 
+	continu = visitor.Visit(e)
+	if !continu {
+		return false
+	}
+
 	continu = e.Right.Accept(visitor)
 	if !continu {
 		return false

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -401,6 +401,10 @@ func (v *findExpressionForTypeVisitor) PreVisit(expr Expr) bool {
 	return true
 }
 
+func (v *findExpressionForTypeVisitor) Visit(expr Expr) bool {
+	return true
+}
+
 func (v *findExpressionForTypeVisitor) PostVisit(expr Expr) bool {
 	found := v.exprType == reflect.TypeOf(expr)
 	if found {

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -512,6 +512,10 @@ func (a *HashAggregate) Finish(ctx context.Context) error {
 		numCols := len(aggregate.groupByCols) + len(aggregate.aggregations)
 		numRows := aggregate.rowCount
 
+		if numRows == 0 { // skip empty aggregates
+			continue
+		}
+
 		groupByFields := make([]arrow.Field, 0, numCols)
 		groupByArrays := make([]arrow.Array, 0, numCols)
 		for _, fieldName := range aggregate.colOrdering {

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -53,6 +53,10 @@ func (f PreExprVisitorFunc) PreVisit(expr logicalplan.Expr) bool {
 	return f(expr)
 }
 
+func (f PreExprVisitorFunc) Visit(expr logicalplan.Expr) bool {
+	return false
+}
+
 func (f PreExprVisitorFunc) PostVisit(expr logicalplan.Expr) bool {
 	return false
 }

--- a/query/physicalplan/planordering.go
+++ b/query/physicalplan/planordering.go
@@ -71,6 +71,10 @@ func (f preExprVisitorFunc) PreVisit(expr logicalplan.Expr) bool {
 	return f(expr)
 }
 
+func (f preExprVisitorFunc) Visit(_ logicalplan.Expr) bool {
+	return true
+}
+
 func (f preExprVisitorFunc) PostVisit(_ logicalplan.Expr) bool {
 	return true
 }

--- a/store.go
+++ b/store.go
@@ -20,6 +20,9 @@ import (
 	"github.com/polarsignals/frostdb/storage"
 )
 
+// DefaultBlockReaderLimit is the concurrency limit for reading blocks.
+const DefaultBlockReaderLimit = 10
+
 // Persist uploads the block to the underlying bucket.
 func (t *TableBlock) Persist() error {
 	if len(t.table.db.sinks) == 0 {
@@ -84,7 +87,7 @@ func NewDefaultObjstoreBucket(b objstore.Bucket, options ...DefaultObjstoreBucke
 		Bucket:           storage.NewBucketReaderAt(b),
 		tracer:           trace.NewNoopTracerProvider().Tracer(""),
 		logger:           log.NewNopLogger(),
-		blockReaderLimit: 10,
+		blockReaderLimit: DefaultBlockReaderLimit,
 	}
 
 	for _, option := range options {

--- a/table.go
+++ b/table.go
@@ -1701,7 +1701,7 @@ func (t *Table) collectRowGroups(
 	// Collect from all other data sources.
 	for _, source := range t.db.sources {
 		span.AddEvent(fmt.Sprintf("source/%s", source.String()))
-		if err := source.TableScan(ctx, filepath.Join(t.db.name, t.name), t.schema, filterExpr, lastBlockTimestamp, rowGroups); err != nil {
+		if err := source.Scan(ctx, filepath.Join(t.db.name, t.name), t.schema, filterExpr, lastBlockTimestamp, rowGroups); err != nil {
 			return err
 		}
 	}

--- a/table.go
+++ b/table.go
@@ -1701,7 +1701,10 @@ func (t *Table) collectRowGroups(
 	// Collect from all other data sources.
 	for _, source := range t.db.sources {
 		span.AddEvent(fmt.Sprintf("source/%s", source.String()))
-		if err := source.Scan(ctx, filepath.Join(t.db.name, t.name), t.schema, filterExpr, lastBlockTimestamp, rowGroups); err != nil {
+		if err := source.Scan(ctx, filepath.Join(t.db.name, t.name), t.schema, filterExpr, lastBlockTimestamp, func(ctx context.Context, v any) error {
+			rowGroups <- v
+			return nil
+		}); err != nil {
 			return err
 		}
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -872,10 +872,12 @@ func Test_DoubleTable(t *testing.T) {
 	config := NewTableConfig(def)
 
 	bucket := objstore.NewInMemBucket()
+	sinksource := NewDefaultObjstoreBucket(bucket)
 	logger := newTestLogger(t)
 	c, err := New(
 		WithLogger(logger),
-		WithBucketStorage(bucket),
+		WithDataSink(sinksource),
+		WithDataSource(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()

--- a/table_test.go
+++ b/table_test.go
@@ -876,8 +876,7 @@ func Test_DoubleTable(t *testing.T) {
 	logger := newTestLogger(t)
 	c, err := New(
 		WithLogger(logger),
-		WithDataSink(sinksource),
-		WithDataSource(sinksource),
+		WithReadWriteStorage(sinksource),
 	)
 	require.NoError(t, err)
 	defer c.Close()

--- a/table_test.go
+++ b/table_test.go
@@ -1073,7 +1073,6 @@ func Test_Table_NestedSchema(t *testing.T) {
 				records++
 				require.Equal(t, int64(1), ar.NumRows())
 				require.Equal(t, int64(3), ar.NumCols())
-				fmt.Println(ar)
 				ar.Retain()
 				r = ar
 				return nil


### PR DESCRIPTION
This replaces the objstore bucket interface with a slightly more specific interface for remote storage called sources and sinks. 

This allows pluggable sources/sinks for remote storage for FrostDB to write and read to/from. This allows us to remove the "ignoreObjstoreOnQuery" flag and instead one could simply configure a sink but not a source to achieve the same goal. The separate set of sources and sinks allows for a more flexible system where one could perform migrations from old storage by configuring a new sink but keep a previous source to continue to read from.

I've also updated the Visitor pattern interface to include an in-order visitor. 