### PR TITLE
Remove TODO since we prehash before wal now

### DIFF
--- a/db.go
+++ b/db.go
@@ -909,9 +909,6 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 					return fmt.Errorf("read record: %w", err)
 				}
 				defer reader.Release()
-
-				// TODO: the issue with this is we aren't prehashing the columns by not doing InsertRecord.
-				// If we prehash before WAL write we don't have to do that here.
 				size := util.TotalRecordSize(record)
 				table.active.index.InsertPart(parts.NewArrowPart(tx, record, uint64(size), table.schema, parts.WithCompactionLevel(int(index.L0))))
 			default:


### PR DESCRIPTION
After reading the `TODO` and inspecting the code. I think it is safe to remove it now. From my understanding the `TODO` reminds us that the record added to `lsm` is not pre hashed and recommends we prehash before writing to wal which we currently do.

cc @asubiotto 