### PR TITLE
*: Add mathematical projections

### DIFF
--- a/logictest/testdata/exec/projection/math_projection
+++ b/logictest/testdata/exec/projection/math_projection
@@ -1,0 +1,15 @@
+createtable schema=default
+----
+
+insert cols=(labels.label1, timestamp, value)
+value1 1 2
+value1 3 4
+value1 5 6
+----
+
+exec
+select value * timestamp
+----
+2
+12
+30

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -129,6 +129,14 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 			frostDBOp = logicalplan.OpEq
 		case opcode.NE:
 			frostDBOp = logicalplan.OpNotEq
+		case opcode.Plus:
+			frostDBOp = logicalplan.OpAdd
+		case opcode.Minus:
+			frostDBOp = logicalplan.OpSub
+		case opcode.Mul:
+			frostDBOp = logicalplan.OpMul
+		case opcode.Div:
+			frostDBOp = logicalplan.OpDiv
 		case opcode.LogicAnd:
 			v.exprStack = append(v.exprStack, logicalplan.And(leftExpr, rightExpr))
 			return nil


### PR DESCRIPTION
After this, we can remove the average aggregation and instead have a logical optimizer that replaces an average expression with `sum(col) / count(col) as avg(col)`.

This is also some groundwork, so we can perform `count * period` calculations in Parca, which is required so we can compare profiling data with different periods.

@thorfour @asubiotto 