### PR TITLE
Push down query filter to Parquet conversion.

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -17,6 +17,7 @@ import (
 	"github.com/polarsignals/frostdb/pqarrow/convert"
 	"github.com/polarsignals/frostdb/pqarrow/writer"
 	"github.com/polarsignals/frostdb/query/logicalplan"
+	"github.com/polarsignals/frostdb/query/physicalplan"
 )
 
 // ParquetRowGroupToArrowSchema converts a parquet row group to an arrow schema.
@@ -212,9 +213,10 @@ type ParquetConverter struct {
 
 	// Output fields, for each outputSchema.Field(i) there will always be a
 	// corresponding builder.Field(i).
-	outputSchema *arrow.Schema
-	iterOpts     logicalplan.IterOptions
-	builder      *builder.RecordBuilder
+	outputSchema   *arrow.Schema
+	iterOpts       logicalplan.IterOptions
+	rowGroupFilter physicalplan.BooleanExpression
+	builder        *builder.RecordBuilder
 
 	// writers are wrappers over a subset of builder.Fields().
 	writers []MultiColumnWriter
@@ -240,7 +242,15 @@ func NewParquetConverter(
 		distinctColInfos: make([]*distinctColInfo, len(iterOpts.DistinctColumns)),
 	}
 
-	if iterOpts.Filter == nil && len(iterOpts.DistinctColumns) != 0 {
+	if iterOpts.Filter != nil {
+		var err error
+		c.rowGroupFilter, err = physicalplan.BooleanExpr(iterOpts.Filter)
+		if err != nil {
+			// This should never happen, as the filter has already been
+			// validated.
+			panic(fmt.Sprintf("programming error: %v", err))
+		}
+	} else if len(iterOpts.DistinctColumns) != 0 {
 		simpleDistinctExprs := true
 		for _, distinctColumn := range iterOpts.DistinctColumns {
 			if _, ok := distinctColumn.(*logicalplan.DynamicColumn); ok ||
@@ -330,6 +340,18 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup, s *
 		// If we get here, we couldn't use the fast path.
 	}
 
+	// Instead of converting every row in a row group we can apply the filter
+	// to the Parquet rows that we've read into memory, and then convert only
+	// the rows that pass the filter. This saves on during Arrow record building.
+	var bm *physicalplan.Bitmap
+	columnData := make([][]parquet.Value, len(rg.ColumnChunks()))
+	if c.rowGroupFilter != nil {
+		bm, columnData, err = c.rowGroupFilter.EvalParquet(rg, columnData)
+		if err != nil {
+			return fmt.Errorf("physical filter of Parquet rows: %w", err)
+		}
+	}
+
 	for _, w := range c.writers {
 		for _, col := range w.colIdx {
 			select {
@@ -341,6 +363,8 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup, s *
 					parquetColumns[col],
 					false,
 					w.writer,
+					bm,
+					columnData[col]...,
 				); err != nil {
 					return fmt.Errorf("convert parquet column to arrow array: %w", err)
 				}
@@ -621,6 +645,7 @@ func (c *ParquetConverter) writeDistinctSingleColumn(
 			columnChunk,
 			true,
 			info.w,
+			nil,
 		); err != nil {
 			return false, err
 		}
@@ -712,6 +737,8 @@ func (c *ParquetConverter) writeColumnToArray(
 	columnChunk parquet.ColumnChunk,
 	dictionaryOnly bool,
 	w writer.ValueWriter,
+	bitmap *physicalplan.Bitmap,
+	preReadValues ...parquet.Value, // Pre-read values if this column was filtered.
 ) error {
 	repeated := n.Repeated()
 	if !repeated && dictionaryOnly {
@@ -772,6 +799,7 @@ func (c *ParquetConverter) writeColumnToArray(
 
 	pages := columnChunk.Pages()
 	defer pages.Close()
+	offset := 0
 	for {
 		p, err := pages.ReadPage()
 		if err != nil {
@@ -783,13 +811,13 @@ func (c *ParquetConverter) writeColumnToArray(
 		dict := p.Dictionary()
 
 		switch {
-		case !repeated && dictionaryOnly && dict != nil && p.NumNulls() == 0:
+		case bitmap == nil && !repeated && dictionaryOnly && dict != nil && p.NumNulls() == 0:
 			// If we are only writing the dictionary, we don't need to read
 			// the values.
 			if err := w.WritePage(dict.Page()); err != nil {
 				return fmt.Errorf("write dictionary page: %w", err)
 			}
-		case !repeated && p.NumNulls() == 0 && dict == nil:
+		case bitmap == nil && !repeated && p.NumNulls() == 0 && dict == nil:
 			// If the column has no nulls, we can read all values at once
 			// consecutively without worrying about null values.
 			if err := w.WritePage(p); err != nil {
@@ -802,14 +830,30 @@ func (c *ParquetConverter) writeColumnToArray(
 				c.scratchValues = c.scratchValues[:n]
 			}
 
-			// We're reading all values in the page so we always expect an io.EOF.
-			reader := p.Values()
-			if _, err := reader.ReadValues(c.scratchValues); err != nil && err != io.EOF {
-				return fmt.Errorf("read values: %w", err)
+			values := c.scratchValues
+			// If values were already read due to the push down of a physical filter. They may be provided to this function to avoid
+			// re-reading them during Arrow conversion.
+			if len(preReadValues) != 0 {
+				values = preReadValues
+			} else {
+				reader := p.Values()
+				if _, err := reader.ReadValues(values); err != nil && err != io.EOF {
+					return fmt.Errorf("read values: %w", err)
+				}
 			}
 
-			w.Write(c.scratchValues)
+			if bitmap != nil && bitmap.GetCardinality() > 0 {
+				for _, i := range bitmap.ToArray() {
+					if offset <= int(i) && int(i) < offset+int(p.NumValues()) {
+						index := int(i) - offset
+						w.Write([]parquet.Value{values[index]})
+					}
+				}
+			} else {
+				w.Write(values)
+			}
 		}
+		offset += int(p.NumValues())
 	}
 
 	return nil

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -5,18 +5,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"regexp"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/compute"
 	"github.com/apache/arrow/go/v15/arrow/scalar"
+	"github.com/parquet-go/parquet-go"
 
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 type ArrayRef struct {
 	ColumnName string
+}
+
+func (a *ArrayRef) ColumnChunk(rg parquet.RowGroup) (parquet.ColumnChunk, int, bool) {
+	leaf, ok := rg.Schema().Lookup(a.ColumnName)
+	if !ok {
+		return nil, -1, false
+	}
+
+	return rg.ColumnChunks()[leaf.ColumnIndex], leaf.ColumnIndex, true
 }
 
 func (a *ArrayRef) ArrowArray(r arrow.Record) (arrow.Array, bool, error) {
@@ -36,6 +48,221 @@ type BinaryScalarExpr struct {
 	Left  *ArrayRef
 	Op    logicalplan.Op
 	Right scalar.Scalar
+}
+
+func (e BinaryScalarExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
+	leftData, index, exists := e.Left.ColumnChunk(rg)
+
+	if !exists {
+		res := NewBitmap()
+		switch e.Op {
+		case logicalplan.OpEq:
+			if e.Right.IsValid() { // missing column; looking for == non-nil
+				switch t := e.Right.(type) {
+				case *scalar.Binary:
+					if t.String() != "" { // treat empty string equivalent to nil
+						return res, nil, nil
+					}
+				case *scalar.String:
+					if t.String() != "" { // treat empty string equivalent to nil
+						return res, nil, nil
+					}
+				}
+			}
+		case logicalplan.OpNotEq: // missing column; looking for != nil
+			if !e.Right.IsValid() {
+				return res, nil, nil
+			}
+		case logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq:
+			return res, nil, nil
+		}
+
+		res.AddRange(0, uint64(rg.NumRows()))
+		return res, nil, nil
+	}
+
+	bm, col, err := BinaryScalarParquetOperation(leftData, e.Right, e.Op)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	in[index] = col
+	return bm, in, nil
+}
+
+func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar, operator logicalplan.Op) (*Bitmap, []parquet.Value, error) {
+	bm := NewBitmap()
+	switch operator { // TODO(optimize): Use the bloom filter or index to speed up the operation for pages with no matching values
+	case logicalplan.OpContains, logicalplan.OpNotContains:
+		var r []byte
+		switch s := right.(type) {
+		case *scalar.Binary:
+			r = s.Data()
+		case *scalar.String:
+			r = s.Data()
+		}
+
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			contains := bytes.Contains(value.Bytes(), r)
+			if contains && operator == logicalplan.OpContains || !contains && operator == logicalplan.OpNotContains {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpEq:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) == 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpNotEq:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) != 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpLt:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) < 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpLtEq:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) <= 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpGt:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) > 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpGtEq:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			if ParquetValueCompareArrowScalar(value, right) >= 0 {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	case logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch:
+		col, err := forEachParquetValue(left, func(i int, value parquet.Value) error {
+			match, err := regexp.MatchString(right.String(), value.String())
+			if err != nil {
+				return err
+			}
+			if match && operator == logicalplan.OpRegexMatch || !match && operator == logicalplan.OpRegexNotMatch {
+				bm.AddInt(i)
+			}
+			return nil
+		})
+		return bm, col, err
+	default:
+		return nil, nil, fmt.Errorf("unsupported operator: %v", operator)
+	}
+}
+
+// ParquetValueCompareArrowScalar compares a parquet.Value to a scalar.Scalar
+// It returns 0 if they are equal, -1 if the parquet.Value is less than the scalar.Scalar, and 1 if the parquet.Value is greater than the scalar.Scalar
+func ParquetValueCompareArrowScalar(v parquet.Value, s scalar.Scalar) int {
+	switch v.Kind() {
+	case parquet.Boolean:
+		if v.Boolean() == s.(*scalar.Boolean).Value {
+			return 0
+		} else if v.Boolean() {
+			return 1
+		} else {
+			return -1
+		}
+	case parquet.Int32:
+		if v.Int32() == s.(*scalar.Int32).Value {
+			return 0
+		} else if v.Int32() > s.(*scalar.Int32).Value {
+			return 1
+		} else {
+			return -1
+		}
+	case parquet.Int64:
+		if v.Int64() == s.(*scalar.Int64).Value {
+			return 0
+		} else if v.Int64() > s.(*scalar.Int64).Value {
+			return 1
+		} else {
+			return -1
+		}
+	case parquet.Float:
+		if v.Float() == s.(*scalar.Float32).Value {
+			return 0
+		} else if v.Float() > s.(*scalar.Float32).Value {
+			return 1
+		} else {
+			return -1
+		}
+	case parquet.Double:
+		if v.Double() == s.(*scalar.Float64).Value {
+			return 0
+		} else if v.Double() > s.(*scalar.Float64).Value {
+			return 1
+		} else {
+			return -1
+		}
+	case parquet.ByteArray:
+		if string(v.ByteArray()) == s.(*scalar.String).String() {
+			return 0
+		} else if string(v.ByteArray()) > s.(*scalar.String).String() {
+			return 1
+		} else {
+			return -1
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %v", v.Kind()))
+	}
+}
+
+func forEachParquetValue(chunk parquet.ColumnChunk, f func(i int, value parquet.Value) error) ([]parquet.Value, error) {
+	vals := make([]parquet.Value, chunk.NumValues())
+	pages := chunk.Pages()
+	defer pages.Close()
+	i := 0
+	n := 0
+	for {
+		p, err := pages.ReadPage()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		reader := p.Values()
+		n, err = reader.ReadValues(vals[n:])
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		for _, v := range vals {
+			if !v.IsNull() {
+				if err := f(i, v); err != nil {
+					return nil, err
+				}
+			}
+			i++
+		}
+	}
+
+	return vals, nil
 }
 
 func (e BinaryScalarExpr) Eval(r arrow.Record) (*Bitmap, error) {

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -176,7 +176,7 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 }
 
 // ParquetValueCompareArrowScalar compares a parquet.Value to a scalar.Scalar
-// It returns 0 if they are equal, -1 if the parquet.Value is less than the scalar.Scalar, and 1 if the parquet.Value is greater than the scalar.Scalar
+// It returns 0 if they are equal, -1 if the parquet.Value is less than the scalar.Scalar, and 1 if the parquet.Value is greater than the scalar.Scalar.
 func ParquetValueCompareArrowScalar(v parquet.Value, s scalar.Scalar) int {
 	switch v.Kind() {
 	case parquet.Boolean:

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/memory"
 	"github.com/apache/arrow/go/v15/arrow/scalar"
+	"github.com/parquet-go/parquet-go"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/polarsignals/frostdb/query/logicalplan"
@@ -40,6 +41,7 @@ func NewBitmap() *Bitmap {
 
 type BooleanExpression interface {
 	Eval(r arrow.Record) (*Bitmap, error)
+	EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error)
 	String() string
 }
 
@@ -130,12 +132,12 @@ func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) 
 			Right: rightScalar,
 		}, nil
 	case logicalplan.OpAnd:
-		left, err := booleanExpr(expr.Left)
+		left, err := BooleanExpr(expr.Left)
 		if err != nil {
 			return nil, fmt.Errorf("left bool expr: %w", err)
 		}
 
-		right, err := booleanExpr(expr.Right)
+		right, err := BooleanExpr(expr.Right)
 		if err != nil {
 			return nil, fmt.Errorf("right bool expr: %w", err)
 		}
@@ -145,12 +147,12 @@ func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) 
 			Right: right,
 		}, nil
 	case logicalplan.OpOr:
-		left, err := booleanExpr(expr.Left)
+		left, err := BooleanExpr(expr.Left)
 		if err != nil {
 			return nil, fmt.Errorf("left bool expr: %w", err)
 		}
 
-		right, err := booleanExpr(expr.Right)
+		right, err := BooleanExpr(expr.Right)
 		if err != nil {
 			return nil, fmt.Errorf("right bool expr: %w", err)
 		}
@@ -167,6 +169,26 @@ func binaryBooleanExpr(expr *logicalplan.BinaryExpr) (BooleanExpression, error) 
 type AndExpr struct {
 	Left  BooleanExpression
 	Right BooleanExpression
+}
+
+func (a *AndExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
+	left, lout, err := a.Left.EvalParquet(rg, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if left.IsEmpty() {
+		return left, nil, nil
+	}
+
+	right, rout, err := a.Right.EvalParquet(rg, lout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// This stores the result in place to avoid allocations.
+	left.And(right)
+	return left, rout, nil
 }
 
 func (a *AndExpr) Eval(r arrow.Record) (*Bitmap, error) {
@@ -198,6 +220,22 @@ type OrExpr struct {
 	Right BooleanExpression
 }
 
+func (a *OrExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
+	left, lout, err := a.Left.EvalParquet(rg, in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	right, rout, err := a.Right.EvalParquet(rg, lout)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// This stores the result in place to avoid allocations.
+	left.Or(right)
+	return left, rout, nil
+}
+
 func (a *OrExpr) Eval(r arrow.Record) (*Bitmap, error) {
 	left, err := a.Left.Eval(r)
 	if err != nil {
@@ -218,17 +256,22 @@ func (a *OrExpr) String() string {
 	return "(" + a.Left.String() + " OR " + a.Right.String() + ")"
 }
 
-func booleanExpr(expr logicalplan.Expr) (BooleanExpression, error) {
+func BooleanExpr(expr logicalplan.Expr) (BooleanExpression, error) {
 	switch e := expr.(type) {
 	case *logicalplan.BinaryExpr:
 		return binaryBooleanExpr(e)
+	case *logicalplan.AggregationFunction:
+		// This happens in the case of an aggregation function with no group by clause.
+		// It gets pushed down into the filter layer, but this isn't supported as a physical
+		// boolean expression yet.
+		return nil, nil
 	default:
 		return nil, ErrUnsupportedBooleanExpression
 	}
 }
 
 func Filter(pool memory.Allocator, tracer trace.Tracer, filterExpr logicalplan.Expr) (*PredicateFilter, error) {
-	expr, err := booleanExpr(filterExpr)
+	expr, err := BooleanExpr(filterExpr)
 	if err != nil {
 		return nil, fmt.Errorf("create bool expr: %w", err)
 	}

--- a/query/physicalplan/filter_test.go
+++ b/query/physicalplan/filter_test.go
@@ -1,9 +1,11 @@
 package physicalplan
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/apache/arrow/go/v15/arrow"
+	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +59,10 @@ var _ BooleanExpression = mockExpression{}
 
 func (e mockExpression) Eval(record arrow.Record) (*Bitmap, error) {
 	return e.evalFn(record)
+}
+
+func (e mockExpression) EvalParquet(_ parquet.RowGroup, _ [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (e mockExpression) String() string {

--- a/query/physicalplan/regexpfilter.go
+++ b/query/physicalplan/regexpfilter.go
@@ -6,12 +6,18 @@ import (
 
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
+	"github.com/parquet-go/parquet-go"
 )
 
 type RegExpFilter struct {
 	left     *ArrayRef
 	notMatch bool
 	right    *regexp.Regexp
+}
+
+func (f *RegExpFilter) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
+	// TODO THOR
+	return nil, nil, fmt.Errorf("RegExpFilter.EvalParquet: not implemented")
 }
 
 func (f *RegExpFilter) Eval(r arrow.Record) (*Bitmap, error) {

--- a/query/physicalplan/regexpfilter.go
+++ b/query/physicalplan/regexpfilter.go
@@ -30,7 +30,11 @@ func (f *RegExpFilter) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*
 		return res, nil, nil
 	}
 
-	col, err := forEachParquetValue(leftData, func(i int, v parquet.Value) error {
+	// Reuse the input slice if it's already been allocated
+	if len(in[index]) < int(leftData.NumValues()) {
+		in[index] = make([]parquet.Value, leftData.NumValues())
+	}
+	col, err := forEachParquetValue(leftData, in[index], func(i int, v parquet.Value) error {
 		match := f.right.MatchString(v.String())
 		if (f.notMatch && !match) || (!f.notMatch && match) {
 			res.Add(uint32(i))

--- a/table.go
+++ b/table.go
@@ -877,7 +877,7 @@ func (t *Table) Iterator(
 					}
 				}
 			}
-		}))
+		}, t.logger))
 	}
 
 	errg.Go(func() error {


### PR DESCRIPTION
Push the query filter down to the Parquet row group conversion layer. This saves on CPU time when building Arrow records since our row group usage tends to be sparse.

```
name               old time/op    new time/op    delta
Query/MergeAll-10     1.34s ± 1%     0.96s ± 1%  -28.18%  (p=0.000 n=10+10)
Query/Merge-10        1.33s ± 2%     0.96s ± 1%  -28.27%  (p=0.000 n=10+9)

name               old alloc/op   new alloc/op   delta
Query/MergeAll-10    5.51GB ± 0%    5.64GB ± 1%   +2.33%  (p=0.000 n=10+9)
Query/Merge-10       5.52GB ± 1%    5.65GB ± 1%   +2.35%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
Query/MergeAll-10     34.1M ± 0%     50.6M ± 0%  +48.35%  (p=0.000 n=10+10)
Query/Merge-10        34.1M ± 0%     50.6M ± 0%  +48.34%  (p=0.000 n=10+9)
```