### PR TITLE
use arrow pkg util for total record size

### DIFF
--- a/pqarrow/arrowutils/arrow.go
+++ b/pqarrow/arrowutils/arrow.go
@@ -3,23 +3,8 @@ package arrowutils
 import (
 	"fmt"
 
-	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 )
-
-// RecordSize returns the arrow record size in bytes.
-func RecordSize(r arrow.Record) int64 {
-	size := int64(0)
-	for _, col := range r.Columns() {
-		bufs := col.Data().Buffers()
-		for _, buf := range bufs {
-			if buf != nil {
-				size += int64(buf.Len())
-			}
-		}
-	}
-	return size
-}
 
 func ForEachValueInList(index int, arr *array.List, iterator func(int, any)) error {
 	start, end := arr.ValueOffsets(index)

--- a/snapshot.go
+++ b/snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/apache/arrow/go/v12/arrow/ipc"
+	"github.com/apache/arrow/go/v12/arrow/util"
 	"github.com/go-kit/log/level"
 	"github.com/google/btree"
 	"github.com/oklog/ulid"
@@ -28,7 +29,6 @@ import (
 	tablepb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/table/v1alpha1"
 	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
 	"github.com/polarsignals/frostdb/parts"
-	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 )
 
 // This file implements writing and reading database snapshots from disk.
@@ -602,7 +602,7 @@ func loadSnapshot(ctx context.Context, db *DB, r io.ReaderAt, size int64) error 
 							return err
 						}
 
-						resultParts = append(resultParts, parts.NewArrowPart(partMeta.Tx, record, int(arrowutils.RecordSize(record)), table.schema, partOptions))
+						resultParts = append(resultParts, parts.NewArrowPart(partMeta.Tx, record, int(util.TotalRecordSize(record)), table.schema, partOptions))
 					default:
 						return fmt.Errorf("unknown part encoding: %s", partMeta.Encoding)
 					}

--- a/table.go
+++ b/table.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/apache/arrow/go/v12/arrow/util"
 	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -43,7 +44,6 @@ import (
 	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
 	"github.com/polarsignals/frostdb/parts"
 	"github.com/polarsignals/frostdb/pqarrow"
-	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 	"github.com/polarsignals/frostdb/wal"
 	walpkg "github.com/polarsignals/frostdb/wal"
@@ -1261,7 +1261,7 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 	}
 
 	// recordSizePerRow is the rough estimate of the size of each row in the record.
-	recordSizePerRow := int(arrowutils.RecordSize(record) / int64(numRows))
+	recordSizePerRow := int(util.TotalRecordSize(record) / int64(numRows))
 
 	var ascendErr error
 	t.Index().DescendLessOrEqual(
@@ -1309,7 +1309,7 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 
 	if idx < 0 {
 		// All rows exhausted.
-		t.size.Add(arrowutils.RecordSize(record))
+		t.size.Add(util.TotalRecordSize(record))
 		return nil
 	}
 
@@ -1326,7 +1326,7 @@ func (t *TableBlock) insertRecordToGranules(tx uint64, record arrow.Record) erro
 	}
 	t.table.metrics.granulesCreated.Inc()
 	t.table.metrics.numParts.Add(float64(1))
-	t.size.Add(arrowutils.RecordSize(record))
+	t.size.Add(util.TotalRecordSize(record))
 	return nil
 }
 

--- a/table_test.go
+++ b/table_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/apache/arrow/go/v12/arrow/array"
 	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/apache/arrow/go/v12/arrow/util"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
@@ -25,7 +26,6 @@ import (
 	"github.com/polarsignals/frostdb/dynparquet"
 	schemapb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha1"
 	"github.com/polarsignals/frostdb/pqarrow"
-	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 	"github.com/polarsignals/frostdb/query"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
@@ -1450,7 +1450,7 @@ func Test_Table_Size(t *testing.T) {
 			require.NoError(t, err)
 
 			after := table.ActiveBlock().Size()
-			require.Equal(t, arrowutils.RecordSize(rec), after-before)
+			require.Equal(t, util.TotalRecordSize(rec), after-before)
 		default:
 			buf, err := samples.ToBuffer(table.Schema())
 			require.NoError(t, err)


### PR DESCRIPTION
Use the provided `TotalRecordSize` util from the arrow package to correctly calculate record sizes. 