### PR TITLE
Snapshot: Always acquire an ActiveWriteBlock

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -409,7 +409,7 @@ func BenchmarkSnapshot(b *testing.B) {
 	bytesWritten := 0
 	for i := 0; i < b.N; i++ {
 		wc := &writeCounter{Writer: io.Discard}
-		require.NoError(b, WriteSnapshot(ctx, db.HighWatermark(), db, wc, false))
+		require.NoError(b, WriteSnapshot(ctx, db.HighWatermark(), db, wc))
 		bytesWritten += wc.count
 	}
 	b.ReportMetric(float64(bytesWritten)/float64(b.N), "size/op")


### PR DESCRIPTION
When we were closing the database we may take a snapshot on close. If we do, that snapshot was taking on "offline" snapshot which doesn't acquire the active writeblock.

Because it doesn't acquire an active write block it menat it could race with an active block rotation, which could close the index before the snapshot occurs resulting in a bad snapshot.

This changes the snapshot behavior to always be "online" and acquire the active write block.