### PR TITLE
Remove manual record building for Samples

### DIFF
--- a/internal/records/record_builder.go
+++ b/internal/records/record_builder.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 
 	schemapb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/schema/v1alpha1"
-	"github.com/polarsignals/frostdb/samples"
 )
 
 const (
@@ -739,9 +738,19 @@ func newUUIDSliceField(mem memory.Allocator, name string) (f *fieldBuilderFunc) 
 	}
 	bd := b.(*array.BinaryDictionaryBuilder)
 	f.buildFunc = func(v reflect.Value) error {
-		return bd.Append(samples.ExtractLocationIDs(v.Interface().([]uuid.UUID)))
+		return bd.Append(ExtractLocationIDs(v.Interface().([]uuid.UUID)))
 	}
 	return
+}
+
+func ExtractLocationIDs(locs []uuid.UUID) []byte {
+	b := make([]byte, len(locs)*16) // UUID are 16 bytes thus multiply by 16
+	index := 0
+	for i := len(locs) - 1; i >= 0; i-- {
+		copy(b[index:index+16], locs[i][:])
+		index += 16
+	}
+	return b
 }
 
 type fieldBuilderFunc struct {

--- a/internal/records/record_builder_test.go
+++ b/internal/records/record_builder_test.go
@@ -1,4 +1,4 @@
-package records
+package records_test
 
 import (
 	"testing"
@@ -8,20 +8,21 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/polarsignals/frostdb/internal/records"
 	"github.com/polarsignals/frostdb/samples"
 )
 
 func TestBuild(t *testing.T) {
 	t.Run("NewBuild", func(t *testing.T) {
-		b := NewBuild[samples.Sample](memory.DefaultAllocator)
+		b := records.NewBuild[samples.Sample](memory.DefaultAllocator)
 		defer b.Release()
 
-		ptr := NewBuild[*samples.Sample](memory.DefaultAllocator)
+		ptr := records.NewBuild[*samples.Sample](memory.DefaultAllocator)
 		defer ptr.Release()
 	})
 
 	t.Run("Schema", func(t *testing.T) {
-		b := NewBuild[samples.Sample](memory.DefaultAllocator)
+		b := records.NewBuild[samples.Sample](memory.DefaultAllocator)
 		defer b.Release()
 		got := b.Schema("test")
 		want := samples.SampleDefinition()
@@ -29,7 +30,7 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("NewRecord", func(t *testing.T) {
-		b := NewBuild[samples.Sample](memory.DefaultAllocator)
+		b := records.NewBuild[samples.Sample](memory.DefaultAllocator)
 		defer b.Release()
 		samples := samples.NewTestSamples()
 		err := b.Append(samples...)
@@ -53,7 +54,7 @@ func TestBuild(t *testing.T) {
 			String     []string
 			StringDict []string `frostdb:",rle_dict"`
 		}
-		b := NewBuild[Repeated](memory.DefaultAllocator)
+		b := records.NewBuild[Repeated](memory.DefaultAllocator)
 		defer b.Release()
 
 		wantSchema := `{
@@ -142,7 +143,7 @@ func TestBuild_pointer_base_types(t *testing.T) {
 		Dynamic map[string]*string
 	}
 
-	b := NewBuild[PointerBase](memory.NewGoAllocator())
+	b := records.NewBuild[PointerBase](memory.NewGoAllocator())
 	defer b.Release()
 
 	err := b.Append(
@@ -178,7 +179,7 @@ func BenchmarkBuild_Append_Then_NewRecord(b *testing.B) {
 	// NewRecord
 	//
 	// They are separate methods because we can't ignore benefits of buffering.
-	build := NewBuild[samples.Sample](memory.DefaultAllocator)
+	build := records.NewBuild[samples.Sample](memory.DefaultAllocator)
 	defer build.Release()
 	samples := samples.NewTestSamples()
 	b.ReportAllocs()


### PR DESCRIPTION
 This commit uses `internal/records.Build` to build `arrow.Record`  for `Samples`. The plan is
 to eventually remove all manual `arrow.Record` generation in tests.

Also, testing package was changed from `records` to `records_test` because we uses Samples to test the builder which causes cyclic dependency. Testing package change is basically a NOOP change(everything stays the same when testing just a different test binary name.)