### PR TITLE
db: add CompactAfterRecovery option back in

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -29,6 +29,9 @@ type CompactionConfig struct {
 	concurrency          int
 	interval             time.Duration
 	l1ToGranuleSizeRatio float64
+
+	// compactAfterRecovery specifies to run compaction on all tables after recovery.
+	compactAfterRecovery bool
 }
 
 // NewCompactionConfig creates a new compaction config with the given options.
@@ -49,6 +52,13 @@ func NewCompactionConfig(options ...CompactionOption) *CompactionConfig {
 		o(c)
 	}
 	return c
+}
+
+// WithCompactionAfterRecovery specifies to run compaction on all tables after recovery.
+func WithCompactionAfterRecovery() CompactionOption {
+	return func(c *CompactionConfig) {
+		c.compactAfterRecovery = true
+	}
 }
 
 // WithConcurrency specifies the number of concurrent goroutines compacting data


### PR DESCRIPTION
Since we recently changed replay to not start compactions, add this option back in so that callers can ensure data is compacted after replay.