### PR TITLE
Optimize dynparquet.MergeDynamicColumnSets

### DIFF
--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1351,11 +1351,10 @@ func mergeDynamicRowGroupDynamicColumns(rowGroups []DynamicRowGroup) map[string]
 	return MergeDynamicColumnSets(sets)
 }
 
-func MergeDynamicColumnSets(sets []map[string][]string) (o map[string][]string) {
+func MergeDynamicColumnSets(sets []map[string][]string) map[string][]string {
 	m := newDynamicColumnSetMerger()
-	o = m.Merge(sets)
-	m.Release() // avoid defer penalty by releasing manually
-	return
+	defer m.Release()
+	return m.Merge(sets)
 }
 
 type dynColSet struct {

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -1350,47 +1351,67 @@ func mergeDynamicRowGroupDynamicColumns(rowGroups []DynamicRowGroup) map[string]
 	return MergeDynamicColumnSets(sets)
 }
 
-func MergeDynamicColumnSets(sets []map[string][]string) map[string][]string {
-	dynamicColumns := map[string][][]string{}
-	for _, set := range sets {
-		for k, v := range set {
-			_, seen := dynamicColumns[k]
-			if !seen {
-				dynamicColumns[k] = [][]string{}
-			}
-			dynamicColumns[k] = append(dynamicColumns[k], v)
-		}
-	}
-
-	resultDynamicColumns := map[string][]string{}
-	for name, dynCols := range dynamicColumns {
-		resultDynamicColumns[name] = mergeDynamicColumns(dynCols)
-	}
-
-	return resultDynamicColumns
+func MergeDynamicColumnSets(sets []map[string][]string) (o map[string][]string) {
+	m := newDynamicColumnSetMerger()
+	o = m.Merge(sets)
+	m.Release() // avoid defer penalty by releasing manually
+	return
 }
 
-// mergeDynamicColumns merges the given concrete dynamic column names into a
-// single superset. It assumes that the given DynamicColumns are all for the
-// same dynamic column name.
-func mergeDynamicColumns(dyn [][]string) []string {
-	return mergeStrings(dyn)
+type dynColSet struct {
+	keys   []string
+	seen   map[string]struct{}
+	values []string
 }
 
-// mergeStrings merges the given sorted string slices into a single sorted and
-// deduplicated slice of strings.
-func mergeStrings(str [][]string) []string {
-	result := []string{}
-	seen := map[string]struct{}{}
-	for _, s := range str {
-		for _, n := range s {
-			if _, ok := seen[n]; !ok {
-				result = append(result, n)
-				seen[n] = struct{}{}
+func newDynamicColumnSetMerger() *dynColSet {
+	return mergeSetPool.Get().(*dynColSet)
+}
+
+var mergeSetPool = &sync.Pool{New: func() any {
+	return &dynColSet{
+		seen:   make(map[string]struct{}),
+		keys:   make([]string, 0, 16), // This is arbitrary we anticipate to be lower than values size
+		values: make([]string, 0, 64), // This is arbitrary
+	}
+}}
+
+func (c *dynColSet) Release() {
+	c.keys = c.keys[:0]
+	clear(c.seen)
+	c.values = c.values[:0]
+	mergeSetPool.Put(c)
+}
+
+func (c *dynColSet) Merge(sets []map[string][]string) (o map[string][]string) {
+	o = make(map[string][]string)
+	for i := range sets {
+		for k := range sets[i] {
+			if _, ok := c.seen[k]; !ok {
+				c.keys = append(c.keys, k)
+				c.seen[k] = struct{}{}
 			}
 		}
 	}
-	return MergeDeduplicatedDynCols(result)
+	for i := range c.keys {
+		clear(c.seen)
+		for j := range sets {
+			ls, ok := sets[j][c.keys[i]]
+			if !ok {
+				continue
+			}
+			for k := range ls {
+				if _, ok := c.seen[ls[k]]; !ok {
+					c.values = append(c.values, ls[k])
+					c.seen[ls[k]] = struct{}{}
+				}
+			}
+		}
+		sort.Strings(c.values)
+		o[c.keys[i]] = slices.Clone(c.values)
+		c.values = c.values[:0]
+	}
+	return
 }
 
 // MergeDeduplicatedDynCols is a light wrapper over sorting the deduplicated

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1383,7 +1383,7 @@ func (c *dynColSet) Release() {
 }
 
 func (c *dynColSet) Merge(sets []map[string][]string) (o map[string][]string) {
-	//TODO:(gernest) use k-way merge
+	// TODO:(gernest) use k-way merge
 	o = make(map[string][]string)
 	for i := range sets {
 		for k := range sets[i] {

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1383,6 +1383,7 @@ func (c *dynColSet) Release() {
 }
 
 func (c *dynColSet) Merge(sets []map[string][]string) (o map[string][]string) {
+	//TODO:(gernest) use k-way merge
 	o = make(map[string][]string)
 	for i := range sets {
 		for k := range sets[i] {

--- a/dynparquet/schema_test.go
+++ b/dynparquet/schema_test.go
@@ -354,3 +354,42 @@ func BenchmarkIsDynamicColumn(b *testing.B) {
 		_ = schema.IsDynamicColumn("labels.label1")
 	}
 }
+
+func TestMergeDynamicColumnSets(t *testing.T) {
+	sets := []map[string][]string{
+		{"labels": {"label1", "label2"}},
+		{"labels": {"label1", "label2"}},
+		{"labels": {"label1", "label2", "label3"}},
+		{
+			"labels": {"label1", "label2"},
+			"foo":    {"label1", "label2"},
+		},
+		{
+			"labels": {"label1", "label2", "label3"},
+			"foo":    {"label1", "label2", "label3"},
+		},
+	}
+	require.Equal(t, map[string][]string{
+		"foo":    {"label1", "label2", "label3"},
+		"labels": {"label1", "label2", "label3"},
+	}, MergeDynamicColumnSets(sets))
+}
+
+func BenchmarkMergeDynamicColumnSets(b *testing.B) {
+	sets := []map[string][]string{
+		{"labels": {"label1", "label2"}},
+		{"labels": {"label1", "label2"}},
+		{"labels": {"label1", "label2", "label3"}},
+		{
+			"labels": {"label1", "label2"},
+			"foo":    {"label1", "label2"},
+		},
+		{
+			"labels": {"label1", "label2", "label3"},
+			"foo":    {"label1", "label2", "label3"},
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		MergeDynamicColumnSets(sets)
+	}
+}


### PR DESCRIPTION
This commit

- Adds test (There were no test covering this function)
- Introduce a new implementation for merging column sets that can be reused.
- Use `*sync.Pool` to reuse the new dynamic column set merger

Benchmark result

```
goos: darwin
goarch: amd64
pkg: github.com/polarsignals/frostdb/dynparquet
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
                         │   old.txt   │               new.txt               │
                         │   sec/op    │   sec/op     vs base                │
MergeDynamicColumnSets-8   2.220µ ± 1%   1.330µ ± 1%  -40.09% (p=0.000 n=10)

                         │   old.txt   │              new.txt               │
                         │    B/op     │    B/op     vs base                │
MergeDynamicColumnSets-8   1104.0 ± 0%   544.0 ± 0%  -50.72% (p=0.000 n=10)

                         │   old.txt   │              new.txt               │
                         │  allocs/op  │ allocs/op   vs base                │
MergeDynamicColumnSets-8   16.000 ± 0%   6.000 ± 0%  -62.50% (p=0.000 n=10)
```