### PR TITLE
722 snapshot tx changes

### DIFF
--- a/db.go
+++ b/db.go
@@ -749,7 +749,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 						filepath.Join(table.db.indexDir(), table.name, table.ActiveBlock().ulid.String()), // Any index files are found at <db.indexDir>/<table.name>/<block.id>
 						table.schema,
 						table.IndexConfig(),
-						db.Wait,
+						db.HighWatermark,
 						index.LSMWithMetrics(table.metrics.indexMetrics),
 						index.LSMWithLogger(table.logger),
 					)

--- a/index/lsm_test.go
+++ b/index/lsm_test.go
@@ -96,7 +96,7 @@ func Test_LSM_Basic(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func Test_LSM_DuplicateSentinel(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func Test_LSM_Compaction(t *testing.T) {
 		{Level: L0, MaxSize: 1, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L1, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -178,7 +178,7 @@ func Test_LSM_CascadeCompaction(t *testing.T) {
 		{Level: 3, MaxSize: 2281, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: 4, MaxSize: 2281},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func Test_LSM_InOrderInsert(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -25,6 +25,7 @@ import (
 	"github.com/polarsignals/frostdb/dynparquet"
 	snapshotpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/snapshot/v1alpha1"
 	tablepb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/table/v1alpha1"
+	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
 	"github.com/polarsignals/frostdb/index"
 	"github.com/polarsignals/frostdb/parts"
 )
@@ -128,14 +129,36 @@ func (db *DB) snapshot(ctx context.Context, async bool, onSuccess func()) {
 		return
 	}
 
-	tx := db.beginRead()
+	tx, _, commit := db.begin()
 	level.Debug(db.logger).Log(
 		"msg", "starting a new snapshot",
 		"tx", tx,
 	)
 	doSnapshot := func(writeSnapshot func(context.Context, io.Writer) error) {
+		db.Wait(tx - 1) // Wait for all transactions to complete before taking a snapshot.
 		start := time.Now()
 		defer db.snapshotInProgress.Store(false)
+		defer commit()
+		if db.columnStore.enableWAL {
+			// Appending a snapshot record to the WAL is necessary,
+			// since the WAL expects a 1:1 relationship between txn ids
+			// and record indexes. This is done before the actual snapshot so
+			// that a failure to snapshot still appends a record to the WAL,
+			// avoiding a WAL deadlock.
+			if err := db.wal.Log(
+				tx,
+				&walpb.Record{
+					Entry: &walpb.Entry{
+						EntryType: &walpb.Entry_Snapshot_{Snapshot: &walpb.Entry_Snapshot{Tx: tx}},
+					},
+				},
+			); err != nil {
+				level.Error(db.logger).Log(
+					"msg", "failed to append snapshot record to WAL", "err", err,
+				)
+				return
+			}
+		}
 		if err := db.snapshotAtTX(ctx, tx, writeSnapshot); err != nil {
 			level.Error(db.logger).Log(
 				"msg", "failed to snapshot database", "err", err,

--- a/snapshot.go
+++ b/snapshot.go
@@ -427,7 +427,7 @@ func WriteSnapshot(ctx context.Context, tx uint64, db *DB, w io.Writer, offline 
 				},
 			}
 
-			if err := block.Index().Snapshot(func(p parts.Part) error {
+			if err := block.Index().Snapshot(tx, func(p parts.Part) error {
 				granuleMeta := &snapshotpb.Granule{}
 				partMeta := &snapshotpb.Part{
 					StartOffset:     int64(offW.offset),

--- a/table.go
+++ b/table.go
@@ -1035,7 +1035,7 @@ func newTableBlock(table *Table, prevTx, tx uint64, id ulid.ULID) (*TableBlock, 
 		filepath.Join(table.db.indexDir(), table.name, id.String()), // Any index files are found at <db.indexDir>/<table.name>/<block.id>
 		table.schema,
 		table.IndexConfig(),
-		table.db.Wait,
+		table.db.HighWatermark,
 		index.LSMWithMetrics(table.metrics.indexMetrics),
 		index.LSMWithLogger(table.logger),
 	)


### PR DESCRIPTION
This modifies the way snapshots are performed to ensure that a snapshot only ever contains data that is <= the snapshot_tx