### PR TITLE
dynparquet: remove SortingWriter usage

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -112,12 +112,13 @@ func (dyn dynamicSortingColumn) Path() []string { return dyn.path }
 // ability that any column definition that is dynamic will have columns
 // dynamically created as their column name is seen for the first time.
 type Schema struct {
-	def                proto.Message
-	columns            []ColumnDefinition
-	columnIndexes      map[string]int
-	sortingColumns     []SortingColumn
-	dynamicColumns     []int
-	uniquePrimaryIndex bool
+	def            proto.Message
+	columns        []ColumnDefinition
+	columnIndexes  map[string]int
+	sortingColumns []SortingColumn
+	dynamicColumns []int
+
+	UniquePrimaryIndex bool
 
 	writers        *sync.Map
 	buffers        *sync.Map
@@ -557,7 +558,7 @@ func newSchema(
 		buffers:            &sync.Map{},
 		sortingSchemas:     &sync.Map{},
 		parquetSchemas:     &sync.Map{},
-		uniquePrimaryIndex: uniquePrimaryIndex,
+		UniquePrimaryIndex: uniquePrimaryIndex,
 	}
 
 	for i, col := range columns {
@@ -1245,15 +1246,7 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string) (Par
 		),
 		parquet.SortingWriterConfig(
 			parquet.SortingColumns(cols...),
-			parquet.DropDuplicatedRows(s.uniquePrimaryIndex),
 		),
-	}
-	if s.uniquePrimaryIndex {
-		return parquet.NewSortingWriter[any](
-			w,
-			32*1024,
-			writerOptions...,
-		), nil
 	}
 	return parquet.NewGenericWriter[any](w, writerOptions...), nil
 }

--- a/table.go
+++ b/table.go
@@ -960,7 +960,7 @@ func (t *TableBlock) rowWriter(writer io.Writer, dynCols map[string][]string, op
 }
 
 // WriteRows will write the given rows to the underlying Parquet writer. It returns the number of rows written.
-func (p *parquetRowWriter) writeRows(rows parquet.Rows) (int, error) {
+func (p *parquetRowWriter) writeRows(rows parquet.RowReader) (int, error) {
 	written := 0
 	for p.maxNumRows == 0 || p.totalRowsWritten < p.maxNumRows {
 		if p.rowGroupSize > 0 && p.rowGroupRowsWritten+len(p.rowsBuf) > p.rowGroupSize {
@@ -1213,7 +1213,16 @@ func (t *Table) compactParts(w io.Writer, compact []*parts.Part) (int64, error) 
 
 		rows := merged.Rows()
 		defer rows.Close()
-		if _, err := p.writeRows(rows); err != nil {
+
+		var rowReader parquet.RowReader = rows
+		if t.schema.UniquePrimaryIndex {
+			// Given all inputs are sorted, we can deduplicate the rows using
+			// DedupeRowReader, which deduplicates consecutive rows that are
+			// equal on the sorting columns.
+			rowReader = parquet.DedupeRowReader(rows, merged.Schema().Comparator(merged.SortingColumns()...))
+		}
+
+		if _, err := p.writeRows(rowReader); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This results in quite high memory usage. Instead, given input parts are sorted in compaction, we can use a DedupeRowReader to deduplicate consecutive primary index rows. Here are the improvements on prod data (0 and 1 are the compacted levels):

```
pkg: github.com/polarsignals/frostdb
                         │  benchmain  │             benchnew              │
                         │   sec/op    │   sec/op    vs base               │
Replay//labels_view/0-12   12.824 ± 1%   9.747 ± 5%  -24.00% (p=0.002 n=6)
Replay//labels_view/1-12    6.169 ± 7%   5.013 ± 6%  -18.74% (p=0.002 n=6)
geomean                     8.895        6.990       -21.41%

                         │  benchmain   │               benchnew               │
                         │     B/op     │     B/op       vs base               │
Replay//labels_view/0-12   34.36Gi ± 5%   17.97Gi ± 12%  -47.71% (p=0.002 n=6)
Replay//labels_view/1-12   9.124Gi ± 2%   7.561Gi ±  2%  -17.13% (p=0.002 n=6)
geomean                    17.71Gi        11.66Gi        -34.17%

                         │  benchmain  │              benchnew              │
                         │  allocs/op  │  allocs/op   vs base               │
Replay//labels_view/0-12   92.78M ± 1%   73.24M ± 2%  -21.06% (p=0.002 n=6)
Replay//labels_view/1-12   14.67M ± 0%   13.44M ± 0%   -8.41% (p=0.002 n=6)
geomean                    36.89M        31.37M       -14.97%
```