### PR TITLE
physicalplan: short-circuit AndExpr if left side evaluates to false

### DIFF
--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -175,6 +175,10 @@ func (a *AndExpr) Eval(r arrow.Record) (*Bitmap, error) {
 		return nil, err
 	}
 
+	if left.IsEmpty() {
+		return left, nil
+	}
+
 	right, err := a.Right.Eval(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, filters run on records would run both the left and right expression on records. However, it is possible to short circuit the evaluation if the left expression evaluates to false on all rows in a record.