### PR TITLE
Query engine in memory only

### DIFF
--- a/db.go
+++ b/db.go
@@ -1144,7 +1144,9 @@ func (db *DB) dropStorage() error {
 	trashDir := db.trashDir()
 
 	if moveErr := func() error {
-		_ = os.Mkdir(trashDir, os.FileMode(0o755))
+		if err := os.MkdirAll(trashDir, os.FileMode(0o755)); err != nil {
+			return fmt.Errorf("making trash dir: %w", err)
+		}
 		// Create a temporary directory in the trash dir to avoid clashing
 		// with other wal/snapshot dirs that might not have been removed
 		// previously.

--- a/db_test.go
+++ b/db_test.go
@@ -1888,8 +1888,6 @@ func Test_DB_EngineInMemory(t *testing.T) {
 
 	db, err = c.DB(context.Background(), "test")
 	require.NoError(t, err)
-	table, err = db.Table("test", config)
-	require.NoError(t, err)
 
 	pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer pool.AssertSize(t, 0)

--- a/query/logicalplan/logicalplan.go
+++ b/query/logicalplan/logicalplan.go
@@ -35,9 +35,16 @@ type IterOptions struct {
 	Projection         []Expr
 	Filter             Expr
 	DistinctColumns    []Expr
+	InMemoryOnly       bool
 }
 
 type Option func(opts *IterOptions)
+
+func WithInMemoryOnly() Option {
+	return func(opts *IterOptions) {
+		opts.InMemoryOnly = true
+	}
+}
 
 func WithPhysicalProjection(e ...Expr) Option {
 	return func(opts *IterOptions) {
@@ -177,6 +184,9 @@ type TableScan struct {
 
 	// Projection is the list of columns that are to be projected.
 	Projection []Expr
+
+	// SkipSources indicates to skip scanning the tables sources.
+	SkipSources bool
 }
 
 func (scan *TableScan) String() string {
@@ -204,6 +214,9 @@ type SchemaScan struct {
 
 	// Projection is the list of columns that are to be projected.
 	Projection []Expr
+
+	// SkipSources indicates to skip scanning the tables sources.
+	SkipSources bool
 }
 
 func (s *SchemaScan) String() string {


### PR DESCRIPTION
Adds an option to the query engine to perform queries only against the in memory portion of the db.