### PR TITLE
Fix use of unsafe.Slice: Use unsafe.SliceData

### DIFF
--- a/pqarrow/builder/optbuilders.go
+++ b/pqarrow/builder/optbuilders.go
@@ -174,7 +174,7 @@ func (b *OptBinaryBuilder) AppendNulls(n int) {
 // a new array.
 func (b *OptBinaryBuilder) NewArray() arrow.Array {
 	b.offsets = append(b.offsets, uint32(len(b.data)))
-	offsetsAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(&b.offsets[0])), len(b.offsets)*arrow.Uint32SizeBytes)
+	offsetsAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(b.offsets))), len(b.offsets)*arrow.Uint32SizeBytes)
 	data := array.NewData(
 		b.dtype,
 		b.length,
@@ -340,7 +340,7 @@ func (b *OptInt64Builder) AppendNulls(n int) {
 }
 
 func (b *OptInt64Builder) NewArray() arrow.Array {
-	dataAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(&b.data[0])), len(b.data)*arrow.Int64SizeBytes)
+	dataAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(b.data))), len(b.data)*arrow.Int64SizeBytes)
 	data := array.NewData(
 		b.dtype,
 		b.length,
@@ -596,7 +596,7 @@ func (b *OptInt32Builder) AppendNulls(n int) {
 }
 
 func (b *OptInt32Builder) NewArray() arrow.Array {
-	dataAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(&b.data[0])), len(b.data)*arrow.Int32SizeBytes)
+	dataAsBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(b.data))), len(b.data)*arrow.Int32SizeBytes)
 	data := array.NewData(
 		b.dtype,
 		b.length,


### PR DESCRIPTION
Since reflect.SliceHeader is deprecated we switched to using unsafe.Slice. However we used data[0] as the pointer to the data of the slice. Which worked until the data array was nil.

This changes that to use unsafe.SliceData instead which hedges against an empty slice

Fixes #614 