### PR TITLE
rewrote compaction to write to separate files for each part

### DIFF
--- a/db.go
+++ b/db.go
@@ -1304,18 +1304,6 @@ func (db *DB) resetToTxn(txn uint64, wal WAL) {
 	db.tx.Store(txn)
 	db.highWatermark.Store(txn)
 	if wal != nil {
-		// Before resetting the wal make sure any pending writes to the index are flushed.
-		errg := errgroup.Group{}
-		for _, table := range db.tables {
-			for _, syncer := range table.ActiveBlock().syncers {
-				errg.Go(syncer.Sync)
-			}
-		}
-
-		if err := errg.Wait(); err != nil {
-			level.Error(db.logger).Log("msg", "failed to sync index before resetting WAL; dataloss may occur", "err", err)
-		}
-
 		// This call resets the WAL to a zero state so that new records can be
 		// logged.
 		if err := wal.Reset(txn + 1); err != nil {


### PR DESCRIPTION
There is a data loss scenario with the persistent LSM's. 

1. Snapshot happens.
2. WAL is truncated.
3. Another compaction is triggered
     While this compaction is being written to the index file the node crashes/shutsdown and the file becomes corrupted. 
 
This corruption of the single file means we cannot recover any of the other parts in the file which results in data loss because we cannot recreate those parts from the WAL due to truncation.

To fix this I've split the index files up to have a file per part. Now if the above scenario happens we can recover the remaining parts in the level, and only the new writes that caused the compaction need to be recovered from the WAL.