### PR TITLE
Project all

### DIFF
--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -690,3 +690,27 @@ func (a *AverageExpr) Accept(visitor Visitor) bool {
 
 	return visitor.PostVisit(a)
 }
+
+type AllExpr struct{}
+
+func All() *AllExpr {
+	return &AllExpr{}
+}
+
+func (a *AllExpr) DataType(*parquet.Schema) (arrow.DataType, error) { return nil, nil }
+func (a *AllExpr) Accept(visitor Visitor) bool {
+	continu := visitor.PreVisit(a)
+	if !continu {
+		return false
+	}
+
+	return visitor.PostVisit(a)
+}
+func (a *AllExpr) Name() string { return "all" }
+func (a *AllExpr) ColumnsUsedExprs() []Expr {
+	return []Expr{&AllExpr{}}
+}
+func (a *AllExpr) MatchColumn(columnName string) bool { return true }
+func (a *AllExpr) MatchPath(path string) bool         { return true }
+func (a *AllExpr) Computed() bool                     { return false }
+func (a *AllExpr) Clone() Expr                        { return &AllExpr{} }

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -351,6 +351,11 @@ func Build(
 			prev = append(prev[:0], plans...)
 			oInfo.nodeMaintainsOrdering()
 		case plan.Projection != nil:
+			for _, e := range plan.Projection.Exprs { // Don't build the projection if it's a wildcard, the projection pushdown optimization will handle it.
+				if e.Name() == "all" {
+					return true
+				}
+			}
 			// For each previous physical plan create one Projection
 			for i := range prev {
 				p, err := Project(pool, tracer, plan.Projection.Exprs)

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -168,6 +168,8 @@ func (p dynamicProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arr
 
 func projectionFromExpr(expr logicalplan.Expr) (columnProjection, error) {
 	switch e := expr.(type) {
+	case *logicalplan.AllExpr:
+		return allProjection{}, nil
 	case *logicalplan.Column:
 		return plainProjection{
 			expr: e,
@@ -355,4 +357,12 @@ func avgInt64arrays(pool memory.Allocator, sums, counts arrow.Array) arrow.Array
 	}
 
 	return res.NewArray()
+}
+
+type allProjection struct{}
+
+func (a allProjection) Name() string { return "all" }
+
+func (a allProjection) Project(mem memory.Allocator, ar arrow.Record) ([]arrow.Field, []arrow.Array, error) {
+	return ar.Schema().Fields(), ar.Columns(), nil
 }


### PR DESCRIPTION
Since fixing the projection pushdowns to also apply to in-memory arrow records we no longer have a way to wildcard select all columns.

This adds a new logicalplan Expr that allows projection of all columns.