### PR TITLE
*: reclaim disk space on successful snapshot

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1442,6 +1442,10 @@ func TestDBRecover(t *testing.T) {
 				WithStoragePath(dir),
 				WithWAL(),
 				WithSnapshotTriggerSize(1),
+				// Disable reclaiming disk space on snapshot (i.e. deleting
+				// old snapshots and WAL). This allows us to modify on-disk
+				// state for some tests.
+				WithTestingNoDiskSpaceReclaimOnSnapshot(),
 			},
 				options...,
 			)...,

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -35,6 +35,11 @@ func TestSnapshot(t *testing.T) {
 		db, err := c.DB(ctx, "test")
 		require.NoError(t, err)
 
+		// Complete a txn so that the snapshot is created at txn 1, snapshots at
+		// txn 0 are considered empty so ignored.
+		_, _, commit := db.begin()
+		commit()
+
 		require.NoError(t, db.snapshotAtTX(ctx, db.highWatermark.Load()))
 
 		txBefore := db.highWatermark.Load()

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,8 @@
+package frostdb
+
+func WithTestingNoDiskSpaceReclaimOnSnapshot() Option {
+	return func(s *ColumnStore) error {
+		s.testingOptions.disableReclaimDiskSpaceOnSnapshot = true
+		return nil
+	}
+}


### PR DESCRIPTION
This PR reclaims disk space after performing a successful snapshot on
block rotation and insert. The code is extra-careful to open a snapshot file
and check the checksum before using that transaction to truncate old entries
from the WAL and old snapshots.

Closes #430 