### PR TITLE
Query limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/apache/arrow/go/v13 v13.0.0-20230524164752-c4ea194c6880
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cockroachdb/datadriven v1.0.2
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140
 	github.com/dustin/go-humanize v1.0.1
@@ -33,7 +34,6 @@ require (
 	github.com/benbjohnson/immutable v0.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/etcd v3.3.27+incompatible // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect

--- a/query/memory.go
+++ b/query/memory.go
@@ -1,0 +1,53 @@
+package query
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/v13/arrow/memory"
+)
+
+const PanicMemoryLimit = "memory limit exceeded"
+
+var _ memory.Allocator = (*LimitAllocator)(nil)
+
+// LimitAllocator is a wrapper around a memory.Allocator that panics if the memory usage exceeds the defined limit.
+type LimitAllocator struct {
+	limit     int64
+	allocated *atomic.Int64
+	allocator memory.Allocator
+}
+
+func NewLimitAllocator(limit int64, allocator memory.Allocator) *LimitAllocator {
+	return &LimitAllocator{
+		limit:     limit,
+		allocated: &atomic.Int64{},
+		allocator: allocator,
+	}
+}
+
+func (a *LimitAllocator) Allocate(size int) []byte {
+	allocated := a.allocated.Add(int64(size))
+	if allocated > a.limit {
+		panic(PanicMemoryLimit)
+	}
+
+	return a.allocator.Allocate(size)
+}
+
+func (a *LimitAllocator) Reallocate(size int, b []byte) []byte {
+	if len(b) == size {
+		return b
+	}
+
+	allocated := a.allocated.Add(int64(size - len(b)))
+	if allocated > a.limit {
+		panic(PanicMemoryLimit)
+	}
+	buf := a.allocator.Reallocate(size, b)
+	return buf
+}
+
+func (a *LimitAllocator) Free(b []byte) {
+	a.allocated.Add(-int64(len(b)))
+	a.allocator.Free(b)
+}

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -120,7 +120,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		callbacks = append(callbacks, plan.Callback)
 	}
 
-	errg, ctx := errgroup.WithContext(ctx)
+	errg, _ := errgroup.WithContext(ctx)
 	errg.Go(recovery.Do(func() error {
 		return table.View(ctx, func(ctx context.Context, tx uint64) error {
 			return table.Iterator(
@@ -139,6 +139,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		return err
 	}
 
+	errg, _ = errgroup.WithContext(ctx)
 	for _, plan := range s.plans {
 		plan := plan
 		errg.Go(recovery.Do(func() (err error) {
@@ -174,8 +175,7 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		callbacks = append(callbacks, plan.Callback)
 	}
 
-	errg, ctx := errgroup.WithContext(ctx)
-
+	errg, _ := errgroup.WithContext(ctx)
 	errg.Go(recovery.Do(func() error {
 		return table.View(ctx, func(ctx context.Context, tx uint64) error {
 			return table.SchemaIterator(
@@ -194,6 +194,7 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		return err
 	}
 
+	errg, _ = errgroup.WithContext(ctx)
 	for _, plan := range s.plans {
 		plan := plan
 		errg.Go(recovery.Do(func() error {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/query/logicalplan"
+	"github.com/polarsignals/frostdb/recovery"
 )
 
 // TODO: Make this smarter.
@@ -119,29 +120,30 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		callbacks = append(callbacks, plan.Callback)
 	}
 
-	err = table.View(ctx, func(ctx context.Context, tx uint64) error {
-		return table.Iterator(
-			ctx,
-			tx,
-			pool,
-			callbacks,
-			logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
-			logicalplan.WithProjection(s.options.Projection...),
-			logicalplan.WithFilter(s.options.Filter),
-			logicalplan.WithDistinctColumns(s.options.Distinct...),
-		)
-	})
-	if err != nil {
+	errg, ctx := errgroup.WithContext(ctx)
+	errg.Go(recovery.Do(func() error {
+		return table.View(ctx, func(ctx context.Context, tx uint64) error {
+			return table.Iterator(
+				ctx,
+				tx,
+				pool,
+				callbacks,
+				logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
+				logicalplan.WithProjection(s.options.Projection...),
+				logicalplan.WithFilter(s.options.Filter),
+				logicalplan.WithDistinctColumns(s.options.Distinct...),
+			)
+		})
+	}))
+	if err := errg.Wait(); err != nil {
 		return err
 	}
 
-	errg, ctx := errgroup.WithContext(ctx)
-
 	for _, plan := range s.plans {
 		plan := plan
-		errg.Go(func() error {
+		errg.Go(recovery.Do(func() (err error) {
 			return plan.Finish(ctx)
-		})
+		}))
 	}
 
 	return errg.Wait()
@@ -172,29 +174,31 @@ func (s *SchemaScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		callbacks = append(callbacks, plan.Callback)
 	}
 
-	err = table.View(ctx, func(ctx context.Context, tx uint64) error {
-		return table.SchemaIterator(
-			ctx,
-			tx,
-			pool,
-			callbacks,
-			logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
-			logicalplan.WithProjection(s.options.Projection...),
-			logicalplan.WithFilter(s.options.Filter),
-			logicalplan.WithDistinctColumns(s.options.Distinct...),
-		)
-	})
-	if err != nil {
+	errg, ctx := errgroup.WithContext(ctx)
+
+	errg.Go(recovery.Do(func() error {
+		return table.View(ctx, func(ctx context.Context, tx uint64) error {
+			return table.SchemaIterator(
+				ctx,
+				tx,
+				pool,
+				callbacks,
+				logicalplan.WithPhysicalProjection(s.options.PhysicalProjection...),
+				logicalplan.WithProjection(s.options.Projection...),
+				logicalplan.WithFilter(s.options.Filter),
+				logicalplan.WithDistinctColumns(s.options.Distinct...),
+			)
+		})
+	}))
+	if err := errg.Wait(); err != nil {
 		return err
 	}
 
-	errg, ctx := errgroup.WithContext(ctx)
-
 	for _, plan := range s.plans {
 		plan := plan
-		errg.Go(func() error {
+		errg.Go(recovery.Do(func() error {
 			return plan.Finish(ctx)
-		})
+		}))
 	}
 
 	return errg.Wait()

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -1,0 +1,22 @@
+package recovery
+
+import (
+	"fmt"
+)
+
+// Do is a function wrapper that will recover from a panic and return the error.
+func Do(f func() error) func() error {
+	return func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				switch e := r.(type) {
+				case error:
+					err = e
+				case string:
+					err = fmt.Errorf("%v", e)
+				}
+			}
+		}()
+		return f()
+	}
+}

--- a/table.go
+++ b/table.go
@@ -45,6 +45,7 @@ import (
 	"github.com/polarsignals/frostdb/parts"
 	"github.com/polarsignals/frostdb/pqarrow"
 	"github.com/polarsignals/frostdb/query/logicalplan"
+	"github.com/polarsignals/frostdb/recovery"
 	"github.com/polarsignals/frostdb/wal"
 	walpkg "github.com/polarsignals/frostdb/wal"
 )
@@ -861,7 +862,7 @@ func (t *Table) Iterator(
 	errg, ctx := errgroup.WithContext(ctx)
 	for _, callback := range callbacks {
 		callback := callback
-		errg.Go(func() error {
+		errg.Go(recovery.Do(func() error {
 			converter := pqarrow.NewParquetConverter(pool, *iterOpts)
 			defer converter.Close()
 
@@ -909,7 +910,7 @@ func (t *Table) Iterator(
 					}
 				}
 			}
-		})
+		}))
 	}
 
 	errg.Go(func() error {
@@ -958,7 +959,7 @@ func (t *Table) SchemaIterator(
 	errg, ctx := errgroup.WithContext(ctx)
 	for _, callback := range callbacks {
 		callback := callback
-		errg.Go(func() error {
+		errg.Go(recovery.Do(func() error {
 			for {
 				select {
 				case <-ctx.Done():
@@ -1005,7 +1006,7 @@ func (t *Table) SchemaIterator(
 					}
 				}
 			}
-		})
+		}))
 	}
 
 	errg.Go(func() error {


### PR DESCRIPTION
This introduces a new type of `memory.Allocator` that acts as a wrapper around the arrow `GoMemoryAllocator` which will account for the number of bytes allocated but not yet freed and will panic if that limit is exceeded.

In addition it adds a recovery step into the query engine, where if a child go routine panics in the query engine, the engine will capture that panic and return an error instead. 