### PR TITLE
pqarrow: remove RecordToDynamicSchema

### DIFF
--- a/parts/part.go
+++ b/parts/part.go
@@ -150,12 +150,13 @@ func (p *Part) Least() (*dynparquet.DynamicRow, error) {
 	}
 
 	if p.record != nil {
-		pooledSchema, err := p.schema.GetDynamicParquetSchema(pqarrow.RecordDynamicCols(p.record))
+		dynCols := pqarrow.RecordDynamicCols(p.record)
+		pooledSchema, err := p.schema.GetDynamicParquetSchema(dynCols)
 		if err != nil {
 			return nil, err
 		}
 		defer p.schema.PutPooledParquetSchema(pooledSchema)
-		p.minRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, 0)
+		p.minRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, dynCols, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -185,12 +186,13 @@ func (p *Part) most() (*dynparquet.DynamicRow, error) {
 	}
 
 	if p.record != nil {
-		pooledSchema, err := p.schema.GetDynamicParquetSchema(pqarrow.RecordDynamicCols(p.record))
+		dynCols := pqarrow.RecordDynamicCols(p.record)
+		pooledSchema, err := p.schema.GetDynamicParquetSchema(dynCols)
 		if err != nil {
 			return nil, err
 		}
 		defer p.schema.PutPooledParquetSchema(pooledSchema)
-		p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, int(p.record.NumRows()-1))
+		p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, dynCols, int(p.record.NumRows()-1))
 		if err != nil {
 			return nil, err
 		}

--- a/table.go
+++ b/table.go
@@ -1245,12 +1245,13 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 	ps := t.table.schema
 	numRows := record.NumRows()
 	idx := numRows - 1
-	pooledSchema, err := ps.GetDynamicParquetSchema(pqarrow.RecordDynamicCols(record))
+	dynCols := pqarrow.RecordDynamicCols(record)
+	pooledSchema, err := ps.GetDynamicParquetSchema(dynCols)
 	if err != nil {
 		return err
 	}
 	defer ps.PutPooledParquetSchema(pooledSchema)
-	row, err := pqarrow.RecordToDynamicRow(ps, pooledSchema.Schema, record, int(idx))
+	row, err := pqarrow.RecordToDynamicRow(ps, pooledSchema.Schema, record, dynCols, int(idx))
 	if err != nil {
 		if err == io.EOF {
 			level.Debug(t.logger).Log("msg", "inserted record with no rows")
@@ -1273,7 +1274,7 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 			// Descend rows to insert until we find a row that does not belong in this granule.
 			n := 0
 			for ; idx >= 0; idx-- {
-				row, err := pqarrow.RecordToDynamicRow(ps, pooledSchema.Schema, record, int(idx))
+				row, err := pqarrow.RecordToDynamicRow(ps, pooledSchema.Schema, record, dynCols, int(idx))
 				if err != nil {
 					ascendErr = err
 					return false


### PR DESCRIPTION
This function was unnecessary since callers can get dynamic columns from the record and request a pooled parquet schema with these. This commit should reduce allocations and CPU time in the ingestion path.