### PR TITLE
snapshot: refactor to simplify

### DIFF
--- a/parts/arrow.go
+++ b/parts/arrow.go
@@ -1,7 +1,10 @@
 package parts
 
 import (
+	"io"
+
 	"github.com/apache/arrow/go/v14/arrow"
+	"github.com/apache/arrow/go/v14/arrow/ipc"
 
 	"github.com/polarsignals/frostdb/dynparquet"
 	"github.com/polarsignals/frostdb/pqarrow"
@@ -32,6 +35,15 @@ func NewArrowPart(tx uint64, record arrow.Record, size uint64, schema *dynparque
 	}
 
 	return p
+}
+
+func (p *arrowPart) Write(w io.Writer) error {
+	recordWriter := ipc.NewWriter(
+		w,
+		ipc.WithSchema(p.record.Schema()),
+	)
+	defer recordWriter.Close()
+	return recordWriter.Write(p.record)
 }
 
 func (p *arrowPart) Retain() { p.record.Retain() }

--- a/parts/parquet.go
+++ b/parts/parquet.go
@@ -2,6 +2,7 @@ package parts
 
 import (
 	"fmt"
+	"io"
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/v14/arrow"
@@ -29,6 +30,17 @@ func (p *parquetPart) Release() {
 	if ref <= 0 && p.release != nil {
 		p.release()
 	}
+}
+
+func (p *parquetPart) Write(w io.Writer) error {
+	buf, err := p.AsSerializedBuffer(nil)
+	if err != nil {
+		return err
+	}
+
+	f := buf.ParquetFile()
+	_, err = io.Copy(w, io.NewSectionReader(f, 0, f.Size()))
+	return err
 }
 
 func (p *parquetPart) SerializeBuffer(_ *dynparquet.Schema, _ dynparquet.ParquetWriter) error {

--- a/parts/part.go
+++ b/parts/part.go
@@ -1,6 +1,7 @@
 package parts
 
 import (
+	"io"
 	"sort"
 
 	"github.com/apache/arrow/go/v14/arrow"
@@ -23,6 +24,7 @@ type Part interface {
 	Least() (*dynparquet.DynamicRow, error)
 	Most() (*dynparquet.DynamicRow, error)
 	OverlapsWith(schema *dynparquet.Schema, otherPart Part) (bool, error)
+	Write(io.Writer) error
 }
 
 type basePart struct {


### PR DESCRIPTION
Part one of #722 

This moves more of the snapshot logic into the index itself instead of in the snapshot layer. 

Previously the snapshot would know to walk `L0` parts and write them to the file, and then depending on how the index was configured it would either write the `L1+` parts to the file or it would skip them and call `index.Snapshot` at the end.

This moves the handling of levels all into the index where it belongs. Now Snapshot provides a writer function for parts, and a directory for the snapshot and just calls `index.Snapshot` for each table. 

Next part will be to move the snapshot into it's own package.