### PR TITLE
*: remove eventual check from TestDBRecover

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -120,6 +120,9 @@ func (db *DB) asyncSnapshot(ctx context.Context, onSuccess func()) {
 	}
 	if !db.snapshotInProgress.CompareAndSwap(false, true) {
 		// Snapshot already in progress.
+		level.Debug(db.logger).Log(
+			"msg", "cannot start snapshot; snapshot already in progress",
+		)
 		return
 	}
 


### PR DESCRIPTION
We wait above the removed check for the snapshot to be written, so the check is unnecessary.