### PR TITLE
Optimize dynparquet..deserializeDynamicColumns

### DIFF
--- a/dynparquet/dynamiccolumns.go
+++ b/dynparquet/dynamiccolumns.go
@@ -26,25 +26,33 @@ func serializeDynamicColumns(dynamicColumns map[string][]string) string {
 	return str
 }
 
-func deserializeDynamicColumns(dynColString string) (map[string][]string, error) {
+func deserializeDynamicColumns(columns string) (map[string][]string, error) {
 	dynCols := map[string][]string{}
 
 	// handle case where the schema has no dynamic columnns
-	if len(dynColString) == 0 {
+	if len(columns) == 0 {
 		return dynCols, nil
 	}
-
-	for _, dynString := range strings.Split(dynColString, ";") {
-		split := strings.Split(dynString, ":")
-		if len(split) != 2 {
+	var column string
+	for {
+		if columns == "" {
+			return dynCols, nil
+		}
+		column, columns, _ = strings.Cut(columns, ";")
+		name, labels, ok := strings.Cut(column, ":")
+		if !ok {
 			return nil, ErrMalformedDynamicColumns
 		}
-		labelValues := strings.Split(split[1], ",")
-		if len(labelValues) == 1 && labelValues[0] == "" {
-			labelValues = []string{}
-		}
-		dynCols[split[0]] = labelValues
-	}
+		values := make([]string, 0, strings.Count(labels, ","))
 
-	return dynCols, nil
+		var label string
+		for {
+			if labels == "" {
+				break
+			}
+			label, labels, _ = strings.Cut(labels, ",")
+			values = append(values, label)
+		}
+		dynCols[name] = values
+	}
 }

--- a/dynparquet/dynamiccolumns_test.go
+++ b/dynparquet/dynamiccolumns_test.go
@@ -52,3 +52,10 @@ func TestDynamicColumnsDeserialization_NoDynamicColumns(t *testing.T) {
 	expected := map[string][]string{}
 	require.Equal(t, expected, output)
 }
+
+func BenchmarkDeserialization(b *testing.B) {
+	input := "labels:__name__;pprof_labels:;pprof_num_labels:bytes"
+	for i := 0; i < b.N; i++ {
+		_, _ = deserializeDynamicColumns(input)
+	}
+}


### PR DESCRIPTION
Benchmark result:

```
goos: darwin
goarch: amd64
pkg: github.com/polarsignals/frostdb/dynparquet
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
                  │   old.txt    │             new.txt             │
                  │    sec/op    │    sec/op     vs base           │
Deserialization-8   715.9n ± ∞ ¹   443.1n ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                  │   old.txt   │            new.txt             │
                  │    B/op     │    B/op      vs base           │
Deserialization-8   592.0 ± ∞ ¹   432.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                  │   old.txt   │            new.txt             │
                  │  allocs/op  │  allocs/op   vs base           │
Deserialization-8   9.000 ± ∞ ¹   4.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```