### PR TITLE
remove hashed optimization regexp compile step

### DIFF
--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -712,7 +712,7 @@ type RegexpColumnMatch struct {
 
 func (a *RegexpColumnMatch) Clone() Expr {
 	return &RegexpColumnMatch{
-		match: a.match.Copy(),
+		match: a.match,
 	}
 }
 

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -692,27 +692,27 @@ func (a *AverageExpr) Accept(visitor Visitor) bool {
 	return visitor.PostVisit(a)
 }
 
-func RegExpColumnMatch(regexp string) *RegexpColumnMatch {
+func RegExpColumnMatch(match *regexp.Regexp) *RegexpColumnMatch {
 	return &RegexpColumnMatch{
-		regexp: regexp,
+		match: match,
 	}
 }
 
-func RegExpNotColumnMatch(regexp string) *RegexpColumnMatch {
+func RegExpNotColumnMatch(match *regexp.Regexp) *RegexpColumnMatch {
 	return &RegexpColumnMatch{
 		inverse: true,
-		regexp:  regexp,
+		match:   match,
 	}
 }
 
 type RegexpColumnMatch struct {
 	inverse bool
-	regexp  string
+	match   *regexp.Regexp
 }
 
 func (a *RegexpColumnMatch) Clone() Expr {
 	return &RegexpColumnMatch{
-		regexp: a.regexp,
+		match: a.match.Copy(),
 	}
 }
 
@@ -721,7 +721,7 @@ func (a *RegexpColumnMatch) DataType(s *parquet.Schema) (arrow.DataType, error) 
 }
 
 func (a *RegexpColumnMatch) Name() string {
-	return a.regexp
+	return a.match.String()
 }
 
 func (a *RegexpColumnMatch) ColumnsUsedExprs() []Expr {
@@ -729,13 +729,11 @@ func (a *RegexpColumnMatch) ColumnsUsedExprs() []Expr {
 }
 
 func (a *RegexpColumnMatch) MatchPath(path string) bool {
-	match, err := regexp.MatchString(a.regexp, path)
-	return err == nil && match != a.inverse
+	return a.match.MatchString(path) != a.inverse
 }
 
 func (a *RegexpColumnMatch) MatchColumn(name string) bool {
-	match, err := regexp.MatchString(a.regexp, name)
-	return err == nil && match != a.inverse
+	return a.match.MatchString(name) != a.inverse
 }
 
 func (a *RegexpColumnMatch) Computed() bool {

--- a/query/logicalplan/optimize.go
+++ b/query/logicalplan/optimize.go
@@ -1,8 +1,12 @@
 package logicalplan
 
 import (
+	"regexp"
+
 	"golang.org/x/exp/slices"
 )
+
+var hashedMatch = regexp.MustCompile("^hashed.")
 
 type Optimizer interface {
 	Optimize(plan *LogicalPlan) *LogicalPlan
@@ -13,7 +17,7 @@ func DefaultOptimizers() []Optimizer {
 		&AverageAggregationPushDown{},
 		&PhysicalProjectionPushDown{
 			defaultProjections: []Expr{
-				RegExpNotColumnMatch("^hashed."),
+				RegExpNotColumnMatch(hashedMatch),
 			},
 		},
 		&FilterPushDown{},
@@ -122,7 +126,7 @@ func (p *PhysicalProjectionPushDown) optimize(plan *LogicalPlan, columnsUsedExpr
 			columnsUsedExprs = append(columnsUsedExprs, expr.ColumnsUsedExprs()...)
 		}
 		p.defaultProjections = []Expr{}
-		columnsUsedExprs = append(columnsUsedExprs, RegExpColumnMatch("^hashed."))
+		columnsUsedExprs = append(columnsUsedExprs, RegExpColumnMatch(hashedMatch))
 	}
 
 	if plan.Input != nil {

--- a/query/logicalplan/optimize_test.go
+++ b/query/logicalplan/optimize_test.go
@@ -35,7 +35,7 @@ func TestOptimizePhysicalProjectionPushDown(t *testing.T) {
 			&Column{ColumnName: "stacktrace"},
 			&Column{ColumnName: "stacktrace"},
 			&Column{ColumnName: "value"},
-			RegExpColumnMatch("^hashed."),
+			RegExpColumnMatch(hashedMatch),
 			&Column{ColumnName: "labels.test"},
 		},
 	},
@@ -205,7 +205,7 @@ func TestAllOptimizers(t *testing.T) {
 			&Column{ColumnName: "stacktrace"},
 			&Column{ColumnName: "stacktrace"},
 			&Column{ColumnName: "value"},
-			RegExpColumnMatch("^hashed."),
+			RegExpColumnMatch(hashedMatch),
 			&Column{ColumnName: "labels.test"},
 		},
 		Filter: &BinaryExpr{


### PR DESCRIPTION
Saves cpu and memory to compile the optimization once