### PR TITLE
Optimize dynparquet.serializeDynamicColumns

### DIFF
--- a/dynparquet/dynamiccolumns.go
+++ b/dynparquet/dynamiccolumns.go
@@ -10,20 +10,32 @@ var ErrMalformedDynamicColumns = errors.New("malformed dynamic columns string")
 
 func serializeDynamicColumns(dynamicColumns map[string][]string) string {
 	names := make([]string, 0, len(dynamicColumns))
-	for name := range dynamicColumns {
+	var size int
+	for name, cols := range dynamicColumns {
 		names = append(names, name)
+		size += len(name) +
+			2 // separators
+		for i := range cols {
+			size += len(cols[i]) + 1
+		}
 	}
 	sort.Strings(names)
-
-	str := ""
+	var str strings.Builder
+	str.Grow(size)
 	for i, name := range names {
 		if i != 0 {
-			str += ";"
+			str.WriteByte(';')
 		}
-		str += name + ":" + strings.Join(dynamicColumns[name], ",")
+		str.WriteString(name)
+		str.WriteByte(':')
+		for j := range dynamicColumns[name] {
+			if j != 0 {
+				str.WriteByte(',')
+			}
+			str.WriteString(dynamicColumns[name][j])
+		}
 	}
-
-	return str
+	return str.String()
 }
 
 func deserializeDynamicColumns(columns string) (map[string][]string, error) {

--- a/dynparquet/dynamiccolumns_test.go
+++ b/dynparquet/dynamiccolumns_test.go
@@ -59,3 +59,21 @@ func BenchmarkDeserialization(b *testing.B) {
 		_, _ = deserializeDynamicColumns(input)
 	}
 }
+
+func BenchmarkSerialize(b *testing.B) {
+	input := map[string][]string{
+		"labels": {
+			"container",
+			"namespace",
+			"node",
+			"pod",
+		},
+		"pprof_labels": {
+			"profile_id",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = serializeDynamicColumns(input)
+	}
+}


### PR DESCRIPTION
This function is used in a hot path.

Benchmark results

```
goos: darwin
goarch: amd64
pkg: github.com/polarsignals/frostdb/dynparquet
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
            │   old.txt    │             new.txt             │
            │    sec/op    │    sec/op     vs base           │
Serialize-8   480.5n ± ∞ ¹   314.6n ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

            │   old.txt   │            new.txt             │
            │    B/op     │    B/op      vs base           │
Serialize-8   248.0 ± ∞ ¹   120.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

            │   old.txt   │            new.txt             │
            │  allocs/op  │  allocs/op   vs base           │
Serialize-8   6.000 ± ∞ ¹   3.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```