### PR TITLE
Query concurrency option

### DIFF
--- a/query/physicalplan/aggregate_test.go
+++ b/query/physicalplan/aggregate_test.go
@@ -47,6 +47,7 @@ func Test_Aggregate_ArrayOverflow(t *testing.T) {
 		},
 		maphash.MakeSeed(),
 		false,
+		false,
 	)
 
 	totalRows := int64(0)

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -277,6 +277,8 @@ func WithOrderedAggregations() Option {
 	}
 }
 
+// WithConcurrency can be used to set the concurrency of the physical plan which decides how many callbacks from the scan layer can be processed concurrently.
+// The default concurrency is the number of logical CPUs.
 func WithConcurrency(concurrency int) Option {
 	return func(o *execOptions) {
 		o.concurrency = concurrency


### PR DESCRIPTION
Previously the query engine concurrency was hardcoded to GOMAXPROCS(0). This adds a physical plan option to manually set the concurrency in the query engine.

This exposed a bug with the query engine where if the concurrency was set to 1, aggregations would not work. So this also updates the aggregation code support not having multiple stages with a syncronizer and instead just having a single final aggregation step.

![](https://media.giphy.com/media/eeUJaTwsHh3tswkaYm/giphy.gif)