### PR TITLE
help add the logic of creating arrow builder for the type uint64 in Go

### DIFF
--- a/internal/records/record_builder.go
+++ b/internal/records/record_builder.go
@@ -584,6 +584,17 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 			}
 			return e.Append(v.Int())
 		}
+	case *array.Uint64DictionaryBuilder:
+		f.buildFunc = func(v reflect.Value) error {
+			if nullable {
+				if v.IsNil() {
+					e.AppendNull()
+					return nil
+				}
+				v = v.Elem()
+			}
+			return e.Append(v.Uint())
+		}
 	case *array.Float64Builder:
 		f.buildFunc = func(v reflect.Value) error {
 			if nullable {
@@ -653,6 +664,19 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 				e.Append(true)
 				build.Reserve(v.Len())
 				return applyInt(v, func(i int64) error {
+					build.Append(i)
+					return nil
+				})
+			}
+		case *array.Uint64Builder:
+			f.buildFunc = func(v reflect.Value) error {
+				if v.IsNil() {
+					e.AppendNull()
+					return nil
+				}
+				e.Append(true)
+				build.Reserve(v.Len())
+				return applyUInt(v, func(i uint64) error {
 					build.Append(i)
 					return nil
 				})
@@ -756,6 +780,12 @@ func applyBool(v reflect.Value, apply func(bool) error) error {
 func applyInt(v reflect.Value, apply func(int64) error) error {
 	return listApply[int64](v, func(v reflect.Value) int64 {
 		return v.Int()
+	}, apply)
+}
+
+func applyUInt(v reflect.Value, apply func(uint64) error) error {
+	return listApply[uint64](v, func(v reflect.Value) uint64 {
+		return v.Uint()
 	}, apply)
 }
 

--- a/internal/records/record_builder.go
+++ b/internal/records/record_builder.go
@@ -561,6 +561,17 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 			e.Append(v.Int())
 			return nil
 		}
+	case *array.Int64DictionaryBuilder:
+		f.buildFunc = func(v reflect.Value) error {
+			if nullable {
+				if v.IsNil() {
+					e.AppendNull()
+					return nil
+				}
+				v = v.Elem()
+			}
+			return e.Append(v.Int())
+		}
 	case *array.Uint64Builder:
 		f.buildFunc = func(v reflect.Value) error {
 			if nullable {
@@ -572,17 +583,6 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 			}
 			e.Append(v.Uint())
 			return nil
-		}
-	case *array.Int64DictionaryBuilder:
-		f.buildFunc = func(v reflect.Value) error {
-			if nullable {
-				if v.IsNil() {
-					e.AppendNull()
-					return nil
-				}
-				v = v.Elem()
-			}
-			return e.Append(v.Int())
 		}
 	case *array.Uint64DictionaryBuilder:
 		f.buildFunc = func(v reflect.Value) error {

--- a/internal/records/record_builder.go
+++ b/internal/records/record_builder.go
@@ -668,6 +668,16 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 					return nil
 				})
 			}
+		case *array.Int64DictionaryBuilder:
+			f.buildFunc = func(v reflect.Value) error {
+				if v.IsNil() {
+					e.AppendNull()
+					return nil
+				}
+				e.Append(true)
+				build.Reserve(v.Len())
+				return applyInt(v, build.Append)
+			}
 		case *array.Uint64Builder:
 			f.buildFunc = func(v reflect.Value) error {
 				if v.IsNil() {
@@ -681,17 +691,6 @@ func newFieldBuild(dt arrow.DataType, mem memory.Allocator, name string, nullabl
 					return nil
 				})
 			}
-		case *array.Int64DictionaryBuilder:
-			f.buildFunc = func(v reflect.Value) error {
-				if v.IsNil() {
-					e.AppendNull()
-					return nil
-				}
-				e.Append(true)
-				build.Reserve(v.Len())
-				return applyInt(v, build.Append)
-			}
-
 		case *array.Float64Builder:
 			f.buildFunc = func(v reflect.Value) error {
 				if v.IsNil() {

--- a/internal/records/record_builder_test.go
+++ b/internal/records/record_builder_test.go
@@ -53,6 +53,7 @@ func TestBuild(t *testing.T) {
 			Bool       []bool
 			String     []string
 			StringDict []string `frostdb:",rle_dict"`
+			Uint64     []uint64
 		}
 		b := records.NewBuild[Repeated](memory.DefaultAllocator)
 		defer b.Release()
@@ -100,6 +101,14 @@ func TestBuild(t *testing.T) {
         "nullable": true,
         "repeated": true
       }
+    },
+ 	{
+      "name": "uint64",
+      "storageLayout": {
+        "type": "TYPE_UINT64",
+        "nullable": true,
+        "repeated": true
+      }
     }
   ]
 }`
@@ -115,6 +124,7 @@ func TestBuild(t *testing.T) {
 				Bool:       []bool{true, true},
 				String:     []string{"a", "b"},
 				StringDict: []string{"a", "b"},
+				Uint64:     []uint64{1, 2},
 			},
 			Repeated{
 				Int:        []int64{1, 2},
@@ -122,12 +132,13 @@ func TestBuild(t *testing.T) {
 				Bool:       []bool{true, true},
 				String:     []string{"a", "b"},
 				StringDict: []string{"c", "d"},
+				Uint64:     []uint64{1, 2},
 			},
 		)
 		require.Nil(t, err)
-		want := `[{"bool":null,"float":null,"int":null,"string":null,"string_dict":null}
-,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["a","b"]}
-,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["c","d"]}
+		want := `[{"bool":null,"float":null,"int":null,"string":null,"string_dict":null, "uint64":null}
+,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["a","b"],"uint64":[1, 2]}
+,{"bool":[true,true],"float":[1,2],"int":[1,2],"string":["a","b"],"string_dict":["c","d"],"uint64":[1, 2]}
 ]`
 		r := b.NewRecord()
 		data, _ := r.MarshalJSON()


### PR DESCRIPTION
Hi, long time no see. Wish you all the best. 
Recently I learned the base knowledge of Apache Arrow and read the code for creating Arrow Builder in your project. I noticed that you are only supporting some primitive types in Go, and these types are int64, float64, string, and bool. 
So I would like to help implement builders for other primitive types in Go, such as uint64, uint8, etc.
I also noticed that we should define the values of enums in protobuf, and the type uint64 has already been defined there. So this PR is just a case for what I want to do, and it implements the arrow builder for the type uint64. 
Would like to wait for your opinions or concerns, thanks!