### PR TITLE
Rename ReorderRecord to Take

### DIFF
--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -61,11 +61,11 @@ func SortRecord(r arrow.Record, columns []SortingColumn) (*array.Int32, error) {
 	return ms.indices.NewArray().(*array.Int32), nil
 }
 
-// ReorderRecord uses indices to create a new record that is sorted according to
-// the indices array.
+// Take uses indices which is an array of row index and returns a new record
+// that only contains rows specified in indices.
 //
 // Use compute.WithAllocator to pass a custom memory.Allocator.
-func ReorderRecord(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Record, error) {
+func Take(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Record, error) {
 	// compute.Take doesn't support dictionaries. Use take on r when r does not have
 	// dictionary column.
 	var hasDictionary bool

--- a/pqarrow/arrowutils/sort_test.go
+++ b/pqarrow/arrowutils/sort_test.go
@@ -225,7 +225,7 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := arrowutils.ReorderRecord(
+		result, err := arrowutils.Take(
 			compute.WithAllocator(context.Background(), mem), r, by)
 		require.Nil(t, err)
 		defer result.Release()
@@ -258,7 +258,7 @@ func TestReorderRecord(t *testing.T) {
 		indices := array.NewInt32Builder(mem)
 		indices.AppendValues([]int32{2, 1, 0}, nil)
 		by := indices.NewInt32Array()
-		result, err := arrowutils.ReorderRecord(
+		result, err := arrowutils.Take(
 			compute.WithAllocator(context.Background(), mem), r, by)
 		require.Nil(t, err)
 		defer result.Release()


### PR DESCRIPTION
The new name reflects what the function does, we are not ordering anything we are just taking specific rows.