### PR TITLE
db: start compactor pool before replaying WAL

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -29,9 +29,6 @@ type CompactionConfig struct {
 	concurrency          int
 	interval             time.Duration
 	l1ToGranuleSizeRatio float64
-
-	// compactAfterRecovery specifies to run compaction on all tables after recovery.
-	compactAfterRecovery bool
 }
 
 // NewCompactionConfig creates a new compaction config with the given options.
@@ -52,13 +49,6 @@ func NewCompactionConfig(options ...CompactionOption) *CompactionConfig {
 		o(c)
 	}
 	return c
-}
-
-// WithCompactionAfterRecovery specifies to run compaction on all tables after recovery.
-func WithCompactionAfterRecovery() CompactionOption {
-	return func(c *CompactionConfig) {
-		c.compactAfterRecovery = true
-	}
 }
 
 // WithConcurrency specifies the number of concurrent goroutines compacting data


### PR DESCRIPTION
Previously, the compactor pool was not running during WAL replay. This could cause memory blow-ups on the first compactions after a WAL replay since there would be a lot of l0 parts processed at the same time.

Starting the compactor pool before WAL replay causes WAL replay to slow down a bit but with the good property that data is compacted during WAL replay and memory spikes are avoided. Also, recovery code already expected the compactor pool to be started.

This commit also removes the CompactAfterRecovery option given it is not needed any more.