### PR TITLE
*: reset the WAL to zero in resetToTxn

### DIFF
--- a/table.go
+++ b/table.go
@@ -178,6 +178,7 @@ type WAL interface {
 	// the last valid index.
 	Replay(tx uint64, handler wal.ReplayHandlerFunc) error
 	Truncate(tx uint64) error
+	Reset(nextTx uint64) error
 	FirstIndex() (uint64, error)
 	LastIndex() (uint64, error)
 }


### PR DESCRIPTION
Previously, we would use the given txn to truncate the WAL. However, this txn could be less than the last index, causing no records to be logged until the high watermark caught up with the last index.

This commit performs an unconditional truncation using the max uint64, resulting in a full reset of the WAL.