### PR TITLE
Use buffered channels in synchronizer

### DIFF
--- a/query/engine.go
+++ b/query/engine.go
@@ -132,7 +132,8 @@ func (b LocalQueryBuilder) Project(
 func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(ctx context.Context, r arrow.Record) error) error {
 	ctx, span := b.tracer.Start(ctx, "LocalQueryBuilder/Execute")
 	defer span.End()
-
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	phyPlan, err := b.buildPhysical(ctx)
 	if err != nil {
 		return err
@@ -142,6 +143,8 @@ func (b LocalQueryBuilder) Execute(ctx context.Context, callback func(ctx contex
 }
 
 func (b LocalQueryBuilder) Explain(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	phyPlan, err := b.buildPhysical(ctx)
 	if err != nil {
 		return "", err

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -371,7 +371,7 @@ func Build(
 			var sync *Synchronizer
 			if len(prev) > 1 {
 				// These distinct operators need to be synchronized.
-				sync = Synchronize(len(prev))
+				sync = Synchronize(ctx, len(prev))
 			}
 			for i := 0; i < len(prev); i++ {
 				d := Distinct(pool, tracer, plan.Distinct.Exprs)
@@ -416,7 +416,7 @@ func Build(
 				if ordered && len(plan.Aggregation.GroupExprs) > 0 {
 					sync = NewOrderedSynchronizer(pool, len(prev), plan.Aggregation.GroupExprs)
 				} else {
-					sync = Synchronize(len(prev))
+					sync = Synchronize(ctx, len(prev))
 				}
 			}
 			seed := maphash.MakeSeed()
@@ -463,7 +463,7 @@ func Build(
 	// Synchronize the last stage if necessary.
 	var sync *Synchronizer
 	if len(prev) > 1 {
-		sync = Synchronize(len(prev))
+		sync = Synchronize(ctx, len(prev))
 		for i := range prev {
 			prev[i].SetNext(sync)
 		}

--- a/query/physicalplan/physicalplan_test.go
+++ b/query/physicalplan/physicalplan_test.go
@@ -74,9 +74,10 @@ func TestBuildPhysicalPlan(t *testing.T) {
 	for _, optimizer := range optimizers {
 		optimizer.Optimize(p)
 	}
-
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	_, err := Build(
-		context.Background(),
+		ctx,
 		memory.DefaultAllocator,
 		trace.NewNoopTracerProvider().Tracer(""),
 		dynparquet.NewSampleSchema(),

--- a/query/physicalplan/synchronize_test.go
+++ b/query/physicalplan/synchronize_test.go
@@ -20,8 +20,10 @@ func TestSynchronize(t *testing.T) {
 	op := &OutputPlan{
 		scan: &mockTableScan{plans: plans},
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	synchronizer := Synchronize(len(plans))
+	synchronizer := Synchronize(ctx, len(plans))
 	synchronizer.SetNext(op)
 
 	for _, p := range plans {


### PR DESCRIPTION
Closes #210

We use a background goroutine for synchronizing the physical plan. This adds a requirement to ensure the passed `context.Context` is cancelled to avoid goroutine leaking calling `(*Synchronizer).Close` safely terminates the background goroutine.. 
