### PR TITLE
Persistent lsm

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -1,0 +1,198 @@
+package frostdb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/go-kit/log/level"
+	"github.com/parquet-go/parquet-go"
+	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/polarsignals/frostdb/parts"
+)
+
+var (
+	ErrCompactionRecoveryFailed = fmt.Errorf("failed to recover compacted level")
+)
+
+type fileCompaction struct {
+	t      *Table
+	file   *os.File
+	offset int64 // Writing offsets into the file
+	ref    int64 // Number of references to file.
+}
+
+func (f *fileCompaction) Close() error {
+	return f.file.Close()
+}
+
+func NewFileCompaction(t *Table, lvl int) *fileCompaction {
+	f := &fileCompaction{
+		t: t,
+	}
+
+	if t.db.storagePath == "" { // No storage path provided, use temp files.
+		file, err := os.CreateTemp("", fmt.Sprintf("L%v-*.parquet", lvl))
+		if err != nil {
+			panic(err)
+		}
+		level.Info(t.logger).Log("msg", "created temp file for level", "level", lvl, "file", file.Name())
+		f.file = file
+		return f
+	}
+
+	indexDir := t.db.indexDir()
+	if err := os.MkdirAll(indexDir, dirPerms); err != nil {
+		panic(err)
+	}
+
+	file, err := os.OpenFile(filepath.Join(indexDir, fmt.Sprintf("L%v.parquet", lvl)), os.O_CREATE|os.O_RDWR, filePerms)
+	if err != nil {
+		panic(err)
+	}
+	f.file = file
+	return f
+}
+
+// accountingWriter is a writer that accounts for the number of bytes written.
+type accountingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (a *accountingWriter) Write(p []byte) (int, error) {
+	n, err := a.w.Write(p)
+	a.n += int64(n)
+	return n, err
+}
+
+// writeRecordsToParquetFile will compact the given parts into a Parquet file written to the next level file.
+func (f *fileCompaction) writeRecordsToParquetFile(compact []parts.Part, options ...parts.Option) ([]parts.Part, int64, int64, error) {
+	if len(compact) == 0 {
+		return nil, 0, 0, fmt.Errorf("no parts to compact")
+	}
+
+	accountant := &accountingWriter{w: f.file}
+	preCompactionSize, err := f.t.compactParts(accountant, compact,
+		parquet.KeyValueMetadata(
+			"compaction_tx", // Compacting up through this transaction.
+			fmt.Sprintf("%v", compact[0].TX()),
+		),
+	) // compact into the next level
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	// Record the writing offset into the file.
+	prevOffset := f.offset
+	f.offset += accountant.n + 8
+	f.ref++
+
+	// Record the file size for recovery.
+	size := make([]byte, 8)
+	binary.LittleEndian.PutUint64(size, uint64(accountant.n))
+	if n, err := f.file.Write(size); n != 8 {
+		return nil, 0, 0, fmt.Errorf("failed to write size to file: %v", err)
+	}
+
+	pf, err := parquet.OpenFile(io.NewSectionReader(f.file, prevOffset, accountant.n), accountant.n)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	buf, err := dynparquet.NewSerializedBuffer(pf)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	return []parts.Part{parts.NewParquetPart(compact[0].TX(), buf, append(options, parts.WithRelease(f.release()))...)}, preCompactionSize, accountant.n, nil
+}
+
+// Truncate will truncate the file to 0 bytes. This is used when a compaction recovery fails.
+func (f *fileCompaction) Truncate() error {
+	return f.file.Truncate(0)
+}
+
+// release will account for all the Parts currently pointing to this file. Once the last one has been released it will truncate the file.
+// release is not safe to call concurrently.
+func (f *fileCompaction) release() func() {
+	return func() {
+		f.ref--
+		if f.ref == 0 {
+			level.Info(f.t.logger).Log("msg", "truncating file", "file", f.file.Name())
+			if err := os.Truncate(f.file.Name(), 0); err != nil {
+				panic(fmt.Errorf("failed to truncate the level file: %v", err))
+			}
+
+			f.offset = 0
+			if _, err := f.file.Seek(0, io.SeekStart); err != nil {
+				panic(fmt.Errorf("failed to seek the level file: %v", err))
+			}
+		}
+	}
+}
+
+func (f *fileCompaction) recover(options ...parts.Option) ([]parts.Part, error) {
+	recovered, err := func() ([]parts.Part, error) {
+		info, err := os.Stat(f.file.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		if info.Size() == 0 { // file was truncated, nothing to recover.
+			return nil, nil
+		}
+
+		recovered := []parts.Part{}
+
+		// Recover all parts from file.
+		for offset := info.Size(); offset > 0; {
+			offset -= 8
+			size := make([]byte, 8)
+			if n, err := f.file.ReadAt(size, offset); n != 8 {
+				return nil, fmt.Errorf("failed to read size from file: %v", err)
+			}
+			parquetSize := int64(binary.LittleEndian.Uint64(size))
+			offset -= parquetSize
+
+			pf, err := parquet.OpenFile(io.NewSectionReader(f.file, offset, parquetSize), parquetSize)
+			if err != nil {
+				return nil, err
+			}
+
+			buf, err := dynparquet.NewSerializedBuffer(pf)
+			if err != nil {
+				return nil, err
+			}
+
+			txstr, ok := buf.ParquetFile().Lookup("compaction_tx")
+			if !ok {
+				return nil, fmt.Errorf("failed to find compaction_tx metadata")
+			}
+
+			tx, err := strconv.Atoi(txstr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse compaction_tx metadata: %v", err)
+			}
+
+			recovered = append(recovered, parts.NewParquetPart(uint64(tx), buf, append(options, parts.WithRelease(f.release()))...))
+		}
+
+		return recovered, nil
+	}()
+
+	// If we failed to recover the file, truncate it.
+	if err != nil {
+		level.Error(f.t.logger).Log("msg", "truncating file after failed recovery", "err", err, "file", f.file.Name())
+		if err := os.Truncate(f.file.Name(), 0); err != nil {
+			return nil, fmt.Errorf("failed to truncate the level file %s: %v", f.file.Name(), err)
+		}
+
+		return nil, ErrCompactionRecoveryFailed
+	}
+
+	return recovered, err
+}

--- a/compaction.go
+++ b/compaction.go
@@ -43,7 +43,7 @@ func NewFileCompaction(t *Table, lvl int) *FileCompaction {
 		return f
 	}
 
-	indexDir := t.db.indexDir()
+	indexDir := filepath.Join(t.db.indexDir(), t.name)
 	if err := os.MkdirAll(indexDir, dirPerms); err != nil {
 		panic(err)
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -29,8 +29,14 @@ type FileCompaction struct {
 	ref    int64 // Number of references to file.
 }
 
-func (f *FileCompaction) Close() error {
-	return f.file.Close()
+func (f *FileCompaction) Close(cleanup bool) error {
+	err := f.file.Close()
+	if cleanup {
+		if err := os.Remove(f.file.Name()); err != nil {
+			return fmt.Errorf("failed to remove file: %v", err)
+		}
+	}
+	return err
 }
 
 func NewFileCompaction(t *Table, block ulid.ULID, lvl int) *FileCompaction {

--- a/compaction.go
+++ b/compaction.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid"
 	"github.com/parquet-go/parquet-go"
 
 	"github.com/polarsignals/frostdb/dynparquet"
@@ -32,7 +33,7 @@ func (f *FileCompaction) Close() error {
 	return f.file.Close()
 }
 
-func NewFileCompaction(t *Table, lvl int) *FileCompaction {
+func NewFileCompaction(t *Table, block ulid.ULID, lvl int) *FileCompaction {
 	f := &FileCompaction{
 		t: t,
 	}
@@ -52,7 +53,7 @@ func NewFileCompaction(t *Table, lvl int) *FileCompaction {
 		panic(err)
 	}
 
-	file, err := os.OpenFile(filepath.Join(indexDir, fmt.Sprintf("L%v.parquet", lvl)), os.O_CREATE|os.O_RDWR, filePerms)
+	file, err := os.OpenFile(filepath.Join(indexDir, fmt.Sprintf("L%v-%s.parquet", lvl, block.String())), os.O_CREATE|os.O_RDWR, filePerms)
 	if err != nil {
 		panic(err)
 	}

--- a/compaction.go
+++ b/compaction.go
@@ -197,3 +197,6 @@ func (f *FileCompaction) recover(options ...parts.Option) ([]parts.Part, error) 
 
 	return recovered, err
 }
+
+// Sync calls Sync on the underlying file.
+func (f *FileCompaction) Sync() error { return f.file.Sync() }

--- a/compaction.go
+++ b/compaction.go
@@ -15,6 +15,10 @@ import (
 	"github.com/polarsignals/frostdb/parts"
 )
 
+const (
+	ParquetCompactionTXKey = "compaction_tx"
+)
+
 var ErrCompactionRecoveryFailed = fmt.Errorf("failed to recover compacted level")
 
 type FileCompaction struct {
@@ -77,7 +81,7 @@ func (f *FileCompaction) writeRecordsToParquetFile(compact []parts.Part, options
 	accountant := &accountingWriter{w: f.file}
 	preCompactionSize, err := f.t.compactParts(accountant, compact,
 		parquet.KeyValueMetadata(
-			"compaction_tx", // Compacting up through this transaction.
+			ParquetCompactionTXKey, // Compacting up through this transaction.
 			fmt.Sprintf("%v", compact[0].TX()),
 		),
 	) // compact into the next level
@@ -167,7 +171,7 @@ func (f *FileCompaction) recover(options ...parts.Option) ([]parts.Part, error) 
 				return nil, err
 			}
 
-			txstr, ok := buf.ParquetFile().Lookup("compaction_tx")
+			txstr, ok := buf.ParquetFile().Lookup(ParquetCompactionTXKey)
 			if !ok {
 				return nil, fmt.Errorf("failed to find compaction_tx metadata")
 			}

--- a/db.go
+++ b/db.go
@@ -912,6 +912,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 				if err != nil {
 					return fmt.Errorf("read record: %w", err)
 				}
+				defer reader.Release()
 
 				// TODO: the issue with this is we aren't prehashing the columns by not doing InsertRecord.
 				// If we prehash before WAL write we don't have to do that here.

--- a/db.go
+++ b/db.go
@@ -749,7 +749,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 				// already been persisted.
 				db.mtx.Lock()
 				if table, ok := db.tables[e.TableBlockPersisted.TableName]; ok {
-					cfg, recovered, err := table.configureLSMLevels(db.columnStore.indexConfig)
+					cfg, recovered, err := table.configureLSMLevels(db.columnStore.indexConfig, table.ActiveBlock().ulid)
 					if err != nil {
 						return fmt.Errorf("configure lsm levels: %w", err)
 					}

--- a/db.go
+++ b/db.go
@@ -749,7 +749,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 				// already been persisted.
 				db.mtx.Lock()
 				if table, ok := db.tables[e.TableBlockPersisted.TableName]; ok {
-					cfg, recovered, err := table.configureLSMLevels(db.columnStore.indexConfig, table.ActiveBlock().ulid)
+					cfg, recovered, err := table.ActiveBlock().configureLSMLevels(db.columnStore.indexConfig)
 					if err != nil {
 						return fmt.Errorf("configure lsm levels: %w", err)
 					}

--- a/db.go
+++ b/db.go
@@ -1313,7 +1313,7 @@ func (db *DB) resetToTxn(txn uint64, wal WAL) {
 		// Before resetting the wal make sure any pending writes to the index are flushed.
 		errg := errgroup.Group{}
 		for _, table := range db.tables {
-			for _, syncer := range table.syncers {
+			for _, syncer := range table.ActiveBlock().syncers {
 				errg.Go(syncer.Sync)
 			}
 		}

--- a/db.go
+++ b/db.go
@@ -1145,6 +1145,10 @@ func (db *DB) promoteReadOnlyTableLocked(name string, config *tablepb.TableConfi
 
 // Table will get or create a new table with the given name and config. If a table already exists with the given name, it will have it's configuration updated.
 func (db *DB) Table(name string, config *tablepb.TableConfig) (*Table, error) {
+	return db.table(name, config, generateULID())
+}
+
+func (db *DB) table(name string, config *tablepb.TableConfig, id ulid.ULID) (*Table, error) {
 	if config == nil {
 		return nil, fmt.Errorf("table config cannot be nil")
 	}
@@ -1195,7 +1199,6 @@ func (db *DB) Table(name string, config *tablepb.TableConfig) (*Table, error) {
 	tx, _, commit := db.begin()
 	defer commit()
 
-	id := generateULID()
 	if err := table.newTableBlock(0, tx, id); err != nil {
 		return nil, err
 	}

--- a/db.go
+++ b/db.go
@@ -1305,7 +1305,6 @@ func (db *DB) resetToTxn(txn uint64, wal WAL) {
 	db.tx.Store(txn)
 	db.highWatermark.Store(txn)
 	if wal != nil {
-
 		// Before resetting the wal make sure any pending writes to the index are flushed.
 		errg := errgroup.Group{}
 		for _, table := range db.tables {

--- a/db_test.go
+++ b/db_test.go
@@ -2493,7 +2493,7 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 	}
 }
 
-// Ensure data integrity when a block is rotated
+// Ensure data integrity when a block is rotated.
 func Test_DB_PersistentDiskCompaction_BlockRotation(t *testing.T) {
 	t.Parallel()
 	config := NewTableConfig(
@@ -2568,7 +2568,7 @@ func Test_DB_PersistentDiskCompaction_BlockRotation(t *testing.T) {
 	validateRows(1200)
 
 	// Rotate block
-	require.NoError(t, table.RotateBlock(nil, table.ActiveBlock(), false))
+	require.NoError(t, table.RotateBlock(context.Background(), table.ActiveBlock(), false))
 
 	validateRows(1200)
 

--- a/db_test.go
+++ b/db_test.go
@@ -2301,7 +2301,7 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 			finalRows:   1200,
 			beforeReplay: func(dir string) {
 				// Corrupt the LSM file; this should trigger a recovery from the WAL
-				levelFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet")
+				levelFile := filepath.Join(dir, "databases", "test", "index", "test", "L1.parquet")
 				info, err := os.Stat(levelFile)
 				require.NoError(t, err)
 				require.NoError(t, os.Truncate(levelFile, info.Size()-1)) // truncate the last byte to pretend the write didn't finish
@@ -2314,7 +2314,7 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 			finalRows:   1200,
 			beforeReplay: func(dir string) {
 				// Corrupt the LSM file; this should trigger a recovery from the WAL
-				levelFile := filepath.Join(dir, "databases", "test", "index", "L2.parquet")
+				levelFile := filepath.Join(dir, "databases", "test", "index", "test", "L2.parquet")
 				info, err := os.Stat(levelFile)
 				require.NoError(t, err)
 				require.NoError(t, os.Truncate(levelFile, info.Size()-1)) // truncate the last byte to pretend the write didn't finish
@@ -2327,11 +2327,11 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 			beforeReplay: func(dir string) {},
 			beforeClose: func(table *Table, dir string) { // trigger a compaction, but save off the L1 file and move it back. This mimics a failure to truncate the L1 file
 				// Save the L1 file
-				levelFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet")
+				levelFile := filepath.Join(dir, "databases", "test", "index", "test", "L1.parquet")
 				src, err := os.Open(levelFile)
 				require.NoError(t, err)
 
-				saveFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet.sav")
+				saveFile := filepath.Join(dir, "databases", "test", "index", "test", "L1.parquet.sav")
 				dst, err := os.Create(saveFile)
 				require.NoError(t, err)
 

--- a/db_test.go
+++ b/db_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/polarsignals/frostdb/dynparquet"
 	schemapb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha1"
 	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
+	"github.com/polarsignals/frostdb/index"
 	"github.com/polarsignals/frostdb/query"
 	"github.com/polarsignals/frostdb/query/logicalplan"
 	"github.com/polarsignals/frostdb/query/physicalplan"
@@ -2270,4 +2271,228 @@ func Test_DB_WithParquetDiskCompaction(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(300), rows)
+}
+
+func Test_DB_PersistentDiskCompaction(t *testing.T) {
+	t.Parallel()
+	config := NewTableConfig(
+		dynparquet.SampleDefinition(),
+	)
+	logger := newTestLogger(t)
+
+	tests := map[string]struct {
+		beforeReplay func(dir string)
+		beforeClose  func(table *Table, dir string)
+		lvl2Parts    int
+		lvl1Parts    int
+		finalRows    int64
+	}{
+		"happy path": {
+			beforeReplay: func(dir string) {},
+			beforeClose:  func(table *Table, dir string) {},
+			lvl2Parts:    3,
+			lvl1Parts:    1,
+			finalRows:    1200,
+		},
+		"corrupted L1": {
+			beforeClose: func(table *Table, dir string) {},
+			lvl2Parts:   3,
+			lvl1Parts:   1,
+			finalRows:   1200,
+			beforeReplay: func(dir string) {
+
+				// Corrupt the LSM file; this should trigger a recovery from the WAL
+				levelFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet")
+				info, err := os.Stat(levelFile)
+				require.NoError(t, err)
+				require.NoError(t, os.Truncate(levelFile, info.Size()-1)) // truncate the last byte to pretend the write didn't finish
+			},
+		},
+		"corrupted L2": {
+			beforeClose: func(table *Table, dir string) {},
+			lvl2Parts:   3,
+			lvl1Parts:   1,
+			finalRows:   1200,
+			beforeReplay: func(dir string) {
+
+				// Corrupt the LSM file; this should trigger a recovery from the WAL
+				levelFile := filepath.Join(dir, "databases", "test", "index", "L2.parquet")
+				info, err := os.Stat(levelFile)
+				require.NoError(t, err)
+				require.NoError(t, os.Truncate(levelFile, info.Size()-1)) // truncate the last byte to pretend the write didn't finish
+			},
+		},
+		"untruncated L1": { // Test that if we fail to truncate the L1 file, we can still recover
+			lvl2Parts:    4,
+			lvl1Parts:    1,
+			finalRows:    1200,
+			beforeReplay: func(dir string) {},
+			beforeClose: func(table *Table, dir string) { // trigger a compaction, but save off the L1 file and move it back. This mimics a failure to truncate the L1 file
+				// Save the L1 file
+				levelFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet")
+				src, err := os.Open(levelFile)
+				require.NoError(t, err)
+
+				saveFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet.sav")
+				dst, err := os.Create(saveFile)
+				require.NoError(t, err)
+
+				_, err = io.Copy(dst, src)
+				require.NoError(t, err)
+				dst.Close()
+				src.Close()
+
+				// This truncates the L1 file
+				require.NoError(t, table.EnsureCompaction())
+
+				fmt.Println(table.active.index)
+
+				// Move the L1 file back
+				require.NoError(t, os.Rename(saveFile, levelFile))
+			},
+		},
+		"snapshot": {
+			beforeReplay: func(dir string) {},
+			beforeClose: func(table *Table, dir string) {
+				// trigger a snapshot
+				tx := table.db.highWatermark.Load()
+				require.NoError(t, table.db.snapshotAtTX(context.Background(), tx, table.db.snapshotWriter(tx)))
+
+				// Write more to the table and trigger a compaction
+				samples := dynparquet.NewTestSamples()
+				for j := 0; j < 100; j++ {
+					r, err := samples.ToRecord()
+					require.NoError(t, err)
+					_, err = table.InsertRecord(context.Background(), r)
+					require.NoError(t, err)
+				}
+				require.Eventually(t, func() bool {
+					return table.active.index.LevelSize(index.L1) != 0
+				}, time.Second, time.Millisecond*10)
+			},
+			lvl2Parts: 3,
+			lvl1Parts: 2,
+			finalRows: 1500,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			dir := t.TempDir()
+
+			cfg := []*IndexConfig{
+				{Level: int(index.L0), MaxSize: 25700, Type: CompactionTypeParquetDisk},
+				{Level: int(index.L1), MaxSize: 1024 * 1024 * 128, Type: CompactionTypeParquetDisk},
+				{Level: int(index.L2), MaxSize: 1024 * 1024 * 512},
+			}
+			c, err := New(
+				WithLogger(logger),
+				WithIndexConfig(cfg),
+				WithStoragePath(dir),
+				WithWAL(),
+			)
+			t.Cleanup(func() {
+				require.NoError(t, c.Close())
+			})
+			require.NoError(t, err)
+			db, err := c.DB(context.Background(), "test")
+			require.NoError(t, err)
+			table, err := db.Table("test", config)
+			require.NoError(t, err)
+
+			samples := dynparquet.NewTestSamples()
+
+			ctx := context.Background()
+			compactions := 3 // 3 compacted parts in L2 file
+			for i := 0; i < compactions; i++ {
+				for j := 0; j < 100; j++ {
+					r, err := samples.ToRecord()
+					require.NoError(t, err)
+					_, err = table.InsertRecord(ctx, r)
+					require.NoError(t, err)
+				}
+				require.NoError(t, table.EnsureCompaction())
+			}
+
+			for j := 0; j < 100; j++ {
+				r, err := samples.ToRecord()
+				require.NoError(t, err)
+				_, err = table.InsertRecord(ctx, r)
+				require.NoError(t, err)
+			}
+			require.Eventually(t, func() bool {
+				return table.active.index.LevelSize(index.L1) != 0
+			}, time.Second, time.Millisecond*10)
+
+			// Ensure that disk compacted data can be recovered
+			pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+			defer pool.AssertSize(t, 0)
+			rows := int64(0)
+			engine := query.NewEngine(pool, db.TableProvider())
+			err = engine.ScanTable("test").
+				Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+					rows += r.NumRows()
+					return nil
+				})
+			require.NoError(t, err)
+			require.Equal(t, int64((300*compactions)+300), rows)
+
+			test.beforeClose(table, dir)
+
+			// Close the database
+			wm := db.highWatermark.Load()
+			require.NoError(t, c.Close())
+
+			fc := NewFileCompaction(table, 2)
+			p, err := fc.recover()
+			require.NoError(t, err)
+			require.Equal(t, test.lvl2Parts, len(p))
+
+			for i := 0; i < compactions; i++ {
+				buf, err := p[i].AsSerializedBuffer(nil)
+				require.NoError(t, err)
+				tx, ok := buf.ParquetFile().Lookup("compaction_tx")
+				require.True(t, ok)
+				require.Equal(t, fmt.Sprintf("%v", test.lvl2Parts*100-(i*100)+1), tx)
+			}
+
+			fc = NewFileCompaction(table, 1)
+			p, err = fc.recover()
+			require.NoError(t, err)
+			require.Equal(t, test.lvl1Parts, len(p))
+
+			buf, err := p[0].AsSerializedBuffer(nil)
+			require.NoError(t, err)
+			tx, ok := buf.ParquetFile().Lookup("compaction_tx")
+			require.True(t, ok)
+			require.Equal(t, fmt.Sprintf("%v", wm), tx)
+
+			// Run the beforeReplay hook
+			test.beforeReplay(dir)
+
+			// Reopen database; expect it to recover from the LSM files and WAL
+			c, err = New(
+				WithLogger(logger),
+				WithIndexConfig(cfg),
+				WithStoragePath(dir),
+				WithWAL(),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, c.Close())
+			})
+			db, err = c.DB(context.Background(), "test")
+
+			rows = int64(0)
+			engine = query.NewEngine(pool, db.TableProvider())
+			err = engine.ScanTable("test").
+				Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+					rows += r.NumRows()
+					return nil
+				})
+			require.NoError(t, err)
+			require.Equal(t, test.finalRows, rows)
+		})
+	}
 }

--- a/db_test.go
+++ b/db_test.go
@@ -2300,7 +2300,6 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 			lvl1Parts:   1,
 			finalRows:   1200,
 			beforeReplay: func(dir string) {
-
 				// Corrupt the LSM file; this should trigger a recovery from the WAL
 				levelFile := filepath.Join(dir, "databases", "test", "index", "L1.parquet")
 				info, err := os.Stat(levelFile)
@@ -2314,7 +2313,6 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 			lvl1Parts:   1,
 			finalRows:   1200,
 			beforeReplay: func(dir string) {
-
 				// Corrupt the LSM file; this should trigger a recovery from the WAL
 				levelFile := filepath.Join(dir, "databases", "test", "index", "L2.parquet")
 				info, err := os.Stat(levelFile)
@@ -2344,8 +2342,6 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 
 				// This truncates the L1 file
 				require.NoError(t, table.EnsureCompaction())
-
-				fmt.Println(table.active.index)
 
 				// Move the L1 file back
 				require.NoError(t, os.Rename(saveFile, levelFile))
@@ -2378,9 +2374,7 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			dir := t.TempDir()
-
 			cfg := []*IndexConfig{
 				{Level: int(index.L0), MaxSize: 25700, Type: CompactionTypeParquetDisk},
 				{Level: int(index.L1), MaxSize: 1024 * 1024 * 128, Type: CompactionTypeParquetDisk},
@@ -2483,6 +2477,7 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 				require.NoError(t, c.Close())
 			})
 			db, err = c.DB(context.Background(), "test")
+			require.NoError(t, err)
 
 			rows = int64(0)
 			engine = query.NewEngine(pool, db.TableProvider())

--- a/dynparquet/schema.go
+++ b/dynparquet/schema.go
@@ -1072,7 +1072,7 @@ const bloomFilterBitsPerValue = 10
 
 // NewWriter returns a new parquet writer with a concrete parquet schema
 // generated using the given concrete dynamic column names.
-func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string, sorting bool) (ParquetWriter, error) {
+func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string, sorting bool, options ...parquet.WriterOption) (ParquetWriter, error) {
 	ps, err := s.GetDynamicParquetSchema(dynamicColumns)
 	if err != nil {
 		return nil, err
@@ -1109,6 +1109,7 @@ func (s *Schema) NewWriter(w io.Writer, dynamicColumns map[string][]string, sort
 			parquet.SortingColumns(cols...),
 		),
 	}
+	writerOptions = append(writerOptions, options...)
 	if sorting {
 		return parquet.NewSortingWriter[any](w, 32*1024, writerOptions...), nil
 	}

--- a/index/lsm.go
+++ b/index/lsm.go
@@ -204,6 +204,10 @@ func (l *LSM) InsertPart(part parts.Part) {
 		}
 	}
 
+	if r := part.Record(); r != nil {
+		r.Retain()
+	}
+
 	if tx := part.TX(); tx > l.maxTXRecoverd[level] {
 		l.maxTXRecoverd[level] = tx
 	}

--- a/index/lsm.go
+++ b/index/lsm.go
@@ -33,13 +33,16 @@ type LSM struct {
 
 	schema *dynparquet.Schema
 
-	prefix  string
-	levels  *Node
-	sizes   []atomic.Int64
-	configs []*LevelConfig
+	prefix        string
+	maxTXRecoverd []uint64
+	levels        *Node
+	sizes         []atomic.Int64
+	configs       []*LevelConfig
 
+	// Options
 	logger  log.Logger
 	metrics *LSMMetrics
+	wait    func(uint64)
 }
 
 // LSMMetrics are the metrics for an LSM index.
@@ -94,19 +97,21 @@ func NewLSMMetrics(reg prometheus.Registerer) *LSMMetrics {
 }
 
 // NewLSM returns an LSM-like index of len(levels) levels.
-func NewLSM(prefix string, schema *dynparquet.Schema, levels []*LevelConfig, options ...LSMOption) (*LSM, error) {
+func NewLSM(prefix string, schema *dynparquet.Schema, levels []*LevelConfig, wait func(uint64), options ...LSMOption) (*LSM, error) {
 	if err := validateLevels(levels); err != nil {
 		return nil, err
 	}
 
 	lsm := &LSM{
-		schema:     schema,
-		prefix:     prefix,
-		levels:     NewList(L0),
-		sizes:      make([]atomic.Int64, len(levels)),
-		configs:    levels,
-		compacting: &atomic.Bool{},
-		logger:     log.NewNopLogger(),
+		schema:        schema,
+		prefix:        prefix,
+		maxTXRecoverd: make([]uint64, len(levels)),
+		levels:        NewList(L0),
+		sizes:         make([]atomic.Int64, len(levels)),
+		configs:       levels,
+		compacting:    &atomic.Bool{},
+		logger:        log.NewNopLogger(),
+		wait:          wait,
 	}
 
 	for _, opt := range options {
@@ -167,7 +172,7 @@ func (l *LSM) MaxLevel() SentinelType {
 func (l *LSM) Add(tx uint64, record arrow.Record) {
 	record.Retain()
 	size := util.TotalRecordSize(record)
-	l.levels.Prepend(parts.NewArrowPart(tx, record, uint64(size), l.schema, parts.WithCompactionLevel(int(L0))))
+	l.levels.Insert(parts.NewArrowPart(tx, record, uint64(size), l.schema, parts.WithCompactionLevel(int(L0))))
 	l0 := l.sizes[L0].Add(int64(size))
 	l.metrics.LevelSize.WithLabelValues(L0.String()).Set(float64(l0))
 	if l0 >= l.configs[L0].MaxSize {
@@ -186,9 +191,25 @@ func (l *LSM) WaitForPendingCompactions() {
 }
 
 // InsertPart inserts a part into the LSM tree. It will be inserted into the correct level. It does not check if the insert should cause a compaction.
-// This should only be used during snapshot recovery.
-func (l *LSM) InsertPart(level SentinelType, part parts.Part) {
-	l.findLevel(level).Prepend(part)
+// This should only be used during snapshot recovery. It will drop the insert on the floor if the part is older than a part in the next level of the LSM. This indicates
+// that this part is already accounted for in the next level vis compaction.
+func (l *LSM) InsertPart(part parts.Part) {
+	level := SentinelType(part.CompactionLevel())
+	// Check the next levels if there is one to see if this part should be inserted.
+	if level != l.MaxLevel() {
+		for i := level + 1; i < l.MaxLevel()+1; i++ {
+			if part.TX() <= l.maxTXRecoverd[i] {
+				return
+			}
+		}
+	}
+
+	if tx := part.TX(); tx > l.maxTXRecoverd[level] {
+		l.maxTXRecoverd[level] = tx
+	}
+
+	// Insert the part into the correct level, but do not do this if parts with newer TXs have already been inserted.
+	l.findLevel(level).Insert(part)
 	size := l.sizes[level].Add(int64(part.Size()))
 	l.metrics.LevelSize.WithLabelValues(level.String()).Set(float64(size))
 }
@@ -334,9 +355,20 @@ func (l *LSM) merge(level SentinelType, externalWriter func([]parts.Part) (parts
 	}
 	l.metrics.Compactions.WithLabelValues(level.String()).Inc()
 
+	compact := l.findLevel(level)
+
+	// Wait for the watermark to reach the most recent transaction.
+	// This ensures a sorted list of transactions.
+	if level == L0 {
+		compact = compact.next.Load()
+		if compact == nil || compact.part == nil {
+			return nil // nothing to compact
+		}
+		l.wait(compact.part.TX())
+	}
+
 	nodeList := []*Node{}
 	var next *Node
-	compact := l.findLevel(level)
 	var iterErr error
 	compact.Iterate(func(node *Node) bool {
 		if node.part == nil { // sentinel encountered

--- a/index/lsm.go
+++ b/index/lsm.go
@@ -97,6 +97,8 @@ func NewLSMMetrics(reg prometheus.Registerer) *LSMMetrics {
 }
 
 // NewLSM returns an LSM-like index of len(levels) levels.
+// wait is a function that will block until the given transaction has been committed; this is used only during compaction to ensure
+// that all the tx in the level up to the compaction tx have been committed before compacting.
 func NewLSM(prefix string, schema *dynparquet.Schema, levels []*LevelConfig, wait func(uint64), options ...LSMOption) (*LSM, error) {
 	if err := validateLevels(levels); err != nil {
 		return nil, err

--- a/index/lsm_list.go
+++ b/index/lsm_list.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"fmt"
+	"runtime"
 	"sync/atomic"
 
 	"github.com/polarsignals/frostdb/parts"
@@ -97,7 +98,7 @@ func (n *Node) Insert(part parts.Part) {
 		}
 	}
 	for !tryInsert() {
-		continue // make the linter happy
+		runtime.Gosched()
 	}
 }
 

--- a/index/lsm_test.go
+++ b/index/lsm_test.go
@@ -181,7 +181,7 @@ func Test_LSM_Compaction(t *testing.T) {
 	lsm.Add(1, r)
 	require.Eventually(t, func() bool {
 		return lsm.sizes[L0].Load() == 0 && lsm.sizes[L1].Load() != 0
-	}, time.Second, 5*time.Millisecond)
+	}, 3*time.Second, 10*time.Millisecond)
 }
 
 func Test_LSM_CascadeCompaction(t *testing.T) {
@@ -208,7 +208,7 @@ func Test_LSM_CascadeCompaction(t *testing.T) {
 			lsm.sizes[L2].Load() == 0 &&
 			lsm.sizes[3].Load() == 0 &&
 			lsm.sizes[4].Load() == 0
-	}, time.Second, 5*time.Millisecond)
+	}, 3*time.Second, 10*time.Millisecond)
 	lsm.Add(2, r)
 	require.Eventually(t, func() bool {
 		return lsm.sizes[L0].Load() == 0 &&
@@ -216,7 +216,7 @@ func Test_LSM_CascadeCompaction(t *testing.T) {
 			lsm.sizes[L2].Load() == 0 &&
 			lsm.sizes[3].Load() == 0 &&
 			lsm.sizes[4].Load() != 0
-	}, time.Second, 5*time.Millisecond)
+	}, 3*time.Second, 10*time.Millisecond)
 }
 
 func Test_LSM_InOrderInsert(t *testing.T) {

--- a/snapshot.go
+++ b/snapshot.go
@@ -68,9 +68,7 @@ const (
 	minReadVersion = snapshotVersion
 )
 
-var (
-	ErrSkipPart = fmt.Errorf("skip part")
-)
+var ErrSkipPart = fmt.Errorf("skip part")
 
 type snapshotMetrics struct {
 	snapshotsTotal            *prometheus.CounterVec

--- a/snapshot.go
+++ b/snapshot.go
@@ -478,16 +478,17 @@ func WriteSnapshot(ctx context.Context, _ uint64, db *DB, w io.Writer, offline b
 					}
 					return nil
 				}()
-				if err != nil && err != ErrSkipPart {
+				if err != nil {
+					if err == ErrSkipPart {
+						return true
+					}
 					ascendErr = err
 					return false
 				}
 
-				if err != ErrSkipPart {
-					partMeta.EndOffset = int64(offW.offset)
-					granuleMeta.PartMetadata = append(granuleMeta.PartMetadata, partMeta)
-					tableMeta.GranuleMetadata = append(tableMeta.GranuleMetadata, granuleMeta) // TODO: we have one part per granule now
-				}
+				partMeta.EndOffset = int64(offW.offset)
+				granuleMeta.PartMetadata = append(granuleMeta.PartMetadata, partMeta)
+				tableMeta.GranuleMetadata = append(tableMeta.GranuleMetadata, granuleMeta) // TODO: we have one part per granule now
 				return true
 			})
 			metadata.TableMetadata = append(metadata.TableMetadata, tableMeta)

--- a/table.go
+++ b/table.go
@@ -1032,7 +1032,7 @@ func (t *TableBlock) Serialize(writer io.Writer) error {
 // Close the block and release all resources.
 func (t *TableBlock) Close(cleanup bool) error {
 	for _, closer := range t.closers {
-		if err := closer.Close(false); err != nil {
+		if err := closer.Close(cleanup); err != nil {
 			return fmt.Errorf("closer: %w", err)
 		}
 	}

--- a/table.go
+++ b/table.go
@@ -1232,7 +1232,9 @@ func (t *Table) configureLSMLevels(levels []*IndexConfig) ([]*index.LevelConfig,
 		case CompactionTypeParquetDisk:
 			fileCompaction := NewFileCompaction(t, i+1)
 			if abortRecovery { // If we failed to recover an LSM file, we need to abort recovery of all lower levels as well, and let the WAL recover.
-				fileCompaction.Truncate()
+				if err := fileCompaction.Truncate(); err != nil {
+					return nil, nil, err
+				}
 			} else {
 				parts, err := fileCompaction.recover(parts.WithCompactionLevel(i + 1))
 				if err != nil {

--- a/table.go
+++ b/table.go
@@ -276,6 +276,11 @@ type Table struct {
 	wal     WAL
 	closing bool
 	closers []io.Closer
+	syncers []Sync
+}
+
+type Sync interface {
+	Sync() error
 }
 
 type WAL interface {
@@ -1247,6 +1252,7 @@ func (t *Table) configureLSMLevels(levels []*IndexConfig) ([]*index.LevelConfig,
 				recovered = append(recovered, parts...)
 			}
 			t.closers = append(t.closers, fileCompaction) // Append to closers so that the underlying files are closed on table close.
+			t.syncers = append(t.syncers, fileCompaction) // Append to syncers so that the underlying files are synced on wal truncation.
 			cfg.Compact = fileCompaction.writeRecordsToParquetFile
 		default:
 			if i != len(levels)-1 { // Compaction type should not be set for last level


### PR DESCRIPTION
Adds support for persistent LSM files.

If storage path is enabled then persistent LSM files are used instead of temporary files. During startup, the database will recover parts from the LSM files and insert them into the index into the corresponding levels. 

If persistent LSM is configured then snapshots will not write those compacted parts into the snapshot file, and will only write the L0 parts.