### PR TITLE
fix panic on write when dynamic column not defined

### DIFF
--- a/table.go
+++ b/table.go
@@ -594,6 +594,9 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 		val := reflect.ValueOf(v)
 		for _, col := range schema.Columns() {
 			cv := findColumn(val, col.Name, v)
+			if cv == nil {
+				continue
+			}
 			switch col.Dynamic {
 			case true:
 				switch reflect.TypeOf(cv).Kind() {
@@ -635,6 +638,9 @@ func ValuesToBuffer(schema *dynparquet.Schema, vals ...any) (*dynparquet.Buffer,
 		colIdx := 0
 		for _, col := range schema.Columns() {
 			cv := findColumn(val, col.Name, v)
+			if cv == nil {
+				continue
+			}
 			switch col.Dynamic {
 			case true:
 				switch reflect.TypeOf(cv).Kind() {

--- a/table_test.go
+++ b/table_test.go
@@ -1769,3 +1769,47 @@ func Test_Table_DynamicColumnMap(t *testing.T) {
 	_, err = table.Write(context.Background(), record)
 	require.NoError(t, err)
 }
+
+func Test_Table_DynamicColumnNotDefined(t *testing.T) {
+	c, err := New()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		c.Close()
+	})
+
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+
+	schema := &schemapb.Schema{
+		Name: "dynamic_col_not_defined",
+		Columns: []*schemapb.Column{
+			{
+				Name: "name",
+				StorageLayout: &schemapb.StorageLayout{
+					Type: schemapb.StorageLayout_TYPE_STRING,
+				},
+			},
+			{
+				Name: "attributes",
+				StorageLayout: &schemapb.StorageLayout{
+					Type: schemapb.StorageLayout_TYPE_STRING,
+				},
+				Dynamic: true,
+			},
+		},
+	}
+
+	config := NewTableConfig(schema)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	// write a record where the dynamic column is not defined
+	record := struct {
+		Name string
+	}{
+		Name: "albert",
+	}
+
+	_, err = table.Write(context.Background(), record)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
When writing to some table, if the schema has a dynamic column and the value being written does not define this column, then the write will panic

```golang
table, _ := db.Table("test", frostdb.NewTableConfig(&schemapb.Schema{
Columns: []*schemapb.Column{
	{
		Name: "name",
		StorageLayout: &schemapb.StorageLayout{
			Type: schemapb.StorageLayout_TYPE_STRING,
		},
	},
	{
		Name: "attributes",
		StorageLayout: &schemapb.StorageLayout{
			Type: schemapb.StorageLayout_TYPE_STRING,
		},
		Dynamic: true,
	},
},
}))

record := struct {
	Name string
	// 'attributes' is not a member of the struct
}{
	Name: "albert",
}

_, err := table.Write(context.Background(), record) // <---- panics
```

This PR fixes the panic