### PR TITLE
Remove explicit memory.Allocator for arrowutils.ReorderRecord

### DIFF
--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -74,6 +74,8 @@ func SortRecord(r arrow.Record, columns []SortingColumn) (*array.Int32, error) {
 
 // ReorderRecord uses indices to create a new record that is sorted according to
 // the indices array.
+//
+// Use compute.WithAllocator to pass a custom memory.Allocator.
 func ReorderRecord(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Record, error) {
 	// compute.Take doesn't support dictionaries. Use take on r when r does not have
 	// dictionary column.

--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -10,7 +10,6 @@ import (
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/apache/arrow/go/v14/arrow/array"
 	"github.com/apache/arrow/go/v14/arrow/compute"
-	"github.com/apache/arrow/go/v14/arrow/memory"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/polarsignals/frostdb/pqarrow/builder"
@@ -75,8 +74,7 @@ func SortRecord(r arrow.Record, columns []SortingColumn) (*array.Int32, error) {
 
 // ReorderRecord uses indices to create a new record that is sorted according to
 // the indices array.
-func ReorderRecord(ctx context.Context, mem memory.Allocator, r arrow.Record, indices *array.Int32) (arrow.Record, error) {
-	ctx = compute.WithAllocator(ctx, mem)
+func ReorderRecord(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Record, error) {
 	// compute.Take doesn't support dictionaries. Use take on r when r does not have
 	// dictionary column.
 	var hasDictionary bool

--- a/pqarrow/arrowutils/sort_test.go
+++ b/pqarrow/arrowutils/sort_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/apache/arrow/go/v14/arrow/array"
+	"github.com/apache/arrow/go/v14/arrow/compute"
 	"github.com/apache/arrow/go/v14/arrow/memory"
 	"github.com/stretchr/testify/require"
 
@@ -224,7 +225,8 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := arrowutils.ReorderRecord(context.Background(), mem, r, by)
+		result, err := arrowutils.ReorderRecord(
+			compute.WithAllocator(context.Background(), mem), r, by)
 		require.Nil(t, err)
 		defer result.Release()
 
@@ -256,7 +258,8 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := arrowutils.ReorderRecord(context.Background(), mem, r, by)
+		result, err := arrowutils.ReorderRecord(
+			compute.WithAllocator(context.Background(), mem), r, by)
 		require.Nil(t, err)
 		defer result.Release()
 


### PR DESCRIPTION
We already pass `context.Context` and use `compute`. Anyone who needs a custom Allocator can use `compute.WithAllocator`.