### PR TITLE
pqarrow/builder: Add Value to OptInt64Builder

### DIFF
--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -394,6 +394,11 @@ func (b *OptInt64Builder) Add(i int, v int64) {
 	b.data[i] += v
 }
 
+// Value returns the ith value of the builder.
+func (b *OptInt64Builder) Value(i int) int64 {
+	return b.data[i]
+}
+
 func (b *OptInt64Builder) AppendParquetValues(values []parquet.Value) {
 	b.resizeData(b.length + len(values))
 	b.validityBitmap = resizeBitmap(b.validityBitmap, b.length+len(values))


### PR DESCRIPTION
Turns out I had this locally all the time and never made the PR. 
This is needed for https://github.com/parca-dev/parca/pull/3448. 