### PR TITLE
Fix limit leaks

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1741,3 +1741,50 @@ func TestReplayBackwardsCompatibility(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 }
+
+func Test_DB_Limiter(t *testing.T) {
+	config := NewTableConfig(
+		dynparquet.SampleDefinition(),
+	)
+
+	c, err := New(
+		WithLogger(newTestLogger(t)),
+	)
+	defer func() {
+		_ = c.Close()
+	}()
+	require.NoError(t, err)
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	samples := dynparquet.NewTestSamples()
+
+	ctx := context.Background()
+	buf, err := samples.ToBuffer(table.Schema())
+	require.NoError(t, err)
+	_, err = table.InsertBuffer(ctx, buf)
+	require.NoError(t, err)
+
+	pool := query.NewLimitAllocator(1024*1024*1024, memory.DefaultAllocator)
+	engine := query.NewEngine(pool, db.TableProvider())
+	err = engine.ScanTable("test").
+		Filter(
+			logicalplan.And(
+				logicalplan.Col("labels.namespace").Eq(logicalplan.Literal("default")),
+			),
+		).
+		Aggregate(
+			[]logicalplan.Expr{logicalplan.Sum(logicalplan.Col("value"))},
+			[]logicalplan.Expr{logicalplan.Col("labels.namespace")},
+		).
+		Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+			require.Equal(t, int64(1), r.NumRows())
+			return nil
+		})
+	require.NoError(t, err)
+
+	// Expect no bytes allocated after the query has finished
+	require.Equal(t, 0, pool.Allocated())
+}

--- a/pqarrow/arrowutils/merge.go
+++ b/pqarrow/arrowutils/merge.go
@@ -30,6 +30,7 @@ func MergeRecords(
 
 	schema := records[0].Schema()
 	recordBuilder := builder.NewRecordBuilder(mem, schema)
+	defer recordBuilder.Release()
 
 	heap.Init(&h)
 	for h.Len() > 0 {

--- a/pqarrow/arrowutils/nullarray.go
+++ b/pqarrow/arrowutils/nullarray.go
@@ -30,6 +30,7 @@ func MakeNullArray(mem memory.Allocator, dt arrow.DataType, len int) arrow.Array
 	// TODO(asubiotto): This can be improved by using the optimized builders'
 	// AppendNulls. Not sure whether this should be part of the builder package.
 	b := builder.NewBuilder(mem, dt)
+	defer b.Release()
 	b.Reserve(len)
 	for i := 0; i < len; i++ {
 		b.AppendNull()

--- a/pqarrow/arrowutils/utils.go
+++ b/pqarrow/arrowutils/utils.go
@@ -29,3 +29,10 @@ func (c *ArrayConcatenator) NewArray(mem memory.Allocator) (arrow.Array, error) 
 func (c *ArrayConcatenator) Len() int {
 	return len(c.arrs)
 }
+
+func (c *ArrayConcatenator) Release() {
+	for _, arr := range c.arrs {
+		arr.Release()
+	}
+	c.arrs = c.arrs[:0]
+}

--- a/query/memory.go
+++ b/query/memory.go
@@ -51,3 +51,7 @@ func (a *LimitAllocator) Free(b []byte) {
 	a.allocated.Add(-int64(len(b)))
 	a.allocator.Free(b)
 }
+
+func (a *LimitAllocator) Allocated() int {
+	return int(a.allocated.Load())
+}

--- a/query/physicalplan/distinct.go
+++ b/query/physicalplan/distinct.go
@@ -82,6 +82,11 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 	}
 
 	resBuilders := make([]builder.ColumnBuilder, 0, len(distinctArrays))
+	defer func() {
+		for _, builder := range resBuilders {
+			builder.Release()
+		}
+	}()
 	for _, arr := range distinctArrays {
 		resBuilders = append(resBuilders, builder.NewBuilder(d.pool, arr.DataType()))
 	}
@@ -137,6 +142,11 @@ func (d *Distinction) Callback(ctx context.Context, r arrow.Record) error {
 	}
 
 	resArrays := make([]arrow.Array, 0, len(resBuilders))
+	defer func() {
+		for _, arr := range resArrays {
+			arr.Release()
+		}
+	}()
 	for _, builder := range resBuilders {
 		resArrays = append(resArrays, builder.NewArray())
 	}

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -267,12 +267,22 @@ func filter(pool memory.Allocator, filterExpr BooleanExpression, ar arrow.Record
 
 	totalRows := int64(0)
 	recordRanges := make([]arrow.Record, len(ranges))
+	defer func() {
+		for _, r := range recordRanges {
+			r.Release()
+		}
+	}()
 	for j, r := range ranges {
 		recordRanges[j] = ar.NewSlice(int64(r.Start), int64(r.End))
 		totalRows += int64(r.End - r.Start)
 	}
 
 	cols := make([]arrow.Array, ar.NumCols())
+	defer func() {
+		for _, col := range cols {
+			col.Release()
+		}
+	}()
 	numRanges := len(recordRanges)
 	for i := range cols {
 		colRanges := make([]arrow.Array, 0, numRanges)


### PR DESCRIPTION
This adds a couple unit tests, but also adds a allocator leak check to the logic tests.

It fixes a lot of the leaks that were uncovered when adding the unit tests.

NOTE: that the check is skipped for the ordered aggregate operator because I was unable to get that one to work.