### PR TITLE
feat: initial work for aggregations with float64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ test:
 .PHONY: gen/proto
 gen/proto:
 	buf generate
+
+lint:
+	golangci-lint --timeout=5m run --fix

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -287,13 +287,6 @@ func SampleDefinition() *schemapb.Schema {
 				Type: schemapb.StorageLayout_TYPE_INT64,
 			},
 			Dynamic: false,
-		}, {
-			Name: "floatvalue",
-			StorageLayout: &schemapb.StorageLayout{
-				Type:     schemapb.StorageLayout_TYPE_DOUBLE,
-				Nullable: true,
-			},
-			Dynamic: false,
 		}},
 		SortingColumns: []*schemapb.SortingColumn{{
 			Name:      "example_type",
@@ -311,6 +304,21 @@ func SampleDefinition() *schemapb.Schema {
 			NullsFirst: true,
 		}},
 	}
+}
+
+// Adds a float column to the SampleDefinition to be able to test
+// aggregations with float values
+func SampleDefinitionWithFloat() *schemapb.Schema {
+	sample := SampleDefinition()
+	sample.Columns = append(sample.Columns, &schemapb.Column{
+		Name: "floatvalue",
+		StorageLayout: &schemapb.StorageLayout{
+			Type:     schemapb.StorageLayout_TYPE_DOUBLE,
+			Nullable: true,
+		},
+		Dynamic: false,
+	})
+	return sample
 }
 
 func NewSampleSchema() *Schema {

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -307,7 +307,7 @@ func SampleDefinition() *schemapb.Schema {
 }
 
 // Adds a float column to the SampleDefinition to be able to test
-// aggregations with float values
+// aggregations with float values.
 func SampleDefinitionWithFloat() *schemapb.Schema {
 	sample := SampleDefinition()
 	sample.Columns = append(sample.Columns, &schemapb.Column{

--- a/dynparquet/example.go
+++ b/dynparquet/example.go
@@ -287,6 +287,13 @@ func SampleDefinition() *schemapb.Schema {
 				Type: schemapb.StorageLayout_TYPE_INT64,
 			},
 			Dynamic: false,
+		}, {
+			Name: "floatvalue",
+			StorageLayout: &schemapb.StorageLayout{
+				Type:     schemapb.StorageLayout_TYPE_DOUBLE,
+				Nullable: true,
+			},
+			Dynamic: false,
 		}},
 		SortingColumns: []*schemapb.SortingColumn{{
 			Name:      "example_type",

--- a/examples/aggregations/aggregations.go
+++ b/examples/aggregations/aggregations.go
@@ -38,6 +38,7 @@ func main() {
 		City     interface{}
 		Day      string
 		Snowfall int64
+		// Snowfall2 float64
 	}
 
 	type CityInProvince struct {
@@ -65,7 +66,7 @@ func main() {
 		WeatherRecord{Day: "Wed", Snowfall: 30, City: toronto},
 		WeatherRecord{Day: "Thu", Snowfall: 00, City: toronto},
 		WeatherRecord{Day: "Fri", Snowfall: 05, City: toronto},
-		WeatherRecord{Day: "Mon", Snowfall: 40, City: minneapolis},
+		WeatherRecord{Day: "Mon", Snowfall: 40.0, City: minneapolis},
 		WeatherRecord{Day: "Tue", Snowfall: 15, City: minneapolis},
 		WeatherRecord{Day: "Wed", Snowfall: 32, City: minneapolis},
 		WeatherRecord{Day: "Thu", Snowfall: 10, City: minneapolis},
@@ -81,7 +82,7 @@ func main() {
 			[]logicalplan.Expr{
 				logicalplan.Max(logicalplan.Col("snowfall")),
 				logicalplan.Min(logicalplan.Col("snowfall")),
-				logicalplan.Avg(logicalplan.Col("snowfall")),
+				// logicalplan.Avg(logicalplan.Col("snowfall")),
 			},
 			[]logicalplan.Expr{logicalplan.Col("city.name")},
 		).
@@ -92,18 +93,18 @@ func main() {
 		})
 
 	// Total snowfall on each day of week:
-	_ = engine.ScanTable("snowfall_table").
-		Aggregate(
-			[]logicalplan.Expr{
-				logicalplan.Sum(logicalplan.Col("snowfall")),
-			},
-			[]logicalplan.Expr{logicalplan.Col("day")},
-		).
-		Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
-			// print the results
-			fmt.Println(r)
-			return nil
-		})
+	// _ = engine.ScanTable("snowfall_table").
+	// 	Aggregate(
+	// 		[]logicalplan.Expr{
+	// 			logicalplan.Sum(logicalplan.Col("snowfall2")),
+	// 		},
+	// 		[]logicalplan.Expr{logicalplan.Col("day")},
+	// 	).
+	// 	Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+	// 		// print the results
+	// 		fmt.Println(r)
+	// 		return nil
+	// 	})
 }
 
 func aggregationSchema() *schemapb.Schema {
@@ -130,7 +131,7 @@ func aggregationSchema() *schemapb.Schema {
 			{
 				Name: "snowfall",
 				StorageLayout: &schemapb.StorageLayout{
-					Type: schemapb.StorageLayout_TYPE_INT64,
+					Type: schemapb.StorageLayout_TYPE_DOUBLE,
 				},
 				Dynamic: false,
 			},

--- a/examples/aggregations/aggregations.go
+++ b/examples/aggregations/aggregations.go
@@ -37,8 +37,7 @@ func main() {
 	type WeatherRecord struct {
 		City     interface{}
 		Day      string
-		Snowfall int64
-		// Snowfall2 float64
+		Snowfall float64
 	}
 
 	type CityInProvince struct {
@@ -59,16 +58,16 @@ func main() {
 		WeatherRecord{Day: "Mon", Snowfall: 20, City: montreal},
 		WeatherRecord{Day: "Tue", Snowfall: 00, City: montreal},
 		WeatherRecord{Day: "Wed", Snowfall: 30, City: montreal},
-		WeatherRecord{Day: "Thu", Snowfall: 25, City: montreal},
+		WeatherRecord{Day: "Thu", Snowfall: 25.1, City: montreal},
 		WeatherRecord{Day: "Fri", Snowfall: 10, City: montreal},
 		WeatherRecord{Day: "Mon", Snowfall: 15, City: toronto},
 		WeatherRecord{Day: "Tue", Snowfall: 25, City: toronto},
 		WeatherRecord{Day: "Wed", Snowfall: 30, City: toronto},
 		WeatherRecord{Day: "Thu", Snowfall: 00, City: toronto},
 		WeatherRecord{Day: "Fri", Snowfall: 05, City: toronto},
-		WeatherRecord{Day: "Mon", Snowfall: 40.0, City: minneapolis},
+		WeatherRecord{Day: "Mon", Snowfall: 40.8, City: minneapolis},
 		WeatherRecord{Day: "Tue", Snowfall: 15, City: minneapolis},
-		WeatherRecord{Day: "Wed", Snowfall: 32, City: minneapolis},
+		WeatherRecord{Day: "Wed", Snowfall: 32.3, City: minneapolis},
 		WeatherRecord{Day: "Thu", Snowfall: 10, City: minneapolis},
 		WeatherRecord{Day: "Fri", Snowfall: 12, City: minneapolis},
 	)
@@ -82,7 +81,7 @@ func main() {
 			[]logicalplan.Expr{
 				logicalplan.Max(logicalplan.Col("snowfall")),
 				logicalplan.Min(logicalplan.Col("snowfall")),
-				// logicalplan.Avg(logicalplan.Col("snowfall")),
+				logicalplan.Avg(logicalplan.Col("snowfall")),
 			},
 			[]logicalplan.Expr{logicalplan.Col("city.name")},
 		).
@@ -93,18 +92,18 @@ func main() {
 		})
 
 	// Total snowfall on each day of week:
-	// _ = engine.ScanTable("snowfall_table").
-	// 	Aggregate(
-	// 		[]logicalplan.Expr{
-	// 			logicalplan.Sum(logicalplan.Col("snowfall2")),
-	// 		},
-	// 		[]logicalplan.Expr{logicalplan.Col("day")},
-	// 	).
-	// 	Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
-	// 		// print the results
-	// 		fmt.Println(r)
-	// 		return nil
-	// 	})
+	_ = engine.ScanTable("snowfall_table").
+		Aggregate(
+			[]logicalplan.Expr{
+				logicalplan.Sum(logicalplan.Col("snowfall")),
+			},
+			[]logicalplan.Expr{logicalplan.Col("day")},
+		).
+		Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+			// print the results
+			fmt.Println(r)
+			return nil
+		})
 }
 
 func aggregationSchema() *schemapb.Schema {

--- a/logictest/logic_test.go
+++ b/logictest/logic_test.go
@@ -39,7 +39,7 @@ func (db frostDB) ScanTable(name string) query.Builder {
 }
 
 var schemas = map[string]*schemapb.Schema{
-	"default": dynparquet.SampleDefinition(),
+	"default": dynparquet.SampleDefinitionWithFloat(),
 	"simple_bool": {
 		Name: "simple_bool",
 		Columns: []*schemapb.Column{{

--- a/logictest/runner.go
+++ b/logictest/runner.go
@@ -221,7 +221,15 @@ func (r *Runner) handleInsert(ctx context.Context, c *datadriven.TestData) (stri
 				if err != nil {
 					return "", fmt.Errorf("insert: %w", err)
 				}
-				rows[i] = append(rows[i], parquet.ValueOf(v).Level(0, 0, colIdx))
+				if col.StorageLayout.Optional() {
+					if parquet.ValueOf(v).IsNull() {
+						rows[i] = append(rows[i], parquet.ValueOf(v).Level(0, 0, colIdx))
+					} else {
+						rows[i] = append(rows[i], parquet.ValueOf(v).Level(0, 1, colIdx))
+					}
+				} else {
+					rows[i] = append(rows[i], parquet.ValueOf(v).Level(0, 0, colIdx))
+				}
 				colIdx++
 				continue
 			}

--- a/logictest/testdata/exec/aggregate/aggregate
+++ b/logictest/testdata/exec/aggregate/aggregate
@@ -21,12 +21,22 @@ value2  21
 exec
 select sum(floatvalue) as float_value_sum group by labels.label2
 ----
-value2  21.21
+value2  23.100000
 
 exec
 select max(value) as value_max group by labels.label2
 ----
 value2  6
+
+exec
+select max(floatvalue) as value_max group by labels.label2
+----
+value2  6.600000
+
+exec
+select min(floatvalue) as value_min group by labels.label2
+----
+value2  1.100000
 
 exec
 select count(value) as value_count group by labels.label2
@@ -41,7 +51,7 @@ value2  3
 exec
 select avg(floatvalue) as value_avg group by labels.label2
 ----
-value2  3.3
+value2  3.850000
 
 exec
 select avg(value) as value_avg group by labels.label4
@@ -55,6 +65,11 @@ select sum(value), count(value) group by stacktrace
 stack1  21      6
 
 exec
+select sum(floatvalue), count(floatvalue) group by stacktrace
+----
+stack1  23.100000  6
+
+exec
 select sum(value) as value_sum, count(value) as value_count group by stacktrace
 ----
 stack1  21      6
@@ -63,6 +78,11 @@ exec
 select sum(value), count(value), min(value), max(value) group by labels.label2
 ----
 value2  21      6       1       6
+
+exec
+select sum(floatvalue), count(floatvalue), min(floatvalue), max(floatvalue) group by labels.label2
+----
+value2  23.100000  6       1.100000  6.600000
 
 exec unordered
 select sum(value) as value_sum where timestamp >= 1 group by labels.label1

--- a/logictest/testdata/exec/aggregate/aggregate
+++ b/logictest/testdata/exec/aggregate/aggregate
@@ -1,22 +1,27 @@
 createtable schema=default
 ----
 
-insert cols=(labels.label1, labels.label2, labels.label3, labels.label4, stacktrace, timestamp, value)
-value1  value2  null    null    stack1  1   1
-value2  value2  value3  null    stack1  2   2
-value3  value2  null    value4  stack1  3   3
+insert cols=(labels.label1, labels.label2, labels.label3, labels.label4, stacktrace, timestamp, value, floatvalue)
+value1  value2  null    null    stack1  1   1   1.1
+value2  value2  value3  null    stack1  2   2   2.2
+value3  value2  null    value4  stack1  3   3   3.3
 ----
 
-insert cols=(labels.label1, labels.label2, labels.label3, labels.label4, stacktrace, timestamp, value)
-value4  value2  null    null    stack1  4   4
-value5  value2  value3  null    stack1  5   5
-value6  value2  null    value4  stack1  6   6
+insert cols=(labels.label1, labels.label2, labels.label3, labels.label4, stacktrace, timestamp, value, floatvalue)
+value4  value2  null    null    stack1  4   4   4.4
+value5  value2  value3  null    stack1  5   5   5.5
+value6  value2  null    value4  stack1  6   6   6.6
 ----
 
 exec
 select sum(value) as value_sum group by labels.label2
 ----
 value2  21
+
+exec
+select sum(floatvalue) as float_value_sum group by labels.label2
+----
+value2  21.21
 
 exec
 select max(value) as value_max group by labels.label2
@@ -32,6 +37,11 @@ exec
 select avg(value) as value_avg group by labels.label2
 ----
 value2  3
+
+exec
+select avg(floatvalue) as value_avg group by labels.label2
+----
+value2  3.3
 
 exec
 select avg(value) as value_avg group by labels.label4

--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -65,6 +65,8 @@ func AppendValue(cb ColumnBuilder, arr arrow.Array, i int) error {
 		b.AppendSingle(arr.(*array.Boolean).Value(i))
 	case *array.Int64Builder:
 		b.Append(arr.(*array.Int64).Value(i))
+	case *array.Float64Builder:
+		b.Append(arr.(*array.Float64).Value(i))
 	case *array.StringBuilder:
 		b.Append(arr.(*array.String).Value(i))
 	case *array.BinaryBuilder:

--- a/query/logicalplan/validate.go
+++ b/query/logicalplan/validate.go
@@ -224,7 +224,8 @@ func ValidateAggregationExpr(plan *LogicalPlan) *ExprValidationError {
 		// check that the column type can be aggregated by the function type
 		columnType := column.StorageLayout.Type()
 		aggFuncExpr := aggFuncFinder.result.(*AggregationFunction)
-		if columnType.LogicalType().UTF8 != nil {
+		logicalType := columnType.LogicalType()
+		if logicalType != nil && logicalType.UTF8 != nil {
 			switch aggFuncExpr.Func {
 			case AggFuncSum:
 				return &ExprValidationError{

--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -97,30 +97,15 @@ func Aggregate(
 
 func chooseAggregationFunction(
 	aggFunc logicalplan.AggFunc,
-	dataType arrow.DataType,
+	_ arrow.DataType,
 ) (AggregationFunction, error) {
 	switch aggFunc {
 	case logicalplan.AggFuncSum:
-		switch dataType.ID() {
-		case arrow.INT64, arrow.FLOAT64:
-			return &SumAggregation{}, nil
-		default:
-			return nil, fmt.Errorf("unsupported sum of type: %s", dataType.Name())
-		}
+		return &SumAggregation{}, nil
 	case logicalplan.AggFuncMin:
-		switch dataType.ID() {
-		case arrow.INT64, arrow.FLOAT64:
-			return &MinAggregation{}, nil
-		default:
-			return nil, fmt.Errorf("unsupported min of type: %s", dataType.Name())
-		}
+		return &MinAggregation{}, nil
 	case logicalplan.AggFuncMax:
-		switch dataType.ID() {
-		case arrow.INT64, arrow.FLOAT64:
-			return &MaxAggregation{}, nil
-		default:
-			return nil, fmt.Errorf("unsupported max of type: %s", dataType.Name())
-		}
+		return &MaxAggregation{}, nil
 	case logicalplan.AggFuncCount:
 		return &CountAggregation{}, nil
 	default:
@@ -674,7 +659,7 @@ func (a *HashAggregate) finishAggregate(ctx context.Context, aggIdx int, aggrega
 
 type SumAggregation struct{}
 
-var ErrUnsupportedSumType = errors.New("unsupported type for sum aggregation, expected int64")
+var ErrUnsupportedSumType = errors.New("unsupported type for sum aggregation, expected int64 or float64")
 
 func (a *SumAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error) {
 	if len(arrs) == 0 {
@@ -720,7 +705,7 @@ func sumFloat64array(arr *array.Float64) float64 {
 	return math.Float64.Sum(arr)
 }
 
-var ErrUnsupportedMinType = errors.New("unsupported type for max aggregation, expected int64")
+var ErrUnsupportedMinType = errors.New("unsupported type for max aggregation, expected int64 or float64")
 
 type MinAggregation struct{}
 
@@ -784,7 +769,7 @@ func minFloat64arrays(pool memory.Allocator, arrs []arrow.Array) arrow.Array {
 	return res.NewArray()
 }
 
-// Same as minInt64array but for Float64
+// Same as minInt64array but for Float64.
 func minFloat64array(arr *array.Float64) float64 {
 	// Note that the zero-length check must be performed before calling this
 	// function.
@@ -800,7 +785,7 @@ func minFloat64array(arr *array.Float64) float64 {
 
 type MaxAggregation struct{}
 
-var ErrUnsupportedMaxType = errors.New("unsupported type for max aggregation, expected int64")
+var ErrUnsupportedMaxType = errors.New("unsupported type for max aggregation, expected int64 or float64")
 
 func (a *MaxAggregation) Aggregate(pool memory.Allocator, arrs []arrow.Array) (arrow.Array, error) {
 	if len(arrs) == 0 {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -164,11 +164,7 @@ func (s *TableScan) Execute(ctx context.Context, pool memory.Allocator) error {
 		}))
 	}
 
-	if err := errg.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return errg.Wait()
 }
 
 type SchemaScan struct {

--- a/query/physicalplan/project.go
+++ b/query/physicalplan/project.go
@@ -354,6 +354,8 @@ func (a *averageProjection) Project(mem memory.Allocator, r arrow.Record) ([]arr
 			Type: &arrow.Float64Type{},
 		})
 		columns = append(columns, avgFloat64arrays(mem, sums, counts))
+	default:
+		return nil, nil, fmt.Errorf("Datatype %s is not supported for average projection", sums.DataType().ID())
 	}
 
 	return fields, columns, nil


### PR DESCRIPTION
This is very much a work in progress and could also be all wrong. 
This is an attempt at adding support for float64 aggregations. At this point, the aggregation works but the values are all wrong. Somehow the conversion of the value to float is wrong and I can't quite see why that is. I've been using the `examples/aggregation.go` to test it and it gives results of `[1.5e-322 1.5e-322 2e-322]` so I've got something wrong. 

If you could point me in the correct direction I could make the changes, or if I'm completely wrong let me know a better way. 

Fixes https://github.com/polarsignals/frostdb/issues/587