### PR TITLE
parquet/converter: New Record call ResetFull on dictionary builders

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -359,6 +359,7 @@ func (c *ParquetConverter) NumRows() int {
 
 func (c *ParquetConverter) NewRecord() arrow.Record {
 	if c.builder != nil {
+		defer c.builder.Reset()
 		return c.builder.NewRecord()
 	}
 

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -359,11 +359,16 @@ func (c *ParquetConverter) NumRows() int {
 
 func (c *ParquetConverter) NewRecord() arrow.Record {
 	if c.builder != nil {
-		defer c.builder.Reset()
 		return c.builder.NewRecord()
 	}
 
 	return nil
+}
+
+func (c *ParquetConverter) Reset() {
+	if c.builder != nil {
+		c.builder.Reset()
+	}
 }
 
 func (c *ParquetConverter) Close() {

--- a/pqarrow/builder/recordbuilder.go
+++ b/pqarrow/builder/recordbuilder.go
@@ -117,3 +117,14 @@ func (b *RecordBuilder) ExpandSchema(schema *arrow.Schema) {
 
 	b.schema = schema
 }
+
+// Reset will call ResetFull on any dictionary builders to prevent memo tables from growing unbounded.
+func (b *RecordBuilder) Reset() {
+	for _, f := range b.fields {
+		if lb, ok := f.(*ListBuilder); ok {
+			if vb, ok := lb.ValueBuilder().(array.DictionaryBuilder); ok {
+				vb.ResetFull()
+			}
+		}
+	}
+}

--- a/table.go
+++ b/table.go
@@ -747,6 +747,7 @@ func (t *Table) Iterator(
 							err := func() error {
 								r := converter.NewRecord()
 								defer r.Release()
+								converter.Reset() // Reset the converter to drop any dictionaries that were built.
 								return callback(ctx, r)
 							}()
 							if err != nil {


### PR DESCRIPTION
This frees the dictionaries between record creations so that stale dictionary values aren't being held.

We were seeing huge storage spikes resulting from this dictionary bloat.