### PR TITLE
Added first aggregation

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -248,7 +248,7 @@ func TestAggregationProjection(t *testing.T) {
 	require.True(t, record.Schema().HasField("max(value)"))
 }
 
-func TestAggregationLimit(t *testing.T) {
+func TestAggregationTakeLimit(t *testing.T) {
 	config := NewTableConfig(dynparquet.SampleDefinition())
 	logger := newTestLogger(t)
 	c, err := New(WithLogger(logger))
@@ -333,8 +333,7 @@ func TestAggregationLimit(t *testing.T) {
 	record := records[0]
 
 	require.True(t, record.Schema().HasField("timestamp"))
-	// TODO --
-	// require.True(t, record.Schema().HasField("limit(value, 2)"))
+	require.True(t, record.Schema().HasField("take(value, 2)"))
 
 	require.Equal(t, int64(2), record.NumCols())
 	require.Equal(t, int64(3), record.NumRows())

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -2,7 +2,6 @@ package frostdb
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -323,7 +322,6 @@ func TestAggregationTakeLimit(t *testing.T) {
 		Execute(context.Background(), func(ctx context.Context, ar arrow.Record) error {
 			records = append(records, ar)
 			ar.Retain()
-			fmt.Printf("%s", ar)
 			return nil
 		})
 

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -314,7 +314,7 @@ func TestAggregationTakeLimit(t *testing.T) {
 	err = engine.ScanTable("test").
 		Aggregate(
 			[]logicalplan.Expr{
-				logicalplan.Limit(logicalplan.Col("value"), 2),
+				logicalplan.Take(logicalplan.Col("value"), 2),
 			},
 			[]logicalplan.Expr{
 				logicalplan.Col("timestamp"),

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -362,7 +362,8 @@ func TestAggregationLimit(t *testing.T) {
 		case 1:
 			require.Equal(t, values.(*array.Int64).Len(), 2)
 			require.Contains(t, valuesRaw, int64(1))
-			require.Contains(t, valuesRaw, int64(2))
+			// the 2nd value in this could be 1 or 2 so we don't check it
+			// to avoid the test flaking ..
 		case 2:
 			require.Equal(t, values.(*array.Int64).Len(), 2)
 			require.Contains(t, valuesRaw, int64(1))

--- a/logictest/runner.go
+++ b/logictest/runner.go
@@ -428,6 +428,10 @@ func arrayToStringVals(a arrow.Array) ([]string, error) {
 		default:
 			return nil, fmt.Errorf("unhandled dictionary type: %T", dict)
 		}
+	case *array.List:
+		for i := range result {
+			result[i] = col.ValueStr(i)
+		}
 	default:
 		return nil, fmt.Errorf("unhandled type %T", col)
 	}

--- a/logictest/testdata/exec/aggregate/aggregate
+++ b/logictest/testdata/exec/aggregate/aggregate
@@ -54,6 +54,11 @@ select sum(value), count(value), min(value), max(value) group by labels.label2
 ----
 value2  21      6       1       6
 
+exec
+select take(value, 1) where timestamp = 3 group by labels.label2
+----
+value2  [3]
+
 exec unordered
 select sum(value) as value_sum where timestamp >= 1 group by labels.label1
 ----

--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -114,6 +114,21 @@ func AppendValue(cb ColumnBuilder, arr arrow.Array, i int) error {
 					}
 				}
 			}
+		case *array.Int64:
+			b.Append(true)
+			for j := 0; j < v.Len(); j++ {
+				switch bldr := vb.(type) {
+				case *array.Int64Builder:
+					bldr.Append(v.Value(j))
+				case *OptInt64Builder:
+					bldr.Append(v.Value(j))
+				default:
+					return fmt.Errorf("uknown value builder type %T", bldr)
+				}
+			}
+
+		default:
+			return fmt.Errorf("unsupported type for arrow list append %T", v)
 		}
 	default:
 		return fmt.Errorf("unsupported type for arrow append %T", b)

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -2,6 +2,7 @@ package logicalplan
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -497,7 +498,11 @@ func (f *AggregationFunction) Computed() bool {
 }
 
 func (f *AggregationFunction) Name() string {
-	return f.Func.String() + "(" + f.Expr.Name() + ")"
+	args := []string{f.Expr.Name()}
+	for _, arg := range f.Args {
+		args = append(args, fmt.Sprintf("%v", arg))
+	}
+	return f.Func.String() + "(" + strings.Join(args, ", ") + ")"
 }
 
 func (f *AggregationFunction) ColumnsUsedExprs() []Expr {
@@ -521,7 +526,7 @@ const (
 	AggFuncMax
 	AggFuncCount
 	AggFuncAvg
-	AggFuncLimit
+	AggFuncTake
 )
 
 func (f AggFunc) String() string {
@@ -536,8 +541,8 @@ func (f AggFunc) String() string {
 		return "count"
 	case AggFuncAvg:
 		return "avg"
-	case AggFuncLimit:
-		return "limit"
+	case AggFuncTake:
+		return "take"
 	default:
 		panic("unknown aggregation function")
 	}
@@ -580,7 +585,7 @@ func Avg(expr Expr) *AggregationFunction {
 
 func Limit(expr Expr, limit uint64) *AggregationFunction {
 	return &AggregationFunction{
-		Func: AggFuncLimit,
+		Func: AggFuncTake,
 		Expr: expr,
 		Args: AggregationArguments{AggArgLimit: limit},
 	}

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -485,6 +485,7 @@ const (
 	AggFuncMax
 	AggFuncCount
 	AggFuncAvg
+	AggFuncFirst
 )
 
 func (f AggFunc) String() string {
@@ -499,6 +500,8 @@ func (f AggFunc) String() string {
 		return "count"
 	case AggFuncAvg:
 		return "avg"
+	case AggFuncFirst:
+		return "first"
 	default:
 		panic("unknown aggregation function")
 	}
@@ -535,6 +538,13 @@ func Count(expr Expr) *AggregationFunction {
 func Avg(expr Expr) *AggregationFunction {
 	return &AggregationFunction{
 		Func: AggFuncAvg,
+		Expr: expr,
+	}
+}
+
+func First(expr Expr) *AggregationFunction {
+	return &AggregationFunction{
+		Func: AggFuncFirst,
 		Expr: expr,
 	}
 }

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -583,7 +583,7 @@ func Avg(expr Expr) *AggregationFunction {
 	}
 }
 
-func Limit(expr Expr, limit uint64) *AggregationFunction {
+func Take(expr Expr, limit uint64) *AggregationFunction {
 	return &AggregationFunction{
 		Func: AggFuncTake,
 		Expr: expr,

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -429,6 +429,7 @@ func (e *LiteralExpr) MatchColumn(columnName string) bool {
 type AggregationFunction struct {
 	Func AggFunc
 	Expr Expr
+	Args map[string]interface{}
 }
 
 func (f *AggregationFunction) Clone() Expr {
@@ -485,7 +486,7 @@ const (
 	AggFuncMax
 	AggFuncCount
 	AggFuncAvg
-	AggFuncFirst
+	AggFuncLimit
 )
 
 func (f AggFunc) String() string {
@@ -500,8 +501,8 @@ func (f AggFunc) String() string {
 		return "count"
 	case AggFuncAvg:
 		return "avg"
-	case AggFuncFirst:
-		return "first"
+	case AggFuncLimit:
+		return "limit"
 	default:
 		panic("unknown aggregation function")
 	}
@@ -542,10 +543,13 @@ func Avg(expr Expr) *AggregationFunction {
 	}
 }
 
-func First(expr Expr) *AggregationFunction {
+func Limit(expr Expr, limit uint64) *AggregationFunction {
 	return &AggregationFunction{
-		Func: AggFuncFirst,
+		Func: AggFuncLimit,
 		Expr: expr,
+		Args: map[string]interface{}{
+			"limit": limit,
+		},
 	}
 }
 

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -863,6 +863,7 @@ func (a *LimitAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) 
 	res := array.NewListBuilder(pool, arrs[0].DataType())
 	defer res.Release()
 	vb := res.ValueBuilder()
+	res.Append(true)
 	for _, arr := range arrs {
 		for i := 0; i < arr.Len() && uint64(i) < a.Limit; i++ {
 			err := vb.AppendValueFromString(arr.ValueStr(i))

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -860,17 +860,20 @@ type LimitAggregation struct {
 }
 
 func (a *LimitAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error) {
-	res := array.NewBuilder(pool, arrs[0].DataType())
+	res := array.NewListBuilder(pool, arrs[0].DataType())
 	defer res.Release()
+	vb := res.ValueBuilder()
 	for _, arr := range arrs {
 		for i := 0; i < arr.Len() && uint64(i) < a.Limit; i++ {
-			err := res.AppendValueFromString(arr.ValueStr(i))
+			err := vb.AppendValueFromString(arr.ValueStr(i))
 			if err != nil {
 				return nil, err
 			}
 		}
+		res.Append(true)
 	}
-	return res.NewArray(), nil
+	r := res.NewArray()
+	return r, nil
 }
 
 // runAggregation is a helper to run the given aggregation function given

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -851,7 +851,10 @@ func (a *FirstAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) 
 			res.AppendNull()
 			continue
 		}
-		res.AppendValueFromString(arr.ValueStr(0))
+		err := res.AppendValueFromString(arr.ValueStr(0))
+		if err != nil {
+			return nil, err
+		}
 	}
 	return res.NewArray(), nil
 }

--- a/query/physicalplan/ordered_aggregate.go
+++ b/query/physicalplan/ordered_aggregate.go
@@ -376,7 +376,7 @@ func (a *OrderedAggregate) Callback(_ context.Context, r arrow.Record) error {
 		return nil
 	}
 
-	results, err := runAggregation(a.finalStage, a.aggregationFunction, a.pool, arraysToAggregate)
+	results, err := runAggregation(a.finalStage, a.aggregationFunction, nil, a.pool, arraysToAggregate)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 		}
 
 		results, err := runAggregation(
-			a.finalStage, a.aggregationFunction, a.pool, []arrow.Array{a.arrayToAggCarry.NewArray()},
+			a.finalStage, a.aggregationFunction, nil, a.pool, []arrow.Array{a.arrayToAggCarry.NewArray()},
 		)
 		if err != nil {
 			return err
@@ -525,7 +525,7 @@ func (a *OrderedAggregate) Finish(ctx context.Context) error {
 			start = end
 		}
 
-		result, err := runAggregation(true, a.aggregationFunction, a.pool, toAggregate)
+		result, err := runAggregation(true, a.aggregationFunction, nil, a.pool, toAggregate)
 		if err != nil {
 			return err
 		}

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -183,6 +183,18 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 		// Deliberate pass-through nodes.
 	case *ast.FuncCallExpr:
 		switch expr.FnName.String() {
+		case "take":
+			left, right := pop(v.exprStack)
+			var exprStack []logicalplan.Expr
+			// exprStack = append(exprStack, right...)
+			switch l := left.(type) {
+			case *logicalplan.LiteralExpr:
+				val := l.Value.(*scalar.Int64)
+				limit := uint64(val.Value)
+				exprStack = append(exprStack, logicalplan.Take(right[0], limit))
+				v.exprStack = exprStack
+			}
+
 		case ast.Second:
 			// This is pretty hacky and only fine because it's in the test only.
 			left, right := pop(v.exprStack)

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -186,7 +186,6 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 		case "take":
 			left, right := pop(v.exprStack)
 			var exprStack []logicalplan.Expr
-			// exprStack = append(exprStack, right...)
 			switch l := left.(type) {
 			case *logicalplan.LiteralExpr:
 				val := l.Value.(*scalar.Int64)


### PR DESCRIPTION
Adds a `First` aggregation.. 

```golang
_ = engine.ScanTable("test").
Aggregate(
	[]logicalplan.Expr{
		logicalplan.First(logicalplan.Col("timestamp")),
	},
	[]logicalplan.Expr{
		logicalplan.Duration(time.Second),
	},
).
Execute(context.Background(), func(_ context.Context, r arrow.Record) error {
	r.Retain()
	results = append(results, r)
	return nil
})
```

this can be used to get the First value in some interval, which I think is what we might want to do [here](https://github.com/parca-dev/parca/issues/2598) (I'm not sure about this, so opening this as a draft while clarifying behaviour)