### PR TITLE
Performance improvement on pqarrow.RecordDynamicCols

### DIFF
--- a/pqarrow/parquet_test.go
+++ b/pqarrow/parquet_test.go
@@ -86,3 +86,56 @@ func BenchmarkRecordsToFile(b *testing.B) {
 		}
 	}
 }
+
+func TestRecordDynamicCols(t *testing.T) {
+	build := array.NewRecordBuilder(memory.NewGoAllocator(),
+		arrow.NewSchema([]arrow.Field{
+			{
+				Name: "labels.label1",
+				Type: arrow.BinaryTypes.String,
+			},
+			{
+				Name: "labels.label2",
+				Type: arrow.BinaryTypes.String,
+			},
+			{
+				Name: "labels.label3",
+				Type: arrow.BinaryTypes.String,
+			},
+		}, nil),
+	)
+	defer build.Release()
+	r := build.NewRecord()
+
+	res := RecordDynamicCols(r)
+	require.Equal(t, map[string][]string{
+		"labels": {"label1", "label2", "label3"},
+	}, res)
+}
+
+func BenchmarkRecordDynamicCols(b *testing.B) {
+	build := array.NewRecordBuilder(memory.NewGoAllocator(),
+		arrow.NewSchema([]arrow.Field{
+			{
+				Name: "labels.label1",
+				Type: arrow.BinaryTypes.String,
+			},
+			{
+				Name: "labels.label2",
+				Type: arrow.BinaryTypes.String,
+			},
+			{
+				Name: "labels.label3",
+				Type: arrow.BinaryTypes.String,
+			},
+		}, nil),
+	)
+	defer build.Release()
+	r := build.NewRecord()
+	defer r.Release()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = RecordDynamicCols(r)
+	}
+}


### PR DESCRIPTION
This function is called on a hot path. I couldn't resist the temptation to squeeze some performance gains from it.

Benchmark results:

```
goos: darwin
goarch: amd64
pkg: github.com/polarsignals/frostdb/pqarrow
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
                    │    old.txt    │             new.txt             │
                    │    sec/op     │    sec/op     vs base           │
RecordDynamicCols-8   1470.0n ± ∞ ¹   792.6n ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                    │   old.txt   │            new.txt             │
                    │    B/op     │    B/op      vs base           │
RecordDynamicCols-8   936.0 ± ∞ ¹   536.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                    │   old.txt    │            new.txt             │
                    │  allocs/op   │  allocs/op   vs base           │
RecordDynamicCols-8   14.000 ± ∞ ¹   6.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```