### PR TITLE
db: notify txpool of watermark changes

### DIFF
--- a/db.go
+++ b/db.go
@@ -1266,6 +1266,7 @@ func (db *DB) begin() (uint64, uint64, func()) {
 		if mark := db.highWatermark.Load(); mark+1 == txn {
 			// This is the next consecutive transaction; increase the watermark.
 			db.highWatermark.Store(txn)
+			db.txPool.notifyWatermark()
 			return
 		}
 

--- a/tx_list.go
+++ b/tx_list.go
@@ -125,6 +125,15 @@ func (l *TxPool) insert(node, prev, next *TxNode) bool {
 	return success
 }
 
+// notifyWatermark notifies the TxPool that the watermark has been updated. This
+// triggers a sweep of the pool.
+func (l *TxPool) notifyWatermark() {
+	select {
+	case l.drain <- struct{}{}:
+	default:
+	}
+}
+
 func (l *TxPool) Iterate(iterate func(txn uint64) bool) {
 	for node := l.head.Load().next.Load(); node.tx != 0; node = getUnmarked(node) {
 		if isMarked(node) == nil && !iterate(node.tx) {


### PR DESCRIPTION
Before a recent fix, we would rely on txn IDs to always be inserted into the TxPool to bubble up the watermark correctly. This commit adds a mechanism to notify the TxPool that the watermark has been changed, which is required in order to bubble up the watermark correctly.