### PR TITLE
Fix: Data not found on rotate

### DIFF
--- a/table.go
+++ b/table.go
@@ -497,6 +497,7 @@ func (t *Table) RotateBlock(ctx context.Context, block *TableBlock, skipPersist 
 
 	id := generateULID()
 	for id.Time() == block.ulid.Time() { // Ensure the new block has a different timestamp.
+		runtime.Gosched()
 		id = generateULID()
 	}
 	if err := t.newTableBlock(t.active.minTx, tx, metadata, id); err != nil {

--- a/table.go
+++ b/table.go
@@ -496,6 +496,9 @@ func (t *Table) RotateBlock(ctx context.Context, block *TableBlock, skipPersist 
 	defer commit()
 
 	id := generateULID()
+	for id.Time() == block.ulid.Time() { // Ensure the new block has a different timestamp.
+		id = generateULID()
+	}
 	if err := t.newTableBlock(t.active.minTx, tx, metadata, id); err != nil {
 		return err
 	}


### PR DESCRIPTION
Hedge against a scenario where the new active block and the preivously uploaded block have the same timestamp in their ulid. This caused queries to discard the uploaded block erroniously.