### PR TITLE
query: Add Contains operator

### DIFF
--- a/logictest/testdata/exec/filter/filter
+++ b/logictest/testdata/exec/filter/filter
@@ -129,3 +129,14 @@ select labels, timestamp, value where doesntexist >= 4
 exec
 select labels, timestamp, value where doesntexist <= 4
 ----
+
+exec
+select stacktrace, value where stacktrace LIKE 'ack'
+----
+stack1  1
+stack1  2
+stack1  3
+
+exec
+select stacktrace, value where stacktrace LIKE 'ack2'
+----

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -27,6 +27,7 @@ const (
 	OpRegexNotMatch
 	OpAnd
 	OpOr
+	OpContains
 )
 
 func (o Op) String() string {
@@ -51,6 +52,8 @@ func (o Op) String() string {
 		return "&&"
 	case OpOr:
 		return "||"
+	case OpContains:
+		return "|="
 	default:
 		panic("unknown operator")
 	}
@@ -275,6 +278,14 @@ func (c *Column) RegexNotMatch(pattern string) *BinaryExpr {
 	return &BinaryExpr{
 		Left:  c,
 		Op:    OpRegexNotMatch,
+		Right: Literal(pattern),
+	}
+}
+
+func (c *Column) Contains(pattern string) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpContains,
 		Right: Literal(pattern),
 	}
 }

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -63,7 +63,7 @@ func (f PreExprVisitorFunc) PostVisit(_ logicalplan.Expr) bool {
 
 func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) {
 	switch expr.Op {
-	case logicalplan.OpEq, logicalplan.OpNotEq, logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq, logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch:
+	case logicalplan.OpEq, logicalplan.OpNotEq, logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq, logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch, logicalplan.OpContains:
 		var leftColumnRef *ArrayRef
 		expr.Left.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {


### PR DESCRIPTION
Adding a `|=` operator to FrostDB.
It's basically `LIKE '%$foo%'` in SQL. It'll return true whenever the string contains the substring.
