### PR TITLE
dynparquet: reduce allocations

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -53,12 +53,13 @@ func insertSampleRecords(ctx context.Context, t *testing.T, table *Table, timest
 		})
 	}
 
-	ps, err := table.Schema().DynamicParquetSchema(map[string][]string{
+	ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
 		"labels": {"label1"},
 	})
 	require.NoError(t, err)
+	defer table.Schema().PutPooledParquetSchema(ps)
 
-	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps, logicalplan.IterOptions{})
+	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
 	require.NoError(t, err)
 
 	ar, err := samples.ToRecord(sc)

--- a/db_test.go
+++ b/db_test.go
@@ -139,12 +139,13 @@ func TestDBWithWAL(t *testing.T) {
 		switch isArrow {
 		case true:
 
-			ps, err := table.Schema().DynamicParquetSchema(map[string][]string{
+			ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
 				"labels": {"label1", "label2", "label3", "label4"},
 			})
 			require.NoError(t, err)
+			defer table.Schema().PutPooledParquetSchema(ps)
 
-			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps, logicalplan.IterOptions{})
+			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
 			require.NoError(t, err)
 
 			rec, err := samples.ToRecord(sc)
@@ -179,12 +180,13 @@ func TestDBWithWAL(t *testing.T) {
 
 		switch isArrow {
 		case true:
-			ps, err := table.Schema().DynamicParquetSchema(map[string][]string{
+			ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
 				"labels": {"label1", "label2"},
 			})
 			require.NoError(t, err)
+			defer table.Schema().PutPooledParquetSchema(ps)
 
-			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps, logicalplan.IterOptions{})
+			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
 			require.NoError(t, err)
 
 			rec, err := samples.ToRecord(sc)
@@ -218,12 +220,13 @@ func TestDBWithWAL(t *testing.T) {
 
 		switch isArrow {
 		case true:
-			ps, err := table.Schema().DynamicParquetSchema(map[string][]string{
+			ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
 				"labels": {"label1", "label2", "label3"},
 			})
 			require.NoError(t, err)
+			defer table.Schema().PutPooledParquetSchema(ps)
 
-			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps, logicalplan.IterOptions{})
+			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
 			require.NoError(t, err)
 
 			rec, err := samples.ToRecord(sc)
@@ -1305,12 +1308,13 @@ func Test_DB_TableWrite_ArrowRecord(t *testing.T) {
 		},
 	}
 
-	ps, err := table.Schema().DynamicParquetSchema(map[string][]string{
+	ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
 		"labels": {"label1", "label2", "label3"},
 	})
 	require.NoError(t, err)
+	defer table.Schema().PutPooledParquetSchema(ps)
 
-	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps, logicalplan.IterOptions{})
+	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
 	require.NoError(t, err)
 
 	r, err := samples.ToRecord(sc)

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -83,8 +83,8 @@ func (s *Schema) Cmp(a, b *DynamicRow) int {
 	if err != nil {
 		panic(fmt.Sprintf("unexpected schema state: %v", err))
 	}
-	sortingSchema := pooledSchema.schema
-	defer s.PutParquetSortingSchema(pooledSchema)
+	sortingSchema := pooledSchema.Schema
+	defer s.PutPooledParquetSchema(pooledSchema)
 
 	// Iterate over all the schema columns to prepare the rows for comparison.
 	// The main reason we can't directly pass in {a,b}.Row is that they might

--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -79,10 +79,12 @@ func (s *Schema) RowLessThan(a, b *DynamicRow) bool {
 func (s *Schema) Cmp(a, b *DynamicRow) int {
 	dynamicColumns := mergeDynamicColumnSets([]map[string][]string{a.DynamicColumns, b.DynamicColumns})
 	cols := s.ParquetSortingColumns(dynamicColumns)
-	sortingSchema, err := s.parquetSortingSchema(dynamicColumns)
+	pooledSchema, err := s.GetParquetSortingSchema(dynamicColumns)
 	if err != nil {
 		panic(fmt.Sprintf("unexpected schema state: %v", err))
 	}
+	sortingSchema := pooledSchema.schema
+	defer s.PutParquetSortingSchema(pooledSchema)
 
 	// Iterate over all the schema columns to prepare the rows for comparison.
 	// The main reason we can't directly pass in {a,b}.Row is that they might

--- a/parts/part.go
+++ b/parts/part.go
@@ -150,8 +150,12 @@ func (p *Part) Least() (*dynparquet.DynamicRow, error) {
 	}
 
 	if p.record != nil {
-		var err error
-		p.minRow, err = pqarrow.RecordToDynamicRow(p.schema, p.record, 0)
+		pooledSchema, err := p.schema.GetDynamicParquetSchema(pqarrow.RecordDynamicCols(p.record))
+		if err != nil {
+			return nil, err
+		}
+		defer p.schema.PutPooledParquetSchema(pooledSchema)
+		p.minRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -181,8 +185,12 @@ func (p *Part) most() (*dynparquet.DynamicRow, error) {
 	}
 
 	if p.record != nil {
-		var err error
-		p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, p.record, int(p.record.NumRows()-1))
+		pooledSchema, err := p.schema.GetDynamicParquetSchema(pqarrow.RecordDynamicCols(p.record))
+		if err != nil {
+			return nil, err
+		}
+		defer p.schema.PutPooledParquetSchema(pooledSchema)
+		p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, int(p.record.NumRows()-1))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR is the result of a Let's Profile stream where we looked at CPU usage in the frostdb ingestion path. The changes improve insertion benchmarks by ~50%.

The only thing I'm not quite sure about is that the third commit release pooled `parquet.Schema`s with a potential use after a release (e.g. storing the schema somewhere). I *think* this is fine because schemas are immutable once created, but it would be nice to have someone else's opinion.