### PR TITLE
Store snapshot

### DIFF
--- a/db.go
+++ b/db.go
@@ -477,9 +477,7 @@ func (s *ColumnStore) DB(ctx context.Context, name string, opts ...DBOption) (*D
 			}, func() float64 {
 				return float64(db.highWatermark.Load().TxnID)
 			}),
-		}
-		if db.columnStore.snapshotTriggerSize != 0 {
-			db.metrics.snapshotMetrics = newSnapshotMetrics(reg)
+			snapshotMetrics: newSnapshotMetrics(reg),
 		}
 		return nil
 	}(); dbSetupErr != nil {

--- a/snapshot.go
+++ b/snapshot.go
@@ -706,3 +706,10 @@ func (db *DB) snapshotsDo(ctx context.Context, dir string, callback func(tx uint
 	}
 	return nil
 }
+
+func StoreSnapshot(ctx context.Context, tx uint64, txnMetadata []byte, db *DB, snapshot io.Reader) error {
+	return db.snapshotAtTX(ctx, tx, txnMetadata, func(ctx context.Context, w io.Writer) error {
+		_, err := io.Copy(w, snapshot)
+		return err
+	})
+}

--- a/table.go
+++ b/table.go
@@ -481,7 +481,7 @@ func (t *Table) writeBlock(block *TableBlock, skipPersist, snapshotDB bool) {
 			// TODO(asubiotto): Eventually we should register a cancel function
 			// that is called with a grace period on db.Close.
 			ctx := context.Background()
-			if err := t.db.snapshotAtTX(ctx, tx, metadata); err != nil {
+			if err := t.db.snapshotAtTX(ctx, tx, metadata, t.db.snapshotWriter(tx, metadata)); err != nil {
 				level.Error(t.logger).Log(
 					"msg", "failed to write snapshot on block rotation",
 					"err", err,


### PR DESCRIPTION
Small refactor inject a writer dependency into `snapshotAtATX` which allows for a new function `StoreSnapshot` that can write an external snapshot into the snapshot directory. 