### PR TITLE
Revert "query: support greater than binary expressions with uint64 scalar"

### DIFF
--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -21,8 +21,6 @@ func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 		return parquet.ValueOf(string(s.Data())), nil
 	case *scalar.Int64:
 		return parquet.ValueOf(s.Value), nil
-	case *scalar.Uint64:
-		return parquet.ValueOf(s.Value), nil
 	case *scalar.FixedSizeBinary:
 		width := s.Type.(*arrow.FixedSizeBinaryType).ByteWidth
 		v := [16]byte{}

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -148,13 +148,6 @@ func BinaryScalarOperation(left arrow.Array, right scalar.Scalar, operator logic
 		default:
 			panic("something terrible has happened, this should have errored previously during validation")
 		}
-	case arrow.PrimitiveTypes.Uint64:
-		switch operator {
-		case logicalplan.OpGt:
-			return Uint64ArrayScalarGreaterThan(left.(*array.Uint64), right.(*scalar.Uint64))
-		default:
-			panic("something terrible has happened, this should have errored previously during validation")
-		}
 	}
 
 	switch arr := left.(type) {
@@ -428,21 +421,6 @@ func Int64ArrayScalarGreaterThanOrEqual(left *array.Int64, right *scalar.Int64) 
 			continue
 		}
 		if left.Value(i) >= right.Value {
-			res.Add(uint32(i))
-		}
-	}
-
-	return res, nil
-}
-
-func Uint64ArrayScalarGreaterThan(left *array.Uint64, right *scalar.Uint64) (*Bitmap, error) {
-	res := NewBitmap()
-
-	for i := 0; i < left.Len(); i++ {
-		if left.IsNull(i) {
-			continue
-		}
-		if left.Value(i) > right.Value {
 			res.Add(uint32(i))
 		}
 	}


### PR DESCRIPTION
This reverts commit 4b2833a106e6c7f51223539cfaead55f292307e1.

The reason is that parquet storage does not support uint64, so this addition is meaningless and in fact confuses the user given they will use a uint64 scalar which might error out since it might be applied against an int64 row group.