### PR TITLE
dynparquet: remove rowWriter

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1210,7 +1210,7 @@ const bloomFilterBitsPerValue = 10
 
 // NewWriter returns a new parquet writer with a concrete parquet schema
 // generated using the given concrete dynamic column names.
-func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (ParquetWriter, error) {
+func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string, opts ...parquet.WriterOption) (ParquetWriter, error) {
 	ps, err := s.GetDynamicParquetSchema(dynamicColumns)
 	if err != nil {
 		return nil, err
@@ -1248,6 +1248,7 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (Par
 			parquet.DropDuplicatedRows(s.uniquePrimaryIndex),
 		),
 	}
+	writerOptions = append(writerOptions, opts...)
 	if s.uniquePrimaryIndex {
 		return parquet.NewSortingWriter[any](
 			w,


### PR DESCRIPTION
The functionality this gave us is already implemented by the parquet library. This also increases compaction efficiency since we can use parquet.Copy.

This gives us a ~20% reduction in compaction memory usage when compacting replayed prod data:
```
goos: darwin
goarch: arm64
pkg: github.com/polarsignals/frostdb
          │ benchnew_mem │          benchcopy_mem           │
          │    sec/op    │   sec/op    vs base              │
Replay-12     23.21 ± 1%   21.15 ± 0%  -8.87% (p=0.002 n=6)

          │ benchnew_mem │            benchcopy_mem            │
          │     B/op     │     B/op      vs base               │
Replay-12   42.07Gi ± 4%   34.53Gi ± 4%  -17.92% (p=0.002 n=6)

          │ benchnew_mem │           benchcopy_mem           │
          │  allocs/op   │  allocs/op   vs base              │
Replay-12    125.8M ± 1%   132.8M ± 0%  +5.57% (p=0.002 n=6)
```

However, it seems like queries suffer:
```
goos: darwin
goarch: arm64
pkg: github.com/polarsignals/frostdb
                │ benchswquery │            benchcopyquery             │
                │    sec/op    │    sec/op      vs base                │
Query/Types-12    7.994m ±  2%   35.582m ±  4%  +345.11% (p=0.002 n=6)
Query/Labels-12   348.8µ ± 10%    340.9µ ±  1%    -2.26% (p=0.002 n=6)
Query/Values-12   1.961m ±  1%   19.438m ±  2%  +891.00% (p=0.002 n=6)
Query/Merge-12    63.31m ±  3%   266.99m ±  4%  +321.68% (p=0.002 n=6)
Query/Range-12    33.21m ±  2%   252.21m ±  2%  +659.45% (p=0.002 n=6)
Query/Filter-12   8.020m ±  1%   37.202m ± 15%  +363.89% (p=0.002 n=6)
geomean           6.722m          28.97m        +330.94%

                │ benchswquery  │            benchcopyquery            │
                │    B/msec     │    B/msec      vs base               │
Query/Filter-12   18.168Mi ± 1%   3.759Mi ± 13%  -79.31% (p=0.002 n=6)
```

I'm really not sure why. It seems like row groups are correctly sized and in fact we read fewer row groups with this approach. Still need to investigate.