### PR TITLE
Page index cache

### DIFF
--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -174,7 +174,7 @@ func (b *serializedRowGroup) ColumnChunks() []parquet.ColumnChunk {
 	if b.indexes != nil && b.offsets != nil {
 		cachedColumnChunks := make([]parquet.ColumnChunk, len(chunks))
 		for i, chunk := range chunks {
-			chunks[i] = &cachedColumnChunk{
+			cachedColumnChunks[i] = &cachedColumnChunk{
 				index:  b.indexes[i],
 				offset: b.offsets[i],
 				chunk:  chunk,


### PR DESCRIPTION
This introduces a new option `StorageWithPageIndexCache` to the default bucket store.

This instructs the storage bucket to not read the page index when opening parquet files, but instead to attempt to load one from the given cache. If the index is found in the cache it will inject that index into the row group, otherwise it will fallback to reading the page index from the file and adding it to the cache. 

This can help prevent costly `thrift.Unmarshal` calls by holding them in memory already unmarshalled. 

```
thor@thors-MacBook-Pro frostdb % benchstat before after
name                              old time/op    new time/op    delta
_DB_StorageWithPageIndexCache-10     112µs ± 1%     102µs ± 1%   -9.43%  (p=0.000 n=9+9)

name                              old alloc/op   new alloc/op   delta
_DB_StorageWithPageIndexCache-10     247kB ± 9%     232kB ±14%     ~     (p=0.052 n=10+10)

name                              old allocs/op  new allocs/op  delta
_DB_StorageWithPageIndexCache-10     1.98k ± 0%     1.64k ± 0%  -16.99%  (p=0.000 n=10+10)
```