### PR TITLE
table: write arrow records directly to parquet file during compaction

### DIFF
--- a/dynparquet/row.go
+++ b/dynparquet/row.go
@@ -77,7 +77,7 @@ func (s *Schema) RowLessThan(a, b *DynamicRow) bool {
 }
 
 func (s *Schema) Cmp(a, b *DynamicRow) int {
-	dynamicColumns := mergeDynamicColumnSets([]map[string][]string{a.DynamicColumns, b.DynamicColumns})
+	dynamicColumns := MergeDynamicColumnSets([]map[string][]string{a.DynamicColumns, b.DynamicColumns})
 	cols := s.ParquetSortingColumns(dynamicColumns)
 	pooledSchema, err := s.GetParquetSortingSchema(dynamicColumns)
 	if err != nil {

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1488,10 +1488,10 @@ func mergeDynamicRowGroupDynamicColumns(rowGroups []DynamicRowGroup) map[string]
 		sets = append(sets, batch.DynamicColumns())
 	}
 
-	return mergeDynamicColumnSets(sets)
+	return MergeDynamicColumnSets(sets)
 }
 
-func mergeDynamicColumnSets(sets []map[string][]string) map[string][]string {
+func MergeDynamicColumnSets(sets []map[string][]string) map[string][]string {
 	dynamicColumns := map[string][][]string{}
 	for _, set := range sets {
 		for k, v := range set {


### PR DESCRIPTION
Previously, non-overlapping arrow records (L0 parts) were each converted to a parquet file and then merged. This commit shortcuts this process by directly converting all L0 arrow records into a parquet part.

This reduces L0 compaction memory usage substantially.

```
                            │ benchmain_alltables │     benchl0direct_sameschema      │
                            │       sec/op        │   sec/op    vs base               │
Replay//stacktraces/0-12               27.68 ± 3%   24.88 ± 1%  -10.12% (p=0.002 n=6)
Replay//stacktraces/1-12               11.47 ± 1%   11.53 ± 1%        ~ (p=0.589 n=6)
Replay//aggregate_view/0-12           14.110 ± 3%   7.955 ± 2%  -43.62% (p=0.002 n=6)
Replay//aggregate_view/1-12            9.559 ± 2%   9.677 ± 2%        ~ (p=0.132 n=6)
Replay//labels_view/0-12               9.866 ± 2%   6.836 ± 4%  -30.70% (p=0.002 n=6)
Replay//labels_view/1-12               4.901 ± 8%   5.101 ± 6%        ~ (p=0.699 n=6)
geomean                                11.29        9.574       -15.20%

                            │ benchmain_alltables │      benchl0direct_sameschema       │
                            │        B/op         │     B/op      vs base               │
Replay//stacktraces/0-12            36.21Gi ±  6%   21.33Gi ± 1%  -41.10% (p=0.002 n=6)
Replay//stacktraces/1-12            18.05Gi ±  1%   18.11Gi ± 0%        ~ (p=0.240 n=6)
Replay//aggregate_view/0-12        26.073Gi ± 14%   9.730Gi ± 2%  -62.68% (p=0.002 n=6)
Replay//aggregate_view/1-12         12.02Gi ±  1%   12.01Gi ± 0%        ~ (p=0.937 n=6)
Replay//labels_view/0-12           17.243Gi ±  8%   9.180Gi ± 3%  -46.76% (p=0.002 n=6)
Replay//labels_view/1-12            7.397Gi ±  4%   7.577Gi ± 2%        ~ (p=0.132 n=6)
geomean                             17.23Gi         12.10Gi       -29.76%

                            │ benchmain_alltables │      benchl0direct_sameschema      │
                            │      allocs/op      │  allocs/op   vs base               │
Replay//stacktraces/0-12              186.8M ± 2%   152.3M ± 2%  -18.43% (p=0.002 n=6)
Replay//stacktraces/1-12              32.63M ± 0%   32.63M ± 0%        ~ (p=0.394 n=6)
Replay//aggregate_view/0-12          104.47M ± 2%   63.89M ± 3%  -38.84% (p=0.002 n=6)
Replay//aggregate_view/1-12           19.60M ± 0%   19.60M ± 0%        ~ (p=0.180 n=6)
Replay//labels_view/0-12              72.94M ± 2%   48.99M ± 2%  -32.84% (p=0.002 n=6)
Replay//labels_view/1-12              13.42M ± 0%   13.43M ± 0%        ~ (p=0.093 n=6)
geomean                               47.99M        40.00M       -16.65%
```