### PR TITLE
Add BenchmarkSortRecord

### DIFF
--- a/pqarrow/arrowutils/sort_benchmark_test.go
+++ b/pqarrow/arrowutils/sort_benchmark_test.go
@@ -88,7 +88,7 @@ func makeRandomInts(n int) []int64 {
 
 func makeRandomStrings(n int) []string {
 	r := rand.New(rand.NewSource(42))
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	ss := make([]string, n)
 	for i := 0; i < n; i++ {
 		var sb strings.Builder

--- a/pqarrow/arrowutils/sort_benchmark_test.go
+++ b/pqarrow/arrowutils/sort_benchmark_test.go
@@ -1,0 +1,102 @@
+package arrowutils_test
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow/go/v14/arrow/memory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/frostdb/internal/records"
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
+)
+
+func BenchmarkSortRecord(b *testing.B) {
+	b.StopTimer()
+	build := records.NewBuild[Model](memory.NewGoAllocator())
+	err := build.Append(makeModels(40)...)
+	require.NoError(b, err)
+	r := build.NewRecord()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := arrowutils.SortRecord(r.Record, r.SortingColumns)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+type Model struct {
+	Timestamp  int64  `frostdb:",asc(0)"`
+	Plain      string `frostdb:",asc(1)"`
+	Dictionary string `frostdb:",asc(2)"`
+}
+
+func makeModels(n int) []Model {
+	o := make([]Model, n)
+	plain := makeRandomStrings(n)
+	dict := makeRandomStrings(n)
+	ts := makeRandomInts(n)
+
+	// Simulate when we need to touch multiple columns
+
+	// case 1
+	// first column is equal second column is not
+	span := 4
+	limit := span + 2
+	for i := span; i < n && i < limit; i++ {
+		ts[i] = ts[span]
+	}
+
+	// case 2
+	// both first and second column are equal
+	span = limit + 1
+	limit = span + 4
+	for i := span; i < n && i < limit; i++ {
+		ts[i] = ts[span]
+		plain[i] = plain[span]
+	}
+	// case 3
+	// all three columns are equal
+	span = limit + 1
+	limit = span + 4
+	for i := span; i < n && i < limit; i++ {
+		ts[i] = ts[span]
+		plain[i] = plain[span]
+		dict[i] = dict[span]
+	}
+	for i := range o {
+		o[i] = Model{
+			Timestamp:  ts[i],
+			Plain:      plain[i],
+			Dictionary: dict[i],
+		}
+	}
+	return o
+}
+
+func makeRandomInts(n int) []int64 {
+	r := rand.New(rand.NewSource(42))
+	ints := make([]int64, n)
+	for i := 0; i < n; i++ {
+		ints[i] = r.Int63n(int64(n))
+	}
+	return ints
+}
+
+func makeRandomStrings(n int) []string {
+	r := rand.New(rand.NewSource(42))
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	ss := make([]string, n)
+	for i := 0; i < n; i++ {
+		var sb strings.Builder
+		slen := 2 + rand.Intn(50)
+		for j := 0; j < slen; j++ {
+			sb.WriteRune(letters[r.Intn(len(letters))])
+		}
+		ss[i] = sb.String()
+	}
+	return ss
+}

--- a/pqarrow/arrowutils/sort_test.go
+++ b/pqarrow/arrowutils/sort_test.go
@@ -1,4 +1,4 @@
-package arrowutils
+package arrowutils_test
 
 import (
 	"context"
@@ -8,6 +8,8 @@ import (
 	"github.com/apache/arrow/go/v14/arrow/array"
 	"github.com/apache/arrow/go/v14/arrow/memory"
 	"github.com/stretchr/testify/require"
+
+	"github.com/polarsignals/frostdb/pqarrow/arrowutils"
 )
 
 func TestSortRecord(t *testing.T) {
@@ -27,14 +29,14 @@ func TestSortRecord(t *testing.T) {
 		{
 			Name:    "No Nows",
 			Samples: Samples{},
-			Columns: []SortingColumn{{Index: 0}},
+			Columns: []arrowutils.SortingColumn{{Index: 0}},
 		},
 		{
 			Name: "One Row",
 			Samples: Samples{
 				{},
 			},
-			Columns: []SortingColumn{
+			Columns: []arrowutils.SortingColumn{
 				{
 					Index: 0,
 				},
@@ -48,7 +50,7 @@ func TestSortRecord(t *testing.T) {
 				{Int: 2},
 				{Int: 1},
 			},
-			Columns: []SortingColumn{
+			Columns: []arrowutils.SortingColumn{
 				{Index: 0},
 			},
 			Indices: []int32{2, 1, 0},
@@ -61,8 +63,8 @@ func TestSortRecord(t *testing.T) {
 				{Int: 3},
 			},
 
-			Columns: []SortingColumn{
-				{Index: 0, Direction: Descending},
+			Columns: []arrowutils.SortingColumn{
+				{Index: 0, Direction: arrowutils.Descending},
 			},
 			Indices: []int32{2, 1, 0},
 		},
@@ -73,7 +75,7 @@ func TestSortRecord(t *testing.T) {
 				{Double: 2},
 				{Double: 1},
 			},
-			Columns: []SortingColumn{{Index: 1}},
+			Columns: []arrowutils.SortingColumn{{Index: 1}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -83,7 +85,7 @@ func TestSortRecord(t *testing.T) {
 				{Double: 2},
 				{Double: 3},
 			},
-			Columns: []SortingColumn{{Index: 1, Direction: Descending}},
+			Columns: []arrowutils.SortingColumn{{Index: 1, Direction: arrowutils.Descending}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -93,7 +95,7 @@ func TestSortRecord(t *testing.T) {
 				{String: "2"},
 				{String: "1"},
 			},
-			Columns: []SortingColumn{{Index: 2}},
+			Columns: []arrowutils.SortingColumn{{Index: 2}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -103,7 +105,7 @@ func TestSortRecord(t *testing.T) {
 				{String: "2"},
 				{String: "3"},
 			},
-			Columns: []SortingColumn{{Index: 2, Direction: Descending}},
+			Columns: []arrowutils.SortingColumn{{Index: 2, Direction: arrowutils.Descending}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -113,7 +115,7 @@ func TestSortRecord(t *testing.T) {
 				{Dict: "2"},
 				{Dict: "1"},
 			},
-			Columns: []SortingColumn{{Index: 3}},
+			Columns: []arrowutils.SortingColumn{{Index: 3}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -123,7 +125,7 @@ func TestSortRecord(t *testing.T) {
 				{Dict: "2"},
 				{Dict: "3"},
 			},
-			Columns: []SortingColumn{{Index: 3, Direction: Descending}},
+			Columns: []arrowutils.SortingColumn{{Index: 3, Direction: arrowutils.Descending}},
 			Indices: []int32{2, 1, 0},
 		},
 		{
@@ -133,7 +135,7 @@ func TestSortRecord(t *testing.T) {
 				{},
 				{Nullable: null(1)},
 			},
-			Columns: []SortingColumn{{Index: 4}},
+			Columns: []arrowutils.SortingColumn{{Index: 4}},
 			Indices: []int32{2, 0, 1},
 		},
 		{
@@ -143,7 +145,7 @@ func TestSortRecord(t *testing.T) {
 				{},
 				{Nullable: null(1)},
 			},
-			Columns: []SortingColumn{{Index: 4, NullsFirst: true}},
+			Columns: []arrowutils.SortingColumn{{Index: 4, NullsFirst: true}},
 			Indices: []int32{0, 1, 2},
 		},
 		{
@@ -153,7 +155,7 @@ func TestSortRecord(t *testing.T) {
 				{},
 				{Nullable: null(1)},
 			},
-			Columns: []SortingColumn{{Index: 4, Direction: Descending}},
+			Columns: []arrowutils.SortingColumn{{Index: 4, Direction: arrowutils.Descending}},
 			Indices: []int32{2, 0, 1},
 		},
 		{
@@ -163,7 +165,7 @@ func TestSortRecord(t *testing.T) {
 				{},
 				{Nullable: null(1)},
 			},
-			Columns: []SortingColumn{{Index: 4, Direction: Descending, NullsFirst: true}},
+			Columns: []arrowutils.SortingColumn{{Index: 4, Direction: arrowutils.Descending, NullsFirst: true}},
 			Indices: []int32{0, 1, 2},
 		},
 		{
@@ -174,7 +176,7 @@ func TestSortRecord(t *testing.T) {
 				{String: "3", Int: 2},
 				{String: "4", Int: 1},
 			},
-			Columns: []SortingColumn{
+			Columns: []arrowutils.SortingColumn{
 				{Index: 0},
 				{Index: 2},
 			},
@@ -188,9 +190,9 @@ func TestSortRecord(t *testing.T) {
 				{String: "3", Int: 2},
 				{String: "4", Int: 1},
 			},
-			Columns: []SortingColumn{
-				{Index: 0, Direction: Ascending},
-				{Index: 2, Direction: Descending},
+			Columns: []arrowutils.SortingColumn{
+				{Index: 0, Direction: arrowutils.Ascending},
+				{Index: 2, Direction: arrowutils.Descending},
 			},
 			Indices: []int32{3, 2, 1, 0},
 		},
@@ -222,7 +224,7 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := ReorderRecord(context.Background(), mem, r, by)
+		result, err := arrowutils.ReorderRecord(context.Background(), mem, r, by)
 		require.Nil(t, err)
 		defer result.Release()
 
@@ -254,7 +256,7 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := ReorderRecord(context.Background(), mem, r, by)
+		result, err := arrowutils.ReorderRecord(context.Background(), mem, r, by)
 		require.Nil(t, err)
 		defer result.Release()
 
@@ -332,7 +334,7 @@ func (s Samples) Record() arrow.Record {
 type SortCase struct {
 	Name    string
 	Samples Samples
-	Columns []SortingColumn
+	Columns []arrowutils.SortingColumn
 	Indices []int32
 	Error   string
 }
@@ -340,7 +342,7 @@ type SortCase struct {
 func sortAndCompare(t *testing.T, kase SortCase) {
 	t.Helper()
 
-	got, err := SortRecord(kase.Samples.Record(), kase.Columns)
+	got, err := arrowutils.SortRecord(kase.Samples.Record(), kase.Columns)
 	if kase.Error != "" {
 		require.NotNil(t, err, kase.Error)
 		return


### PR DESCRIPTION
This was supposed to be part of #635

I will work on benchmarking `ReorderRecord` separately, I am not satisfied with `ReorderRecord` api, will think more about it( we pass `memory.Allocator` together with `context.Context`, we need to only pass `context.Context` like what `compute` apis do).