### PR TITLE
Fix: double snapshot data loss

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -2853,8 +2853,6 @@ func Test_DB_SnapshotDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	db, err = c.DB(context.Background(), "test")
 	require.NoError(t, err)
-	table, err = db.Table("test", config)
-	require.NoError(t, err)
 
 	validateRows := func(expected int64) {
 		pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
@@ -2942,8 +2940,6 @@ func Test_DB_SnapshotDuplicate_Corrupted(t *testing.T) {
 	})
 	require.NoError(t, err)
 	db, err = c.DB(context.Background(), "test")
-	require.NoError(t, err)
-	table, err = db.Table("test", config)
 	require.NoError(t, err)
 
 	validateRows := func(expected int64) {

--- a/db_test.go
+++ b/db_test.go
@@ -2784,3 +2784,181 @@ func Test_DB_SnapshotNewerData(t *testing.T) {
 		})
 	}
 }
+
+// Test_DB_SnapshotDuplicate verifies that if we attempt to take a snapshot again at the same tx that it will abort if the current snapshot is valid.
+func Test_DB_SnapshotDuplicate(t *testing.T) {
+	t.Parallel()
+	config := NewTableConfig(
+		dynparquet.SampleDefinition(),
+	)
+	logger := newTestLogger(t)
+
+	cfg := []*index.LevelConfig{
+		{Level: index.L0, MaxSize: 336, Type: index.CompactionTypeParquetDisk},
+		{Level: index.L1, MaxSize: 1024 * 1024 * 128, Type: index.CompactionTypeParquetDisk},
+		{Level: index.L2, MaxSize: 1024 * 1024 * 512},
+	}
+	dir := t.TempDir()
+	c, err := New(
+		WithLogger(logger),
+		WithIndexConfig(cfg),
+		WithStoragePath(dir),
+		WithWAL(),
+		WithManualBlockRotation(),
+		WithSnapshotTriggerSize(1024*1024*1024), // we just need a non-zero value; but don't want the writes to unexpectedly trigger a snapshot
+	)
+	t.Cleanup(func() {
+		require.NoError(t, c.Close())
+	})
+	require.NoError(t, err)
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	samples := dynparquet.GenerateTestSamples(10)
+	r, err := samples.ToRecord()
+	require.NoError(t, err)
+	_, err = table.InsertRecord(ctx, r)
+	require.NoError(t, err)
+
+	require.NoError(t, table.EnsureCompaction())
+
+	// Snapshot the file
+	success := false
+	table.db.snapshot(context.Background(), false, func() {
+		success = true
+	})
+	require.True(t, success)
+
+	require.NoError(t, db.wal.Truncate(2))
+	time.Sleep(1 * time.Second) // wal flushes every 50ms
+
+	// Close the database to trigger a snapshot on close
+	require.NoError(t, c.Close())
+
+	// Reopen the database and expect the data to be there
+	c, err = New(
+		WithLogger(logger),
+		WithIndexConfig(cfg),
+		WithStoragePath(dir),
+		WithWAL(),
+		WithManualBlockRotation(),
+		WithSnapshotTriggerSize(1024*1024*1024), // we just need a non-zero value; but don't want the writes to unexpectedly trigger a snapshot
+	)
+	t.Cleanup(func() {
+		require.NoError(t, c.Close())
+	})
+	require.NoError(t, err)
+	db, err = c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err = db.Table("test", config)
+	require.NoError(t, err)
+
+	validateRows := func(expected int64) {
+		pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+		defer pool.AssertSize(t, 0)
+		rows := int64(0)
+		engine := query.NewEngine(pool, db.TableProvider())
+		err = engine.ScanTable("test").
+			Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+				rows += r.NumRows()
+				return nil
+			})
+		require.NoError(t, err)
+		require.Equal(t, expected, rows)
+	}
+
+	validateRows(10)
+}
+
+func Test_DB_SnapshotDuplicate_Corrupted(t *testing.T) {
+	t.Parallel()
+	config := NewTableConfig(
+		dynparquet.SampleDefinition(),
+	)
+	logger := newTestLogger(t)
+
+	cfg := []*index.LevelConfig{
+		{Level: index.L0, MaxSize: 336, Type: index.CompactionTypeParquetDisk},
+		{Level: index.L1, MaxSize: 1024 * 1024 * 128, Type: index.CompactionTypeParquetDisk},
+		{Level: index.L2, MaxSize: 1024 * 1024 * 512},
+	}
+	dir := t.TempDir()
+	c, err := New(
+		WithLogger(logger),
+		WithIndexConfig(cfg),
+		WithStoragePath(dir),
+		WithWAL(),
+		WithManualBlockRotation(),
+		WithSnapshotTriggerSize(1024*1024*1024), // we just need a non-zero value; but don't want the writes to unexpectedly trigger a snapshot
+	)
+	t.Cleanup(func() {
+		require.NoError(t, c.Close())
+	})
+	require.NoError(t, err)
+	db, err := c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err := db.Table("test", config)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	samples := dynparquet.GenerateTestSamples(10)
+	r, err := samples.ToRecord()
+	require.NoError(t, err)
+	_, err = table.InsertRecord(ctx, r)
+	require.NoError(t, err)
+
+	require.NoError(t, table.EnsureCompaction())
+
+	// Snapshot the file
+	success := false
+	table.db.snapshot(context.Background(), false, func() {
+		success = true
+	})
+	require.True(t, success)
+
+	require.NoError(t, db.wal.Truncate(2))
+	time.Sleep(1 * time.Second) // wal flushes every 50ms
+
+	// Corrupt the snapshot file.
+	require.NoError(t, os.Truncate(filepath.Join(SnapshotDir(db, 2), snapshotFileName(2)), 100))
+
+	// Close the database to trigger a snapshot on close
+	require.NoError(t, c.Close())
+
+	// Reopen the database and expect the data to be there
+	c, err = New(
+		WithLogger(logger),
+		WithIndexConfig(cfg),
+		WithStoragePath(dir),
+		WithWAL(),
+		WithManualBlockRotation(),
+		WithSnapshotTriggerSize(1024*1024*1024), // we just need a non-zero value; but don't want the writes to unexpectedly trigger a snapshot
+	)
+	t.Cleanup(func() {
+		require.NoError(t, c.Close())
+	})
+	require.NoError(t, err)
+	db, err = c.DB(context.Background(), "test")
+	require.NoError(t, err)
+	table, err = db.Table("test", config)
+	require.NoError(t, err)
+
+	validateRows := func(expected int64) {
+		pool := memory.NewCheckedAllocator(memory.DefaultAllocator)
+		defer pool.AssertSize(t, 0)
+		rows := int64(0)
+		engine := query.NewEngine(pool, db.TableProvider())
+		err = engine.ScanTable("test").
+			Execute(context.Background(), func(ctx context.Context, r arrow.Record) error {
+				rows += r.NumRows()
+				return nil
+			})
+		require.NoError(t, err)
+		require.Equal(t, expected, rows)
+	}
+
+	validateRows(10)
+}


### PR DESCRIPTION
Previously if we took a snapshot, stopped writing and shutdown the database we would take another snapshot. This snapshot would fail which would cause it to remove the valid snapshot directory.

This changes the behavior of snapshots to first check if a snapshot already exists. If it does validate it and if the snapshot is valid abort taking a new one. If the snapshot is invalid then remove it and perform the snapshot.

Closes #753 