### PR TITLE
run all logic tests as arrow

### DIFF
--- a/logictest/logic_test.go
+++ b/logictest/logic_test.go
@@ -80,7 +80,18 @@ func TestLogic(t *testing.T) {
 		require.NoError(t, err)
 		r := NewRunner(frostDB{DB: db}, schemas)
 		datadriven.RunTest(t, path, func(t *testing.T, c *datadriven.TestData) string {
-			return r.RunCmd(ctx, c)
+			return r.RunCmd(ctx, c, false)
+		})
+	})
+	datadriven.Walk(t, testdataDirectory, func(t *testing.T, path string) {
+		columnStore, err := frostdb.New()
+		require.NoError(t, err)
+		defer columnStore.Close()
+		db, err := columnStore.DB(ctx, "test")
+		require.NoError(t, err)
+		r := NewRunner(frostDB{DB: db}, schemas)
+		datadriven.RunTest(t, path, func(t *testing.T, c *datadriven.TestData) string {
+			return r.RunCmd(ctx, c, true)
 		})
 	})
 }


### PR DESCRIPTION
In addition to running the logic tests with Parquet insertions we now also run the tests with arrow insertion