### PR TITLE
table: avoid deadlock when releasing parts

### DIFF
--- a/table.go
+++ b/table.go
@@ -875,11 +875,8 @@ func (t *Table) Iterator(
 	}
 
 	errg.Go(func() error {
-		if err := t.collectRowGroups(ctx, tx, iterOpts.Filter, iterOpts.InMemoryOnly, rowGroups); err != nil {
-			return err
-		}
-		close(rowGroups)
-		return nil
+		defer close(rowGroups)
+		return t.collectRowGroups(ctx, tx, iterOpts.Filter, iterOpts.InMemoryOnly, rowGroups)
 	})
 
 	return errg.Wait()


### PR DESCRIPTION
Previously if collectRowGroups returned with an error (e.g. context cancellation), the rowGroups channel would not be closed. This commit closes the channel in a defer so that the cleanup code correctly exits the `for rowGroups` release logic.