### PR TITLE
Support repeated columns for Generic Record Builder

### DIFF
--- a/dynparquet/record_builder_test.go
+++ b/dynparquet/record_builder_test.go
@@ -104,8 +104,8 @@ func TestBuild(t *testing.T) {
 		d, _ := m.Marshal(b.Schema("repeated"))
 		require.JSONEq(t, wantSchema, string(d))
 
-		b.Append(
-			Repeated{}, //nulls
+		err := b.Append(
+			Repeated{}, // nulls
 			Repeated{
 				Int:        []int64{1, 2},
 				Float:      []float64{1, 2},
@@ -121,6 +121,7 @@ func TestBuild(t *testing.T) {
 				StringDict: []string{"c", "d"},
 			},
 		)
+		require.Nil(t, err)
 		want := `[{"bool":null,"float":null,"int":null,"string":null,"string_dict":null}
 ,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["a","b"]}
 ,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["c","d"]}


### PR DESCRIPTION
Support repeated columns for all base types `[]int64` `[]float64`  `[]bool` `[]string`.   Use all supported tags on this column like other base columns( set encoding ,compression etc)

Since we deal with slices I took the liberty to make repeated fields nullable by default. 

Example

```go
		type Example struct {
			StringDict []string `frostdb:",rle_dict"`
		}
```