### PR TITLE
db: move snapshots and wal directories to trash

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -197,7 +197,7 @@ func Open(
 				Help: "The number of times the WAL had to be repaired (truncated) due to corrupt records",
 			}),
 			walRepairsLostRecords: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_wal_replairs_lost_records_total",
+				Name: "frostdb_wal_repairs_lost_records_total",
 				Help: "The number of WAL records lost due to WAL repairs (truncations)",
 			}),
 		},


### PR DESCRIPTION
Previously, db.Close would call os.RemoveAll on the snapshots and wal
directories. This is an O(n) operation, which could lead to some leftover
files if we exceed the graceful shutdown period.

This commit changes the removal to move both directories to a trash/ directory,
which is an O(1) operation. This trash/ directory can be removed safely on
startup if it still exists.

Additionally, this commit moves closeInternal to before removing the
directories. This ensures that the WAL is flushed and closed before deletion.