### PR TITLE
Fix index deadlocks

### DIFF
--- a/table.go
+++ b/table.go
@@ -805,7 +805,7 @@ func (t *Table) Iterator(
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
-				case rg, ok := <-rowGroups: // TODO we HAVE to ensure that we have drained the rowGroups channel now with file backed parts.
+				case rg, ok := <-rowGroups:
 					if !ok {
 						r := converter.NewRecord()
 						if r == nil {


### PR DESCRIPTION
Snapshot's and Compaction could deadlock. This fixes that.

Compactions wait for the watermark to reach the newest transaction in the L0 level.
Snapshots were creating a write tx, but where then calling index.Snapshot which acquires the index.Compaction lock.

This could result in a deadlock if a write came in that was newer than the snapshot tx and the compaction was waiting for the watermark to get to that, but the snapshot was waiting to commit it's tx waiting for the compaction lock.

Instead of acquiring a write tx we need only to get a read tx so we don't block the watermark. We also do not need to log to the WAL for snapshots because we do nothing with that information on replay.