### PR TITLE
Cleanup db

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/parts"
-	"github.com/polarsignals/frostdb/pqarrow"
-	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 // insertSamples is a helper function to insert a deterministic sample with a
@@ -53,16 +51,7 @@ func insertSampleRecords(ctx context.Context, t *testing.T, table *Table, timest
 		})
 	}
 
-	ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
-		"labels": {"label1"},
-	})
-	require.NoError(t, err)
-	defer table.Schema().PutPooledParquetSchema(ps)
-
-	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
-	require.NoError(t, err)
-
-	ar, err := samples.ToRecord(sc)
+	ar, err := samples.ToRecord()
 	require.NoError(t, err)
 
 	tx, err := table.InsertRecord(ctx, ar)

--- a/db.go
+++ b/db.go
@@ -797,7 +797,7 @@ func (db *DB) Close() error {
 	}
 
 	if shouldPersist {
-		if err := db.DropStorage(); err != nil {
+		if err := db.DropStorage(false); err != nil {
 			return err
 		}
 		level.Info(db.logger).Log("msg", "cleaned up wal & snapshots")
@@ -1083,7 +1083,10 @@ func validateName(name string) bool {
 }
 
 // DropStorage removes snapshots and WAL data from the storage directory.
-func (db *DB) DropStorage() error {
+func (db *DB) DropStorage(newwal bool) error {
+	if newwal {
+		defer db.wal.Reset(0) // TODO: can we reset to 0, or do we need to reset to the last txn?
+	}
 	trashDir := db.trashDir()
 
 	if moveErr := func() error {

--- a/db_test.go
+++ b/db_test.go
@@ -1792,7 +1792,9 @@ func Test_DB_DropStorage(t *testing.T) {
 		WithStoragePath(dir),
 		WithActiveMemorySize(1024*1024),
 	)
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 	require.NoError(t, err)
 	db, err := c.DB(context.Background(), "test")
 	require.NoError(t, err)
@@ -1832,12 +1834,14 @@ func Test_DB_DropStorage(t *testing.T) {
 		WithStoragePath(dir),
 		WithActiveMemorySize(1024*1024),
 	)
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 	require.NoError(t, err)
 	level.Debug(logger).Log("msg", "opening new db")
 	db, err = c.DB(context.Background(), "test")
 	require.NoError(t, err)
-	table, err = db.Table("test", config)
+	_, err = db.Table("test", config)
 	require.NoError(t, err)
 	countRows(0)
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1823,7 +1823,7 @@ func Test_DB_DropStorage(t *testing.T) {
 	countRows(300)
 
 	level.Debug(logger).Log("msg", "dropping storage")
-	require.NoError(t, db.DropStorage(true))
+	require.NoError(t, db.Close(WithClearStorage()))
 
 	// Open a new store against the dropped storage, and expect empty db
 	c, err = New(

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -54,7 +54,48 @@ func (s Samples) ToBuffer(schema *Schema) (*Buffer, error) {
 	return pb, nil
 }
 
-func (s Samples) ToRecord(schema *arrow.Schema) (arrow.Record, error) {
+func (s Samples) ToRecord() (arrow.Record, error) {
+	fields := []arrow.Field{
+		{
+			Name: "example_type",
+			Type: &arrow.DictionaryType{
+				IndexType: &arrow.Int32Type{},
+				ValueType: &arrow.BinaryType{},
+			},
+		},
+	}
+	seen := map[string]struct{}{}
+	for _, smpl := range s {
+		for _, lbl := range smpl.Labels {
+			if _, ok := seen[lbl.Name]; ok {
+				continue
+			}
+			seen[lbl.Name] = struct{}{}
+			fields = append(fields,
+				arrow.Field{
+					Name:     "labels." + lbl.Name,
+					Nullable: true,
+					Type: &arrow.DictionaryType{
+						IndexType: &arrow.Int32Type{},
+						ValueType: &arrow.BinaryType{},
+					},
+				},
+			)
+		}
+	}
+	fields = append(fields, arrow.Field{
+		Name: "stacktrace",
+		Type: &arrow.DictionaryType{
+			IndexType: &arrow.Int32Type{},
+			ValueType: &arrow.BinaryType{},
+		},
+	},
+	)
+	fields = append(fields, arrow.Field{Name: "timestamp", Type: arrow.PrimitiveTypes.Int64})
+	fields = append(fields, arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})
+	schema := arrow.NewSchema(fields, nil)
+	fmt.Println(schema)
+
 	bld := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
 	defer bld.Release()
 

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -94,7 +94,6 @@ func (s Samples) ToRecord() (arrow.Record, error) {
 	fields = append(fields, arrow.Field{Name: "timestamp", Type: arrow.PrimitiveTypes.Int64})
 	fields = append(fields, arrow.Field{Name: "value", Type: arrow.PrimitiveTypes.Int64})
 	schema := arrow.NewSchema(fields, nil)
-	fmt.Println(schema)
 
 	bld := array.NewRecordBuilder(memory.NewGoAllocator(), schema)
 	defer bld.Release()

--- a/table_test.go
+++ b/table_test.go
@@ -1172,19 +1172,10 @@ func Test_L0Query(t *testing.T) {
 		Value:     3,
 	}}
 
-	ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
-		"labels": {"label1", "label2", "label3", "label4"},
-	})
+	r, err := samples.ToRecord()
 	require.NoError(t, err)
-	defer table.Schema().PutPooledParquetSchema(ps)
 
 	ctx := context.Background()
-	sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
-	require.NoError(t, err)
-
-	r, err := samples.ToRecord(sc)
-	require.NoError(t, err)
-
 	_, err = table.InsertRecord(ctx, r)
 	require.NoError(t, err)
 
@@ -1427,19 +1418,10 @@ func Test_Table_Size(t *testing.T) {
 		samples := dynparquet.NewTestSamples()
 		switch isArrow {
 		case true:
-			ps, err := table.Schema().GetDynamicParquetSchema(map[string][]string{
-				"labels": {"node", "namespace", "container"},
-			})
+			rec, err := samples.ToRecord()
 			require.NoError(t, err)
-			defer table.Schema().PutPooledParquetSchema(ps)
 
 			ctx := context.Background()
-			sc, err := pqarrow.ParquetSchemaToArrowSchema(ctx, ps.Schema, logicalplan.IterOptions{})
-			require.NoError(t, err)
-
-			rec, err := samples.ToRecord(sc)
-			require.NoError(t, err)
-
 			_, err = table.InsertRecord(ctx, rec)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Made clearing the storage a little more natural, and with fewer footguns. Now it uses `db.Close` to perform clear storage, which means that it's no longer valid to use this DB afterwards.

This is preferable to previously with `DropStorage` because the wal isn't meant to be live reloaded and that created a lot of footguns. So instead to acheive the same results one would clear the db storage, and reopen the database again. 
```
db.Close(WithClearStorage())
db = c.DB(....)
```