### PR TITLE
*: remove unnecessary allocations

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -126,9 +126,26 @@ type Schema struct {
 	parquetSchemas *sync.Map
 }
 
-// IsDynamicColumn returns true if the passed in column is a dynamic column.
-func (s *Schema) IsDynamicColumn(col string) bool {
-	return s.columns[s.columnIndexes[col]].Dynamic
+// IsDynamicColumn returns true if the passed in column name of the type
+// "labels.label1" is a dynamic column the schema recognizes.
+func (s *Schema) IsDynamicColumn(column string) bool {
+	periodPosition := 0
+	foundPeriod := false
+	for i, c := range column {
+		if c != '.' {
+			continue
+		}
+		if foundPeriod {
+			// Can't have more than one period.
+			return false
+		}
+		foundPeriod = true
+		periodPosition = i
+	}
+	if !foundPeriod {
+		return false
+	}
+	return s.columns[s.columnIndexes[column[0:periodPosition]]].Dynamic
 }
 
 func findLeavesFromNode(node *schemav2pb.Node) []ColumnDefinition {

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -75,7 +75,7 @@ func getRecordRow(schema *dynparquet.Schema, record arrow.Record, index int, fin
 		for j, af := range recordFields {
 			if f.Name() == af.Name {
 				def := 0
-				if isDynamicColumn(schema, af.Name) {
+				if schema.IsDynamicColumn(af.Name) {
 					def = 1
 				}
 				row, err = appendToRow(row, record.Column(j), index, 0, def, i)
@@ -94,11 +94,6 @@ func getRecordRow(schema *dynparquet.Schema, record arrow.Record, index int, fin
 	}
 
 	return row, nil
-}
-
-func isDynamicColumn(schema *dynparquet.Schema, column string) bool {
-	parts := strings.SplitN(column, ".", 2)
-	return len(parts) == 2 && schema.IsDynamicColumn(parts[0]) // dynamic column
 }
 
 func RecordDynamicCols(record arrow.Record) map[string][]string {


### PR DESCRIPTION
These two commits reduce some of the biggest offenders in terms of the number of allocated objects (50% of a production profile), which greatly affects GC. The improvements on a replay of a production WAL are already noticeable but I think this change should shine in steady-state memory usage:
```
pkg: github.com/polarsignals/frostdb
          │ benchmain  │             benchnew              │
          │   sec/op   │   sec/op    vs base               │
Replay-12   8.747 ± 2%   6.359 ± 4%  -27.30% (p=0.002 n=6)

          │  benchmain   │              benchnew               │
          │     B/op     │     B/op      vs base               │
Replay-12   22.85Gi ± 1%   20.21Gi ± 0%  -11.57% (p=0.002 n=6)

          │  benchmain  │              benchnew              │
          │  allocs/op  │  allocs/op   vs base               │
Replay-12   146.8M ± 2%   101.3M ± 1%  -31.01% (p=0.002 n=6)
```