### PR TITLE
Validate index files

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2583,14 +2583,14 @@ func Test_DB_PersistentDiskCompaction(t *testing.T) {
 		},
 		"corrupted snapshot": { // The actual snapshot index file is corrupted
 			beforeReplay: func(table *Table, dir string) {
-				filepath.WalkDir(table.db.snapshotsDir(), func(path string, info fs.DirEntry, err error) error {
+				require.NoError(t, filepath.WalkDir(table.db.snapshotsDir(), func(path string, info fs.DirEntry, err error) error {
 					if filepath.Ext(path) == index.IndexFileExtension {
 						info, err := os.Stat(path)
 						require.NoError(t, err)
 						require.NoError(t, os.Truncate(path, info.Size()-1)) // truncate the last byte to corrupt the file
 					}
 					return nil
-				})
+				}))
 			},
 			beforeClose: func(table *Table, dir string) {
 				// trigger a snapshot

--- a/index/compaction.go
+++ b/index/compaction.go
@@ -336,6 +336,7 @@ func ValidateIndexDir(dir string) error {
 		if err != nil {
 			return fmt.Errorf("failed to open index file %s: %w", path, err)
 		}
+		defer idxfile.Close()
 
 		// Attempt to read the final Parquet file to ensure it is valid.
 		info, err := idxfile.Stat()

--- a/snapshot.go
+++ b/snapshot.go
@@ -607,7 +607,7 @@ func loadSnapshot(ctx context.Context, db *DB, r io.ReaderAt, size int64, dir st
 
 			table, err := db.table(tableMeta.Name, tableConfig, blockUlid)
 			if err != nil {
-				return err
+				return fmt.Errorf("recovering table from snapshot: %w", err)
 			}
 
 			table.mtx.Lock()
@@ -752,6 +752,10 @@ func restoreIndexFilesFromSnapshot(db *DB, table, snapshotDir, blockID string) e
 	}
 
 	snapshotIndexDir := filepath.Join(snapshotDir, "index", table, blockID)
+
+	if err := index.ValidateIndexDir(snapshotIndexDir); err != nil {
+		return fmt.Errorf("failed to validate snapshot index directory: %w", err)
+	}
 
 	// Restore the index files from the snapshot files.
 	return filepath.WalkDir(snapshotIndexDir, func(path string, d os.DirEntry, err error) error {

--- a/snapshot.go
+++ b/snapshot.go
@@ -300,6 +300,12 @@ func (db *DB) getLatestValidSnapshotTxn(ctx context.Context) (uint64, error) {
 			if _, err := readFooter(f, info.Size()); err != nil {
 				return err
 			}
+
+			// Validate any index files if the exist
+			if err := index.ValidateIndexDir(filepath.Join(dir, entry.Name(), "index")); err != nil {
+				return err
+			}
+
 			return nil
 		}(); err != nil {
 			level.Debug(db.logger).Log(


### PR DESCRIPTION
Added a `ValidateIndexDir` function for when we're validating snapshots

Added this to the find valid snapshot function as well as before we restore an index from snapshot which keeps us from panicing when we have a corrupted snapshot.

Also added a compaction file seek to the offset when an error during write occurs. Should make compactions more resilient. 