### PR TITLE
Fix physical projections

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1341,7 +1341,7 @@ func Test_DB_TableWrite_ArrowRecord(t *testing.T) {
 		"timestamp filter": {
 			filter: logicalplan.Col("timestamp").GtEq(logicalplan.Literal(12)),
 			rows:   1,
-			cols:   7,
+			cols:   1,
 		},
 		"distinct": {
 			distinct: logicalplan.DynCol("labels"),

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -1201,6 +1201,7 @@ func Project(r arrow.Record, projections []logicalplan.Expr) arrow.Record {
 			if projection.MatchColumn(r.Schema().Field(i).Name) {
 				cols = append(cols, r.Column(i))
 				fields = append(fields, r.Schema().Field(i))
+				break
 			}
 		}
 	}

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -1186,3 +1186,24 @@ func ColToWriter(col int, writers []MultiColumnWriter) writer.ValueWriter {
 
 	return nil
 }
+
+// Project will project the record according to the given projections.
+func Project(r arrow.Record, projections []logicalplan.Expr) arrow.Record {
+	if len(projections) == 0 {
+		r.Retain() // NOTE: we're creating another reference to this record, so retain it
+		return r
+	}
+
+	cols := make([]arrow.Array, 0, r.Schema().NumFields())
+	fields := make([]arrow.Field, 0, r.Schema().NumFields())
+	for i := 0; i < r.Schema().NumFields(); i++ {
+		for _, projection := range projections {
+			if projection.MatchColumn(r.Schema().Field(i).Name) {
+				cols = append(cols, r.Column(i))
+				fields = append(fields, r.Schema().Field(i))
+			}
+		}
+	}
+
+	return array.NewRecord(arrow.NewSchema(fields, nil), cols, r.NumRows())
+}

--- a/table.go
+++ b/table.go
@@ -946,7 +946,9 @@ func (t *Table) Iterator(
 					switch t := rg.(type) {
 					case arrow.Record:
 						defer t.Release()
-						err := callback(ctx, t)
+						r := pqarrow.Project(t, iterOpts.PhysicalProjection)
+						defer r.Release()
+						err := callback(ctx, r)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
Previously we weren't performing physical projections on returned arrow records which caused discrepancy with the data that was returned for a given query whether it was in arrow or parquet format. This fixes that discrepancy by running the physical projections on arrow records to drop columns that are not included in the query.