### PR TITLE
*: do not use SortingWriter for compaction

### DIFF
--- a/table.go
+++ b/table.go
@@ -912,7 +912,7 @@ type parquetRowWriterOption func(p *parquetRowWriter)
 
 // rowWriter returns a new Parquet row writer with the given dynamic columns.
 func (t *TableBlock) rowWriter(writer io.Writer, dynCols map[string][]string, options ...parquetRowWriterOption) (*parquetRowWriter, error) {
-	w, err := t.table.schema.NewSortingWriter(writer, dynCols)
+	w, err := t.table.schema.NewWriter(writer, dynCols)
 	if err != nil {
 		return nil, err
 	}
@@ -1137,6 +1137,8 @@ func (t *Table) compactParts(w io.Writer, compact []*parts.Part) (int64, error) 
 	// To reduce the number of open cursors at the same time (which helps in
 	// memory usage reduction), find which parts do not overlap with any other
 	// part. These parts can be sorted and read one by one.
+	// This compaction code assumes the invariant that rows are sorted within
+	// parts. This helps reduce memory usage in various ways.
 	nonOverlappingParts, overlappingParts, err := parts.FindMaximumNonOverlappingSet(t.schema, compact)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This commit removes SortingWriter for compaction, given it increases our memory usage. Since we now rely on l0 parts being sorted, we can use a more efficient non-sorting writer for compaction.

On a prod wal replay:
```
benchstat benchmain_mem benchnew_mem
goos: darwin
goarch: arm64
pkg: github.com/polarsignals/frostdb
          │ benchmain_mem │           benchnew_mem            │
          │    sec/op     │   sec/op    vs base               │
Replay-12      34.99 ± 0%   23.21 ± 1%  -33.66% (p=0.002 n=6)

          │ benchmain_mem │            benchnew_mem             │
          │     B/op      │     B/op      vs base               │
Replay-12    50.54Gi ± 2%   42.07Gi ± 4%  -16.77% (p=0.002 n=6)

          │ benchmain_mem │           benchnew_mem            │
          │   allocs/op   │  allocs/op   vs base              │
Replay-12     131.9M ± 1%   125.8M ± 1%  -4.66% (p=0.002 n=6)
```