### PR TITLE
[WIP] Add implementation of  TimescaleDB time_bucket

### DIFF
--- a/query/physicalplan/aggregate.go
+++ b/query/physicalplan/aggregate.go
@@ -333,6 +333,10 @@ func (a *HashAggregate) Callback(_ context.Context, r arrow.Record) error {
 					groupByFieldHashes = append(groupByFieldHashes,
 						&durationHashCombine{milliseconds: uint64(duration.Milliseconds())},
 					)
+				case *logicalplan.TimeBucketExpr:
+					groupByFieldHashes = append(groupByFieldHashes,
+						newTimeBucketHash(v.Value()),
+					)
 				default:
 					groupByFieldHashes = append(groupByFieldHashes,
 						&uint64HashCombine{value: scalar.Hash(a.hashSeed, scalar.NewStringScalar(field.Name))},

--- a/query/physicalplan/time_bucket.go
+++ b/query/physicalplan/time_bucket.go
@@ -18,11 +18,6 @@ const (
 	maxTs = math.MinInt64
 )
 
-type Period interface {
-	Milliseconds() int64
-	internal()
-}
-
 func newTimeBucketHash(period logicalplan.Period) *bucketHashCombine {
 	switch e := period.(type) {
 	case logicalplan.Day:

--- a/query/physicalplan/time_bucket.go
+++ b/query/physicalplan/time_bucket.go
@@ -111,9 +111,8 @@ func timeBucket(period, timestamp, offset int64) (result int64) {
 	if timestamp < 0 && (timestamp%period) != 0 {
 		if result < minTs+period {
 			panic("time_bucket: timestamp out of range")
-		} else {
-			result -= period
 		}
+		result -= period
 	}
 	result += offset
 	return

--- a/query/physicalplan/time_bucket.go
+++ b/query/physicalplan/time_bucket.go
@@ -1,0 +1,120 @@
+package physicalplan
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/polarsignals/frostdb/query/logicalplan"
+)
+
+var (
+	defaultOrigin, _ = time.Parse(time.DateOnly, "2000-01-03")
+	defaultOriginMs  = defaultOrigin.UnixMilli()
+)
+
+const (
+	minTs = math.MinInt64
+	maxTs = math.MinInt64
+)
+
+type Period interface {
+	Milliseconds() int64
+	internal()
+}
+
+func newTimeBucketHash(period logicalplan.Period) *bucketHashCombine {
+	switch e := period.(type) {
+	case logicalplan.Day:
+		return &bucketHashCombine{
+			period: (time.Hour * 24 * time.Duration(e)).Milliseconds(),
+			hash:   bucketDay,
+		}
+	case logicalplan.Week:
+		return &bucketHashCombine{
+			period: (time.Hour * 24 * 7 * time.Duration(e)).Milliseconds(),
+			hash:   bucketWeek,
+		}
+	case logicalplan.Month:
+		return &bucketHashCombine{
+			period: (time.Hour * 24 * 30 * time.Duration(e)).Milliseconds(),
+			hash:   bucketMonth,
+		}
+	case logicalplan.Year:
+		return &bucketHashCombine{
+			period: (time.Hour * 24 * 365 * time.Duration(e)).Milliseconds(),
+			hash:   bucketYear,
+		}
+	default:
+		panic(fmt.Sprintf("time_bucket: unexpected period type %T", period))
+	}
+}
+
+type bucketHashCombine struct {
+	period int64
+	hash   func(int64, time.Time) time.Time
+}
+
+func (b *bucketHashCombine) hashCombine(v uint64) uint64 {
+	ts := time.UnixMilli(int64(v))
+	yy, mm, dd := ts.Date()
+	date := time.Date(yy, mm, dd, 0, 0, 0, 0, time.UTC)
+	return uint64(b.hash(b.period, date).UnixMilli())
+}
+
+func bucketWeek(period int64, date time.Time) time.Time {
+	r := timeBucket(
+		period, date.UnixMilli(), defaultOriginMs,
+	)
+	yy, mm, dd := time.UnixMilli(r).UTC().Date()
+	day := time.Date(yy, mm, dd, 0, 0, 0, 0, time.UTC)
+	return day.AddDate(0, 0, -int(day.Weekday()))
+}
+
+func bucketDay(period int64, date time.Time) time.Time {
+	r := timeBucket(
+		period, date.UnixMilli(), defaultOriginMs,
+	)
+	yy, mm, dd := time.UnixMilli(r).UTC().Date()
+	return time.Date(yy, mm, dd, 0, 0, 0, 0, time.UTC)
+}
+
+func bucketMonth(period int64, date time.Time) time.Time {
+	r := timeBucket(
+		period, date.UnixMilli(), defaultOriginMs,
+	)
+	yy, mm, _ := time.UnixMilli(r).UTC().Date()
+	return time.Date(yy, mm, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func bucketYear(period int64, date time.Time) time.Time {
+	r := timeBucket(
+		period, date.UnixMilli(), defaultOriginMs,
+	)
+	yy, _, _ := time.UnixMilli(r).UTC().Date()
+	return time.Date(yy, time.January, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func timeBucket(period, timestamp, offset int64) (result int64) {
+	if period <= 0 {
+		panic("time_bucket: period must be greater than 0")
+	}
+	if offset != 0 {
+		offset = offset % period
+		if (offset > 0 && timestamp < minTs+offset) ||
+			(offset < 0 && timestamp > maxTs+offset) {
+			panic("time_bucket: timestamp out of range")
+		}
+		timestamp -= offset
+	}
+	result = (timestamp / period) * period
+	if timestamp < 0 && (timestamp%period) != 0 {
+		if result < minTs+period {
+			panic("time_bucket: timestamp out of range")
+		} else {
+			result -= period
+		}
+	}
+	result += offset
+	return
+}


### PR DESCRIPTION
Inspired by this blogpost from timescaledb  [Aggregate time-series data with time_bucket](https://docs.timescale.com/use-timescale/latest/time-buckets/use-time-buckets/#aggregate-time-series-data-with-time_bucket) .

It is similar but simplified due to the nature of our api. I had a need to be able to compute aggregates for `daily`, `weekly`, `monthly` and `yearly` reports for my now defunct web analytics project.

Some underlying code is direct port from `c` implementation on `timescaledb` see function `timeBucket` function.  There is a long way to go untill this is ready for review.