### PR TITLE
*: listen to context cancellation when collecting records

### DIFF
--- a/db.go
+++ b/db.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
@@ -1023,16 +1024,12 @@ func (db *DB) TableProvider() *DBTableProvider {
 	return NewDBTableProvider(db)
 }
 
-// IterateTables iterates over all the tables in the database in no particular
-// order. Iteration is cut short if the given iterator returns false.
-func (db *DB) IterateTables(i func(name string) bool) {
+// TableNames returns the names of all the db's tables.
+func (db *DB) TableNames() []string {
 	db.mtx.RLock()
-	defer db.mtx.RUnlock()
-	for name := range db.tables {
-		if !i(name) {
-			return
-		}
-	}
+	tables := maps.Keys(db.tables)
+	db.mtx.RUnlock()
+	return tables
 }
 
 type DBTableProvider struct {

--- a/granule.go
+++ b/granule.go
@@ -167,7 +167,10 @@ func (g *Granule) Collect(ctx context.Context, tx uint64, filter TrueNegativeFil
 		}
 	} else {
 		for _, r := range records {
-			collector <- r
+			select {
+			case <-ctx.Done():
+			case collector <- r:
+			}
 		}
 	}
 }


### PR DESCRIPTION
There are cases where the context gets canceled and granule collection would not react.