### PR TITLE
Support updating the table config

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1558,7 +1558,7 @@ func TestDBRecover(t *testing.T) {
 
 		db, err := c.DB(ctx, dbAndTableName)
 		require.NoError(t, err)
-		table, err := db.Table(dbAndTableName, nil)
+		table, err := db.GetTable(dbAndTableName)
 		require.NoError(t, err)
 		newWriteAndExpectWALRecord(t, db, table)
 	})
@@ -1658,7 +1658,7 @@ func TestDBRecover(t *testing.T) {
 
 		db, err := c.DB(ctx, dbAndTableName)
 		require.NoError(t, err)
-		table, err := db.Table(dbAndTableName, nil)
+		table, err := db.GetTable(dbAndTableName)
 		require.NoError(t, err)
 
 		require.NoError(t, table.RotateBlock(ctx, table.ActiveBlock(), false))
@@ -1730,7 +1730,7 @@ func Test_DB_WalReplayTableConfig(t *testing.T) {
 	require.NoError(t, err)
 	table, err := db.Table("test", config)
 	require.NoError(t, err)
-	require.Equal(t, uint64(10), table.config.RowGroupSize)
+	require.Equal(t, uint64(10), table.config.Load().RowGroupSize)
 
 	samples := dynparquet.NewTestSamples()
 
@@ -1754,9 +1754,9 @@ func Test_DB_WalReplayTableConfig(t *testing.T) {
 	db, err = c.DB(ctx, "test")
 	require.NoError(t, err)
 
-	table, err = db.Table("test", nil) // Pass nil because we expect the table to already exist because of wal replay
+	table, err = db.GetTable("test")
 	require.NoError(t, err)
-	require.Equal(t, uint64(10), table.config.RowGroupSize)
+	require.Equal(t, uint64(10), table.config.Load().RowGroupSize)
 }
 
 func TestDBMinTXPersisted(t *testing.T) {

--- a/snapshot.go
+++ b/snapshot.go
@@ -419,7 +419,7 @@ func WriteSnapshot(ctx context.Context, _ uint64, txnMetadata []byte, db *DB, w 
 			}
 			tableMeta := &snapshotpb.Table{
 				Name:   t.name,
-				Config: t.config,
+				Config: t.config.Load(),
 				ActiveBlock: &snapshotpb.Table_TableBlock{
 					Ulid:   blockUlid,
 					Size:   block.Size(),

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -166,7 +166,7 @@ func TestSnapshot(t *testing.T) {
 			// Reset sync.Maps so reflect.DeepEqual can be used below.
 			db.tables[testCase.name].schema.ResetWriters()
 			db.tables[testCase.name].schema.ResetBuffers()
-			require.Equal(t, db.tables[testCase.name].config, snapshotDB.tables[testCase.name].config)
+			require.Equal(t, db.tables[testCase.name].config.Load(), snapshotDB.tables[testCase.name].config.Load())
 		}
 	})
 


### PR DESCRIPTION
Previously if a Table was replayed from the WAL/snapshots all future calls to `Table(..., config)` would not overwrite the tables configuration. Which results in no way to actually update a tables configuration.

This changes that behavior to always update the Table's config to the newest configuration. 