### PR TITLE
parts: don't consider parts overlapping if a.end == b.start

### DIFF
--- a/parts/part.go
+++ b/parts/part.go
@@ -315,7 +315,7 @@ func FindMaximumNonOverlappingSet(schema *dynparquet.Schema, parts []*Part) ([]*
 		if err != nil {
 			return nil, nil, err
 		}
-		if schema.Cmp(prevEnd, start) < 0 {
+		if schema.Cmp(prevEnd, start) <= 0 {
 			// No overlap, append the previous part and update end for the next
 			// iteration.
 			nonOverlapping = append(nonOverlapping, parts[prev])


### PR DESCRIPTION
This removes a lot of unnecessary overlaps and allows us to take advantage of some compaction optimizations:
```
pkg: github.com/polarsignals/frostdb
                            │  benchmain  │            benchpartseq            │
                            │   sec/op    │   sec/op     vs base               │
Replay//stacktraces/0-12       5.862 ± 2%    4.573 ± 1%  -21.99% (p=0.002 n=6)
Replay//stacktraces/1-12       3.385 ± 2%    3.400 ± 2%        ~ (p=0.818 n=6)
Replay//aggregate_view/0-12    2.315 ± 3%    2.187 ± 3%   -5.53% (p=0.002 n=6)
Replay//aggregate_view/1-12    6.577 ± 2%    6.583 ± 1%        ~ (p=1.000 n=6)
Replay//labels_view/0-12      724.2m ± 3%   727.9m ± 5%        ~ (p=0.485 n=6)
Replay//labels_view/1-12       1.641 ± 3%    1.661 ± 6%        ~ (p=0.485 n=6)
geomean                        2.666         2.543        -4.61%

                            │  benchmain   │            benchpartseq             │
                            │     B/op     │     B/op      vs base               │
Replay//stacktraces/0-12      6.130Gi ± 3%   4.324Gi ± 1%  -29.47% (p=0.002 n=6)
Replay//stacktraces/1-12      5.725Gi ± 2%   5.730Gi ± 1%        ~ (p=0.818 n=6)
Replay//aggregate_view/0-12   3.836Gi ± 6%   2.891Gi ± 7%  -24.63% (p=0.002 n=6)
Replay//aggregate_view/1-12   3.361Gi ± 5%   3.375Gi ± 4%        ~ (p=0.699 n=6)
Replay//labels_view/0-12      1.457Gi ± 3%   1.448Gi ± 2%        ~ (p=0.937 n=6)
Replay//labels_view/1-12      2.396Gi ± 1%   2.411Gi ± 3%        ~ (p=1.000 n=6)
geomean                       3.413Gi        3.074Gi        -9.91%

                            │  benchmain  │           benchpartseq            │
                            │  allocs/op  │  allocs/op   vs base              │
Replay//stacktraces/0-12      32.60M ± 0%   31.18M ± 1%  -4.34% (p=0.002 n=6)
Replay//stacktraces/1-12      9.103M ± 0%   9.104M ± 0%       ~ (p=0.589 n=6)
Replay//aggregate_view/0-12   15.63M ± 1%   14.56M ± 1%  -6.88% (p=0.002 n=6)
Replay//aggregate_view/1-12   7.682M ± 0%   7.683M ± 0%       ~ (p=0.589 n=6)
Replay//labels_view/0-12      5.005M ± 0%   5.004M ± 0%       ~ (p=0.937 n=6)
Replay//labels_view/1-12      3.603M ± 0%   3.604M ± 0%       ~ (p=0.589 n=6)
geomean                       9.290M        9.113M       -1.90%
```