### PR TITLE
Fix deadlock

### DIFF
--- a/index/compaction.go
+++ b/index/compaction.go
@@ -250,7 +250,7 @@ func (f *FileCompaction) recover(options ...parts.Option) ([]parts.Part, error) 
 
 				txstr, ok := buf.ParquetFile().Lookup(ParquetCompactionTXKey)
 				if !ok {
-					return fmt.Errorf("failed to find compaction_tx metadata")
+					return fmt.Errorf("failed to find compaction_tx metadata: %s", file.Name())
 				}
 
 				tx, err := strconv.Atoi(txstr)

--- a/snapshot.go
+++ b/snapshot.go
@@ -714,6 +714,9 @@ func (db *DB) snapshotsDo(ctx context.Context, dir string, callback func(tx uint
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
+		if filepath.Ext(entry.Name()) == ".fdbs" { // Legacy snapshots were stored at the top-level. Ignore these
+			continue
+		}
 		name := entry.Name()
 		if len(name) < 20 {
 			continue


### PR DESCRIPTION
Fixes a deadlock that can occur if the reading goroutine exits but strands the collect row groups routine. 