### PR TITLE
Parquet tool

### DIFF
--- a/cmd/parquet-tool/cmd/dump.go
+++ b/cmd/parquet-tool/cmd/dump.go
@@ -21,10 +21,12 @@ var dumpCmd = &cobra.Command{
 }
 
 func dump(file string) error {
-	pf, err := openParquetFile(file)
+	pf, closer, err := openParquetFile(file)
 	if err != nil {
 		return err
 	}
+	defer closer.Close()
+
 	fmt.Println("schema:", pf.Schema())
 	meta := pf.Metadata()
 	fmt.Println("Num Rows:", meta.NumRows)

--- a/cmd/parquet-tool/cmd/find.go
+++ b/cmd/parquet-tool/cmd/find.go
@@ -92,10 +92,11 @@ func findAll(fileOrDir, column string) error {
 }
 
 func find(file, column string, t *table.Table) error {
-	pf, err := openParquetFile(file)
+	pf, closer, err := openParquetFile(file)
 	if err != nil {
 		return err
 	}
+	defer closer.Close()
 
 	columns, err := parseColumnArg(column)
 	if err != nil {

--- a/cmd/parquet-tool/cmd/find.go
+++ b/cmd/parquet-tool/cmd/find.go
@@ -117,11 +117,7 @@ func find(file, column string, t *table.Table) error {
 			}
 
 			// Check the min max values of each column
-			index, err := rg.ColumnChunks()[j].ColumnIndex()
-			if err != nil {
-				return err
-			}
-
+			index := rg.ColumnChunks()[j].ColumnIndex()
 			for k := 0; k < index.NumPages(); k++ {
 				if compare(index.MinValue(k), v) <= 0 &&
 					compare(index.MaxValue(k), v) >= 0 {

--- a/cmd/parquet-tool/cmd/root.go
+++ b/cmd/parquet-tool/cmd/root.go
@@ -27,4 +27,5 @@ func init() {
 	rootCmd.AddCommand(findCmd)
 	rootCmd.AddCommand(walCmd)
 	rootCmd.AddCommand(snapshotCmd)
+	rootCmd.AddCommand(rowgroupCmd)
 }

--- a/cmd/parquet-tool/cmd/root.go
+++ b/cmd/parquet-tool/cmd/root.go
@@ -28,4 +28,5 @@ func init() {
 	rootCmd.AddCommand(walCmd)
 	rootCmd.AddCommand(snapshotCmd)
 	rootCmd.AddCommand(rowgroupCmd)
+	rootCmd.AddCommand(columnCmd)
 }

--- a/cmd/parquet-tool/cmd/rowgroup.go
+++ b/cmd/parquet-tool/cmd/rowgroup.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/spf13/cobra"
+)
+
+var rowgroupCmd = &cobra.Command{
+	Use:     "rowgroup",
+	Example: "parquet-tool rg </path/to/parquet-file> <row_group_index>",
+	Short:   "Dump the column index for a row group",
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rg, err := strconv.Atoi(args[1])
+		if err != nil {
+			return err
+		}
+		return rowgroup(args[0], rg)
+	},
+}
+
+func rowgroup(file string, rg int) error {
+	f, err := openParquetFile(file)
+	if err != nil {
+		return err
+	}
+
+	t := table.New().
+		Border(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("99"))).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			switch {
+			case row == 0:
+				return HeaderStyle
+			case row%2 == 0:
+				return EvenRowStyle
+			default:
+				return OddRowStyle
+			}
+		}).
+		Headers("Column", "Page", "Min", "Max", "Nulls")
+	defer fmt.Println(t)
+
+	rowgroup := f.RowGroups()[rg]
+	fields := rowgroup.Schema().Fields()
+
+	for i, chunk := range rowgroup.ColumnChunks() {
+		index := chunk.ColumnIndex()
+		for j := 0; j < index.NumPages(); j++ {
+			t.Row(
+				fields[i%len(fields)].Name(),
+				strconv.Itoa(j),
+				fmt.Sprintf("%v", index.MinValue(j)),
+				fmt.Sprintf("%v", index.MaxValue(j)),
+				fmt.Sprintf("%v", index.NullCount(j)),
+			)
+		}
+	}
+	return nil
+}

--- a/cmd/parquet-tool/cmd/rowgroup.go
+++ b/cmd/parquet-tool/cmd/rowgroup.go
@@ -24,10 +24,11 @@ var rowgroupCmd = &cobra.Command{
 }
 
 func rowgroup(file string, rg int) error {
-	f, err := openParquetFile(file)
+	f, closer, err := openParquetFile(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open file :", err)
 	}
+	defer closer.Close()
 
 	t := table.New().
 		Border(lipgloss.NormalBorder()).

--- a/cmd/parquet-tool/cmd/util.go
+++ b/cmd/parquet-tool/cmd/util.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/apache/arrow/go/v14/arrow"
@@ -9,22 +10,21 @@ import (
 	"github.com/parquet-go/parquet-go"
 )
 
-func openParquetFile(file string) (*parquet.File, error) {
+func openParquetFile(file string) (*parquet.File, io.Closer, error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	defer f.Close()
 	stats, err := f.Stat()
 	if err != nil {
-		return nil, err
+		return nil, f, err
 	}
 	pf, err := parquet.OpenFile(f, stats.Size())
 	if err != nil {
-		return nil, err
+		return nil, f, err
 	}
 
-	return pf, nil
+	return pf, f, nil
 }
 
 func compare(v1, v2 parquet.Value) int {


### PR DESCRIPTION
Adds

- rowgroup command to dump the index for an individual row group
- column command to dump the data in a column in a row group
- find: Support matching a rowgroup against multiple column matchers at once