### PR TITLE
replace GetValue helper function with new GetOneForMarshal

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/polarsignals/frostdb/dynparquet"
-	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/query"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
@@ -156,10 +155,7 @@ func getDeterministicTypeFilterExpr(
 		for i := 0; i < int(r.NumRows()); i++ {
 			row := make([]string, 0, len(typeColumns))
 			for j := range typeColumns {
-				v, err := arrowutils.GetValue(r.Column(j), i)
-				if err != nil {
-					return err
-				}
+				v := r.Column(j).GetOneForMarshal(i)
 				row = append(row, string(v.([]byte)))
 			}
 			results = append(results, row)
@@ -206,10 +202,7 @@ func getDeterministicLabelValuePair(ctx context.Context, engine *query.LocalEngi
 				if arr.IsNull(i) {
 					continue
 				}
-				v, err := arrowutils.GetValue(arr, i)
-				if err != nil {
-					return err
-				}
+				v := arr.GetOneForMarshal(i)
 				values = append(values, string(v.([]byte)))
 			}
 			return nil

--- a/pqarrow/arrowutils/groupranges.go
+++ b/pqarrow/arrowutils/groupranges.go
@@ -68,10 +68,7 @@ func GetGroupsAndOrderedSetRanges(
 			}
 
 			// And update the current group.
-			v, err := GetValue(t, j)
-			if err != nil {
-				return err
-			}
+			v := t.GetOneForMarshal(j)
 			switch concreteV := v.(type) {
 			case []byte:
 				// Safe copy, otherwise the value might get overwritten.

--- a/pqarrow/arrowutils/utils.go
+++ b/pqarrow/arrowutils/utils.go
@@ -1,42 +1,10 @@
 package arrowutils
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/memory"
 )
-
-// GetValue returns the value at index i in arr. If the value is null, nil is
-// returned.
-func GetValue(arr arrow.Array, i int) (any, error) {
-	if arr.IsNull(i) {
-		return nil, nil
-	}
-
-	switch a := arr.(type) {
-	case *array.Binary:
-		return a.Value(i), nil
-	case *array.FixedSizeBinary:
-		return a.Value(i), nil
-	case *array.String:
-		return a.Value(i), nil
-	case *array.Int64:
-		return a.Value(i), nil
-	case *array.Boolean:
-		return a.Value(i), nil
-	case *array.Dictionary:
-		switch dict := a.Dictionary().(type) {
-		case *array.Binary:
-			return dict.Value(a.GetValueIndex(i)), nil
-		default:
-			return nil, fmt.Errorf("unsupported dictionary type for GetValue %T", dict)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported type for GetValue %T", a)
-	}
-}
 
 // ArrayConcatenator is an object that helps callers keep track of a slice of
 // arrays and concatenate them into a single one when needed. This is more

--- a/pqarrow/builder/optbuilders_test.go
+++ b/pqarrow/builder/optbuilders_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/memory"
 	"github.com/stretchr/testify/require"
 
-	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/pqarrow/builder"
 )
 
@@ -54,8 +53,7 @@ func TestRepeatLastValue(t *testing.T) {
 		require.Equal(t, tc.b.Len(), 10)
 		a := tc.b.NewArray()
 		for i := 0; i < a.Len(); i++ {
-			v, err := arrowutils.GetValue(a, i)
-			require.NoError(t, err)
+			v := a.GetOneForMarshal(i)
 			require.Equal(t, tc.v, v)
 		}
 	}


### PR DESCRIPTION
Since moving to arrow v12 we can use some of the new helper functions that library provides.