### PR TITLE
bench: add BenchmarkQuery/Filter

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: '1.20'
 
     - name: Test
       run: go test -short -race -tags debug -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: ^1.19
+          go-version: ^1.20
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This sub-benchmark runs within the BenchmarkQuery setup to measure how fast a simple filter runs. B/msec are also reported, which is something that we're tracking in our OKRs (i.e. scan layer throughput). These bytes are measured as total block size, so if we discard scanning granules, that counts as processing that granule which is nice because it captures how well we're doing in scan layer filtering before parquet conversion.