### PR TITLE
Add `OpNotContains` filter

### DIFF
--- a/logictest/testdata/exec/filter/filter
+++ b/logictest/testdata/exec/filter/filter
@@ -158,12 +158,29 @@ select labels, timestamp, value where doesntexist <= 4
 ----
 
 exec
-select stacktrace, value where stacktrace LIKE 'ack'
+select stacktrace, value where stacktrace like 'ack'
 ----
 stack1  1
 stack1  2
 stack1  3
 
 exec
-select stacktrace, value where stacktrace LIKE 'ack2'
+select stacktrace, value where stacktrace like 'ack2'
 ----
+
+exec
+select stacktrace, value where stacktrace not like 'ack'
+----
+
+exec
+select stacktrace, value where stacktrace not like 'ack2'
+----
+stack1  1
+stack1  2
+stack1  3
+
+exec
+select stacktrace, value where labels.label1 not like 'ue2' and stacktrace like 'ack'
+----
+stack1  1
+stack1  3

--- a/logictest/testdata/exec/filter/filter_contains
+++ b/logictest/testdata/exec/filter/filter_contains
@@ -17,3 +17,8 @@ select labels, timestamp, value where value LIKE 'a'
 ----
 value2  value2  value3  null    2       bar
 value3  value2  null    value4  3       baz
+
+exec
+select labels, timestamp, value where value NOT LIKE 'a'
+----
+value1  value2  null    null    1       foo

--- a/logictest/testdata/plan/filter/filter
+++ b/logictest/testdata/plan/filter/filter
@@ -4,4 +4,14 @@ createtable schema=default
 exec
 explain select stacktrace, value where stacktrace LIKE 'ack'
 ----
-TableScan [concurrent] - PredicateFilter (stacktrace |= ack) - Projection (stacktrace, value) - Synchronizer
+TableScan [concurrent] - PredicateFilter (stacktrace contains ack) - Projection (stacktrace, value) - Synchronizer
+
+exec
+explain select stacktrace, value where stacktrace NOT LIKE 'ack'
+----
+TableScan [concurrent] - PredicateFilter (stacktrace not contains ack) - Projection (stacktrace, value) - Synchronizer
+
+exec
+explain select stacktrace, value where labels.label1 not like 'ue2' and stacktrace like 'ack'
+----
+TableScan [concurrent] - PredicateFilter ((labels.label1 not contains ue2 AND stacktrace contains ack)) - Projection (stacktrace, value) - Synchronizer

--- a/query/logicalplan/expr.go
+++ b/query/logicalplan/expr.go
@@ -29,6 +29,7 @@ const (
 	OpMul
 	OpDiv
 	OpContains
+	OpNotContains
 )
 
 func (o Op) String() string {
@@ -62,7 +63,9 @@ func (o Op) String() string {
 	case OpDiv:
 		return "/"
 	case OpContains:
-		return "|="
+		return "contains"
+	case OpNotContains:
+		return "not contains"
 	default:
 		panic("unknown operator")
 	}
@@ -95,7 +98,7 @@ func (o Op) ArrowString() string {
 	case OpDiv:
 		return "divide"
 	default:
-		panic("unknown operator")
+		panic("unknown arrow operator")
 	}
 }
 
@@ -419,6 +422,14 @@ func (c *Column) Contains(pattern string) *BinaryExpr {
 	return &BinaryExpr{
 		Left:  c,
 		Op:    OpContains,
+		Right: Literal(pattern),
+	}
+}
+
+func (c *Column) ContainsNot(pattern string) *BinaryExpr {
+	return &BinaryExpr{
+		Left:  c,
+		Op:    OpNotContains,
 		Right: Literal(pattern),
 	}
 }

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -63,7 +63,20 @@ func (f PreExprVisitorFunc) PostVisit(_ logicalplan.Expr) bool {
 
 func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) {
 	switch expr.Op {
-	case logicalplan.OpEq, logicalplan.OpNotEq, logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq, logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch, logicalplan.OpAdd, logicalplan.OpSub, logicalplan.OpMul, logicalplan.OpDiv, logicalplan.OpContains:
+	case logicalplan.OpEq,
+		logicalplan.OpNotEq,
+		logicalplan.OpLt,
+		logicalplan.OpLtEq,
+		logicalplan.OpGt,
+		logicalplan.OpGtEq,
+		logicalplan.OpRegexMatch,
+		logicalplan.OpRegexNotMatch,
+		logicalplan.OpAdd,
+		logicalplan.OpSub,
+		logicalplan.OpMul,
+		logicalplan.OpDiv,
+		logicalplan.OpContains,
+		logicalplan.OpNotContains:
 		var leftColumnRef *ArrayRef
 		expr.Left.Accept(PreExprVisitorFunc(func(expr logicalplan.Expr) bool {
 			switch e := expr.(type) {

--- a/sqlparse/visitor.go
+++ b/sqlparse/visitor.go
@@ -293,9 +293,14 @@ func (v *astVisitor) leaveImpl(n ast.Node) error {
 		leftExpr, newExprs := pop(newExprs)
 		v.exprStack = newExprs
 
+		op := logicalplan.OpContains
+		if expr.Not {
+			op = logicalplan.OpNotContains
+		}
+
 		v.exprStack = append(v.exprStack, &logicalplan.BinaryExpr{
 			Left:  logicalplan.Col(leftExpr.Name()),
-			Op:    logicalplan.OpContains,
+			Op:    op,
 			Right: rightExpr,
 		})
 	case *ast.GroupByClause:


### PR DESCRIPTION
Similar to `OpContains`, adding `OpNotContains` now. 
It reuses the same `BinaryScalarOperation` but sets a `not` flag to negate all results. 

@brancz, you were right about using `contains` over `|=`. This is because it is obvious that adding `not contains` now and the `!=` would have conflicted. I decided to call it `contains` and not `like` because like has some additional properties that this operator doesn't fulfill. 