### PR TITLE
query/physicalplan: For special substring regexp filter run substr matching directly

### DIFF
--- a/logictest/testdata/exec/filter/filter
+++ b/logictest/testdata/exec/filter/filter
@@ -93,6 +93,21 @@ select labels, stacktrace, timestamp, value where labels.label3 regexp 'value.' 
 value2  value2  value3  null    stack1  2       2
 
 exec
+select labels, stacktrace, timestamp, value where labels.label3 regexp '.*alu.*'
+----
+value2  value2  value3  null    stack1  2       2
+
+exec
+select labels, stacktrace, timestamp, value where labels.label3 regexp '.*'
+----
+value2  value2  value3  null    stack1  2       2
+
+exec
+select labels, stacktrace, timestamp, value where labels.label3 not regexp '.*foo.*'
+----
+value2  value2  value3  null    stack1  2       2
+
+exec
 select labels, stacktrace, timestamp, value where labels.label1 regexp 'value.' and  labels.label2 = 'value2' and labels.label1 != 'value3'
 ----
 value1  value2  null    null    stack1  1       1

--- a/logictest/testdata/plan/filter/filter
+++ b/logictest/testdata/plan/filter/filter
@@ -1,0 +1,16 @@
+createtable schema=default
+----
+
+# Regexp matching with .* at the beginning and the end of the pattern
+# is optimized to use the Substr function instead of the Regexp function.
+exec
+explain select labels, stacktrace, timestamp, value where labels.label3 regexp '.*alu.*'
+----
+TableScan [concurrent] - PredicateFilter (Substr(labels.label3, alu)) - Projection (labels, stacktrace, timestamp, value) - Synchronizer
+
+# Regexp matching with .* at the beginning and the end of the pattern
+# is optimized to use the Substr function instead of the Regexp function.
+exec
+explain select labels, stacktrace, timestamp, value where labels.label3 not regexp '.*alu.*'
+----
+TableScan [concurrent] - PredicateFilter (!Substr(labels.label3, alu)) - Projection (labels, stacktrace, timestamp, value) - Synchronizer

--- a/query/physicalplan/binaryscalarexpr_test.go
+++ b/query/physicalplan/binaryscalarexpr_test.go
@@ -3,6 +3,7 @@ package physicalplan
 import (
 	"testing"
 
+	"github.com/apache/arrow/go/v14/arrow"
 	"github.com/apache/arrow/go/v14/arrow/array"
 	"github.com/apache/arrow/go/v14/arrow/memory"
 	"github.com/apache/arrow/go/v14/arrow/scalar"
@@ -66,4 +67,53 @@ func Test_ArrayScalarCompute_Leak(t *testing.T) {
 	s := scalar.NewInt64Scalar(4)
 	_, err := ArrayScalarCompute("equal", arr, s)
 	require.NoError(t, err)
+}
+
+func BenchmarkBinaryScalarRegexp(b *testing.B) {
+	ab := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
+	num := int64(10_000)
+	for i := int64(0); i < num; i++ {
+		line := lines[i%int64(len(lines))]
+		ab.AppendString(line)
+	}
+
+	arr := ab.NewBinaryArray()
+	ab.Release()
+
+	record := array.NewRecord(
+		arrow.NewSchema([]arrow.Field{{Name: "values", Type: arrow.BinaryTypes.Binary}}, nil),
+		[]arrow.Array{arr},
+		num,
+	)
+
+	operators := []logicalplan.Op{
+		logicalplan.OpRegexMatch,
+		logicalplan.OpRegexNotMatch,
+	}
+
+	for _, op := range operators {
+		b.Run(op.String(), func(b *testing.B) {
+			expr, err := binaryBooleanExpr(&logicalplan.BinaryExpr{
+				Left:  logicalplan.Col("values"),
+				Op:    logicalplan.OpRegexMatch,
+				Right: logicalplan.Literal(".*vegan.*"),
+			})
+			require.NoError(b, err)
+
+			for i := 0; i < b.N; i++ {
+				_, err := expr.Eval(record)
+				if err != nil {
+					return
+				}
+			}
+		})
+	}
+}
+
+var lines = []string{
+	"Hot chicken dolor truffaut knausgaard, ramps shaman skateboard neutral milk hotel af letterpress kickstarter art party church-key hoodie. Butcher typewriter cold-pressed, williamsburg voluptate organic bushwick roof party banjo live-edge bodega boys. Fixie praxis incididunt health goth, in salvia cray commodo fam trust fund. Kale chips street art slow-carb shabby chic occaecat echo park messenger bag fam meggings DSA offal leggings. Taiyaki yes plz everyday carry sartorial eiusmod fugiat williamsburg elit jean shorts pop-up grailed. Authentic exercitation palo santo praxis distillery. Fam 3 wolf moon tbh pabst la croix lumbersexual sunt subway tile normcore.",
+	"Vexillologist art party cloud bread ipsum. Mlkshk intelligentsia taiyaki semiotics ut. Before they sold out YOLO health goth poke plaid. Literally edison bulb excepteur ethical man bun tacos, viral retro ipsum bicycle rights four dollar toast. Franzen roof party enim green juice iPhone officia. Gorpcore squid vegan dolore mumblecore quinoa lomo ullamco. Pork belly labore intelligentsia skateboard.",
+	"Actually lumbersexual praxis art party pug church-key yuccie JOMO tilde mollit reprehenderit. Fanny pack chambray literally fam biodiesel, single-origin coffee marxism everyday carry velit la croix direct trade JOMO. Offal praxis live-edge plaid cloud bread cupidatat est wayfarers farm-to-table +1 sed echo park magna. Hella raw denim cornhole slow-carb marxism gorpcore. Pop-up voluptate cornhole mumblecore tbh hexagon heirloom echo park activated charcoal eu. Beard kickstarter ethical pabst fingerstache bespoke tousled kogi 8-bit lyft try-hard bodega boys ullamco readymade.",
+	"Cardigan bruh cronut, farm-to-table marfa ex aliqua subway tile kinfolk. Brunch tbh adaptogen fam chartreuse, irure palo santo shaman JOMO neutra. Paleo thundercats non hashtag ennui. In readymade four loko non ea. Kinfolk subway tile kogi, waistcoat copper mug lomo pug duis sunt.",
+	"Deserunt you probably haven't heard of them lyft migas. Palo santo reprehenderit vegan, marfa proident gochujang kale chips paleo edison bulb ascot kinfolk banjo. Copper mug seitan quis officia flannel everyday carry sed cold-pressed. Blue bottle 3 wolf moon air plant, ex salvia fixie crucifix you probably haven't heard of them keffiyeh enim meditation kinfolk four dollar toast poke. 8-bit banh mi godard, offal cred fanny pack readymade taiyaki. Fixie glossier waistcoat, incididunt non pinterest yes plz ullamco pour-over aesthetic lo-fi.",
 }


### PR DESCRIPTION
Once a regexp filter is run it checks for .% at the beginning and end.
If it is true, then using bytes.Contains or strings.Contains is way more performant than running regexp.

Here's the result of running BenchmarkBinaryScalarRegexp:
```
name                      old time/op  new time/op  delta
BinaryScalarRegexp/=~-24   122ms ± 3%     1ms ±26%  -99.34%  (p=0.000 n=10+9)
BinaryScalarRegexp/!~-24   123ms ± 2%     1ms ±14%  -99.31%  (p=0.000 n=10+9)
```
