### PR TITLE
Have the `dropPendingBlock` function wait for writes

### DIFF
--- a/table.go
+++ b/table.go
@@ -389,8 +389,9 @@ func (t *Table) dropPendingBlock(block *TableBlock) {
 	defer t.mtx.Unlock()
 	delete(t.pendingBlocks, block)
 
-	// Wait for outstanding readers to finish with the block before releasing underlying resources.
+	// Wait for outstanding readers/writers to finish with the block before releasing underlying resources.
 	block.pendingReadersWg.Wait()
+	block.pendingWritersWg.Wait()
 
 	block.Index().Ascend(func(i btree.Item) bool {
 		g := i.(*Granule)


### PR DESCRIPTION
This prevents snapshots from racing with dropping a pending block hopefully this addresses #514 

[edit] Updates `PartsForTx` function to not return records that may have been released