### PR TITLE
Optimize pqarrow.recordToRows

### DIFF
--- a/pqarrow/parquet_test.go
+++ b/pqarrow/parquet_test.go
@@ -60,7 +60,6 @@ func BenchmarkRecordsToFile(b *testing.B) {
 	defer builder.Release()
 
 	const numRows = 1024
-	b.ResetTimer()
 	for i := 0; i < numRows; i++ {
 		builder.Field(0).(*array.Int64Builder).Append(int64(i))
 
@@ -78,6 +77,7 @@ func BenchmarkRecordsToFile(b *testing.B) {
 	}
 
 	record := builder.NewRecord()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := recordToRows(
 			noopWriter{}, func(string) bool { return false }, record, 0, numRows, parquetFields.Fields(),


### PR DESCRIPTION
From #599 It indicated to me any gains here will be good for `parca`. This is my first pass on it, there are still many opportunities to squeeze more performance from it.

Benchmark results

```
goos: darwin
goarch: amd64
pkg: github.com/polarsignals/frostdb/pqarrow
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
                │   old.txt    │             new.txt             │
                │    sec/op    │    sec/op     vs base           │
RecordsToFile-8   497.1µ ± ∞ ¹   364.1µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                │    old.txt    │             new.txt              │
                │     B/op      │     B/op       vs base           │
RecordsToFile-8   56.57Ki ± ∞ ¹   32.84Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                │   old.txt    │             new.txt             │
                │  allocs/op   │  allocs/op    vs base           │
RecordsToFile-8   3.079k ± ∞ ¹   2.062k ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```