### PR TITLE
support map as dynamic type

### DIFF
--- a/table.go
+++ b/table.go
@@ -612,12 +612,12 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 					dynVals := reflect.ValueOf(cv)
 					for _, key := range dynVals.MapKeys() {
 						if key.Kind() != reflect.String {
-							return nil, fmt.Errorf("unsupported dynamic map key type for column")
+							return nil, fmt.Errorf("unsupported dynamic map key type for column for column '%s'", col.Name)
 						}
 						dynamicColumns[col.Name] = append(dynamicColumns[col.Name], ToSnakeCase(fmt.Sprintf("%v", key.String())))
 					}
 				default:
-					return nil, fmt.Errorf("unsupported dynamic type")
+					return nil, fmt.Errorf("unsupported dynamic type for column '%s'", col.Name)
 				}
 			}
 		}
@@ -692,11 +692,11 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 							}
 						}
 						if key.Kind() != reflect.String {
-							return nil, fmt.Errorf("unsupported dynamic map key type")
+							return nil, fmt.Errorf("unsupported dynamic map key type for column '%s'", col.Name)
 						}
 					}
 				default:
-					return nil, fmt.Errorf("unsupported dynamic type")
+					return nil, fmt.Errorf("unsupported dynamic type for column '%s'", col.Name)
 				}
 			default:
 				switch t := cv.(type) {

--- a/table_test.go
+++ b/table_test.go
@@ -1722,3 +1722,50 @@ func Test_Compact_Repeated(t *testing.T) {
 		return nil
 	})
 }
+
+func Test_Table_DynamicColumnMap(t *testing.T) {
+	c, err := New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c.Close()
+	})
+
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+
+	schema := &schemapb.Schema{
+		Name: "dynamic_col_map",
+		Columns: []*schemapb.Column{
+			{
+				Name: "name",
+				StorageLayout: &schemapb.StorageLayout{
+					Type: schemapb.StorageLayout_TYPE_STRING,
+				},
+			},
+			{
+				Name: "attributes",
+				StorageLayout: &schemapb.StorageLayout{
+					Type: schemapb.StorageLayout_TYPE_STRING,
+				},
+				Dynamic: true,
+			},
+		},
+	}
+
+	config := NewTableConfig(schema)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	record := struct {
+		Name       string
+		Attributes map[string]string
+	}{
+		Name: "albert",
+		Attributes: map[string]string{
+			"age": "9999",
+		},
+	}
+
+	_, err = table.Write(context.Background(), record)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
I would like to propose consider supporting `map[string]...` as a type that can be inserted into a dynamic column.

Currently using a map as the value for a dynamic column will fail:
```golang
func main() {
	columnstore, _ := frostdb.New()
	db, _ := columnstore.DB(context.Background(), "test")
	table, _ := db.Table("test", frostdb.NewTableConfig(&schemapb.Schema{
		Columns: []*schemapb.Column{
			{
				Name: "name",
				StorageLayout: &schemapb.StorageLayout{
					Type: schemapb.StorageLayout_TYPE_STRING,
				},
			},
			{
				Name: "attributes",
				StorageLayout: &schemapb.StorageLayout{
					Type: schemapb.StorageLayout_TYPE_STRING,
				},
				Dynamic: true,
			},
		},
	}))

	record := struct {
		Name       string
		Attributes map[string]string
	}{
		Name: "albert",
		Attributes: map[string]string{
			"age": "9999",
		},
	}

	_, err := table.Write(context.Background(), record) // <---- Panics
```

Here is the panic. I would like to also suggest improving the error message to include the column name.
```
2023-07-24 17:43:01.303927 I | err happen
panic: unsupported dynamic type

goroutine 1 [running]:
main.main()
        /home/albertlockett/Development/otel-logs-frostdb/example/main.go:48 +0x5fb
exit status 2
```
