### PR TITLE
Revert "Use a large list insted of a normal list (#449)"

### DIFF
--- a/pqarrow/arrow_test.go
+++ b/pqarrow/arrow_test.go
@@ -226,27 +226,27 @@ func TestMergeToArrow(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, as.Fields(), 8)
 	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}})
 	require.Equal(t, as.Field(1), arrow.Field{Name: "labels.label1", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}, Nullable: true})
 	require.Equal(t, as.Field(2), arrow.Field{Name: "labels.label2", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}, Nullable: true})
 	require.Equal(t, as.Field(3), arrow.Field{Name: "labels.label3", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}, Nullable: true})
 	require.Equal(t, as.Field(4), arrow.Field{Name: "labels.label4", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}, Nullable: true})
 	require.Equal(t, as.Field(5), arrow.Field{Name: "stacktrace", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}})
 	require.Equal(t, as.Field(6), arrow.Field{Name: "timestamp", Type: &arrow.Int64Type{}})
@@ -455,7 +455,7 @@ func TestDistinctBinaryExprOptimization(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, as.Fields(), 3)
 	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}})
 	require.Equal(t, as.Field(1), arrow.Field{Name: "timestamp", Type: &arrow.Int64Type{}})
@@ -550,7 +550,7 @@ func TestDistinctBinaryExprOptimizationMixed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, as.Fields(), 3)
 	require.Equal(t, as.Field(0), arrow.Field{Name: "example_type", Type: &arrow.DictionaryType{
-		IndexType: &arrow.Int16Type{},
+		IndexType: &arrow.Uint32Type{},
 		ValueType: &arrow.BinaryType{},
 	}})
 	require.Equal(t, as.Field(1), arrow.Field{Name: "value", Type: &arrow.Int64Type{}})
@@ -593,10 +593,10 @@ func TestList(t *testing.T) {
 	require.Equal(t, int64(1), record.NumCols())
 
 	column := record.Column(0)
-	colType := column.DataType().(*arrow.LargeListType)
+	colType := column.DataType().(*arrow.ListType)
 	require.True(t, colType.ElemField().Nullable)
 
-	listArray := column.(*array.LargeList)
+	listArray := column.(*array.List)
 	vals := listArray.ListValues().(*array.Int64).Int64Values()
 	for i := range data {
 		require.Equal(
@@ -647,7 +647,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label1",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -655,7 +655,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label2",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -664,11 +664,11 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 				},
 				{
 					Name: "timestamps",
-					Type: arrow.LargeListOf(&arrow.Int64Type{}),
+					Type: arrow.ListOf(&arrow.Int64Type{}),
 				},
 				{
 					Name: "values",
-					Type: arrow.LargeListOf(&arrow.Int64Type{}),
+					Type: arrow.ListOf(&arrow.Int64Type{}),
 				},
 			}, nil),
 		},
@@ -684,7 +684,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label1",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -693,7 +693,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 				},
 				{
 					Name: "timestamps",
-					Type: arrow.LargeListOf(&arrow.Int64Type{}),
+					Type: arrow.ListOf(&arrow.Int64Type{}),
 				},
 			}, nil),
 		},
@@ -709,7 +709,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label2",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -718,7 +718,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 				},
 				{
 					Name: "timestamps",
-					Type: arrow.LargeListOf(&arrow.Int64Type{}),
+					Type: arrow.ListOf(&arrow.Int64Type{}),
 				},
 			}, nil),
 		},
@@ -734,7 +734,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label1",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -742,7 +742,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 						{
 							Name: "label2",
 							Type: &arrow.DictionaryType{
-								IndexType: &arrow.Int16Type{},
+								IndexType: &arrow.Uint32Type{},
 								ValueType: &arrow.BinaryType{},
 							},
 							Nullable: true,
@@ -751,7 +751,7 @@ func Test_ParquetRowGroupToArrowSchema_Groups(t *testing.T) {
 				},
 				{
 					Name: "timestamps",
-					Type: arrow.LargeListOf(&arrow.Int64Type{}),
+					Type: arrow.ListOf(&arrow.Int64Type{}),
 				},
 			}, nil),
 		},

--- a/pqarrow/arrowutils/arrow.go
+++ b/pqarrow/arrowutils/arrow.go
@@ -21,7 +21,7 @@ func RecordSize(r arrow.Record) int64 {
 	return size
 }
 
-func ForEachValueInList(index int, arr *array.LargeList, iterator func(int, any)) error {
+func ForEachValueInList(index int, arr *array.List, iterator func(int, any)) error {
 	start, end := arr.ValueOffsets(index)
 	list := array.NewSlice(arr.ListValues(), start, end)
 	defer list.Release()

--- a/pqarrow/builder/optbuilders_test.go
+++ b/pqarrow/builder/optbuilders_test.go
@@ -62,7 +62,7 @@ func TestRepeatLastValue(t *testing.T) {
 }
 
 func Test_ListBuilder(t *testing.T) {
-	lb := builder.NewLargeListBuilder(memory.NewGoAllocator(), &arrow.Int64Type{})
+	lb := builder.NewListBuilder(memory.NewGoAllocator(), &arrow.Int64Type{})
 
 	lb.Append(true)
 	lb.ValueBuilder().(*builder.OptInt64Builder).Append(1)

--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -15,8 +15,8 @@ func NewBuilder(mem memory.Allocator, t arrow.DataType) ColumnBuilder {
 		return NewOptBinaryBuilder(arrow.BinaryTypes.Binary)
 	case *arrow.Int64Type:
 		return NewOptInt64Builder(arrow.PrimitiveTypes.Int64)
-	case *arrow.LargeListType:
-		return NewLargeListBuilder(mem, t.Elem())
+	case *arrow.ListType:
+		return NewListBuilder(mem, t.Elem())
 	case *arrow.BooleanType:
 		return NewOptBooleanBuilder(arrow.FixedWidthTypes.Boolean)
 	default:
@@ -91,9 +91,9 @@ func AppendValue(cb ColumnBuilder, arr arrow.Array, i int) error {
 		default:
 			return fmt.Errorf("non-dictionary array %T provided for dictionary builder", a)
 		}
-	case *LargeListBuilder:
+	case *ListBuilder:
 		vb := b.ValueBuilder()
-		list := arr.(*array.LargeList)
+		list := arr.(*array.List)
 		start, end := list.ValueOffsets(i)
 		values := array.NewSlice(list.ListValues(), start, end)
 		defer values.Release()

--- a/pqarrow/convert/convert.go
+++ b/pqarrow/convert/convert.go
@@ -65,7 +65,7 @@ func ParquetNodeToType(n parquet.Node) (arrow.DataType, error) {
 					fallthrough
 				case format.RLEDictionary:
 					dt = &arrow.DictionaryType{
-						IndexType: &arrow.Int16Type{}, // TODO: do we need more width?
+						IndexType: &arrow.Uint32Type{},
 						ValueType: &arrow.BinaryType{},
 					}
 				default:
@@ -95,7 +95,7 @@ func ParquetNodeToType(n parquet.Node) (arrow.DataType, error) {
 	}
 
 	if n.Repeated() {
-		dt = arrow.LargeListOf(dt)
+		dt = arrow.ListOf(dt)
 	}
 
 	return dt, nil
@@ -109,7 +109,7 @@ func GetWriter(offset int, n parquet.Node) (writer.NewWriterFunc, error) {
 	}
 
 	list := false
-	if typ, ok := dt.(*arrow.LargeListType); ok {
+	if typ, ok := dt.(*arrow.ListType); ok {
 		// Unwrap the list type.
 		list = true
 		dt = typ.Elem()
@@ -211,5 +211,5 @@ func listType(n parquet.Node) (arrow.DataType, error) {
 	if err != nil {
 		return nil, err
 	}
-	return arrow.LargeListOf(listType), nil
+	return arrow.ListOf(listType), nil
 }

--- a/pqarrow/convert/convert_test.go
+++ b/pqarrow/convert/convert_test.go
@@ -37,7 +37,7 @@ func TestParquetNodeToType(t *testing.T) {
 		},
 		{
 			parquetNode: parquet.List(parquet.String()), // NOTE: can't determine string vs binary in conversion
-			arrowType:   arrow.LargeListOf(&arrow.BinaryType{}),
+			arrowType:   arrow.ListOf(&arrow.BinaryType{}),
 		},
 		{
 			parquetNode: parquet.Map( // NOTE: can't determine string vs binary in conversion

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -65,7 +65,7 @@ func appendToRow(row []parquet.Value, c arrow.Array, index, rep, def, col int) (
 		default:
 			return nil, fmt.Errorf("dictionary not of expected type: %T", dict)
 		}
-	case *array.LargeList:
+	case *array.List:
 		if err := arrowutils.ForEachValueInList(index, arr, func(i int, v any) {
 			switch i {
 			case 0:

--- a/pqarrow/writer/writer.go
+++ b/pqarrow/writer/writer.go
@@ -139,13 +139,13 @@ func (w *uint64ValueWriter) WritePage(p parquet.Page) error {
 }
 
 type repeatedValueWriter struct {
-	b      *builder.LargeListBuilder
+	b      *builder.ListBuilder
 	values ValueWriter
 }
 
 func NewListValueWriter(newValueWriter func(b builder.ColumnBuilder, numValues int) ValueWriter) func(b builder.ColumnBuilder, numValues int) ValueWriter {
 	return func(b builder.ColumnBuilder, numValues int) ValueWriter {
-		builder := b.(*builder.LargeListBuilder)
+		builder := b.(*builder.ListBuilder)
 
 		return &repeatedValueWriter{
 			b:      builder,

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -271,14 +271,14 @@ func hashArray(arr arrow.Array) []uint64 {
 		return hashBooleanArray(ar)
 	case *array.Dictionary:
 		return hashDictionaryArray(ar)
-	case *array.LargeList:
+	case *array.List:
 		return hashListArray(ar)
 	default:
 		panic("unsupported array type " + fmt.Sprintf("%T", arr))
 	}
 }
 
-func hashListArray(arr *array.LargeList) []uint64 {
+func hashListArray(arr *array.List) []uint64 {
 	res := make([]uint64, arr.Len())
 	for i := 0; i < arr.Len(); i++ {
 		list := []byte{}

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -161,7 +161,7 @@ func BinaryScalarOperation(left arrow.Array, right scalar.Scalar, operator logic
 	}
 
 	switch leftType.(type) {
-	case *arrow.LargeListType:
+	case *arrow.ListType:
 		panic("TODO: list comparisons unimplemented")
 	}
 


### PR DESCRIPTION
This reverts commit c236424d87e62b753883f42180c86319aa69a881.

Turns out the slicing bug was only fixed on regular lists, not large lists. Reverting until we can use large lists.