### PR TITLE
pqarrow/builders: Fix out of range check

### DIFF
--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -488,14 +488,14 @@ func (b *OptBooleanBuilder) Append(data []byte, valid int) {
 }
 
 func (b *OptBooleanBuilder) Set(i int, v bool) {
-	if i < 0 || i >= len(b.data) {
+	if i < 0 || i >= b.length {
 		panic("arrow/array: index out of range")
 	}
 	bitutil.SetBitTo(b.data, i, v)
 }
 
 func (b *OptBooleanBuilder) Value(i int) bool {
-	if i < 0 || i >= len(b.data) {
+	if i < 0 || i >= b.length {
 		panic("arrow/array: index out of range")
 	}
 	return bitutil.BitIsSet(b.data, i)


### PR DESCRIPTION
Data is just a byte array, but boolean values are a bitmap, so 8 values are encoded in 1 byte, therefore we need to perform bounds checks with the length value not the data size.