### PR TITLE
table: require at least one sorting column

### DIFF
--- a/table.go
+++ b/table.go
@@ -261,6 +261,9 @@ func newTable(
 	if err != nil {
 		return nil, err
 	}
+	if len(s.SortingColumns()) == 0 {
+		return nil, errors.New("table schema must have at least one sorting column")
+	}
 
 	t := &Table{
 		db:     db,


### PR DESCRIPTION
Since sorting columns define a primary key, the absence of sorting columns can lead to weird edge cases.