### PR TITLE
Fix memory leak in arrowutils.Take

### DIFF
--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -79,8 +79,8 @@ func Take(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Reco
 		res, err := compute.Take(
 			ctx,
 			compute.TakeOptions{BoundsCheck: true},
-			compute.NewDatum(r),
-			compute.NewDatum(indices),
+			compute.NewDatumWithoutOwning(r),
+			compute.NewDatumWithoutOwning(indices),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
 `r` and `indices` are externally managed resources. Owning them increases ref
 count ,since we never releases them they will leak when `r` has no dictionary field.

 There is no need to own these resources inside `Take`.

 This is part of #672