### PR TITLE
Simplify (*AndExpr).Eval

### DIFF
--- a/query/expr/filter.go
+++ b/query/expr/filter.go
@@ -145,9 +145,7 @@ func (a *AndExpr) Eval(p Particulate) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	// This stores the result in place to avoid allocations.
-	return left && right, nil
+	return right, nil
 }
 
 type OrExpr struct {


### PR DESCRIPTION
`(true && boolean) == boolean` no need for extra work. I also removed a comment that might be out of place, `right` is on the stack, there is no heap allocation.