### PR TITLE
fix: uint64 persistence

### DIFF
--- a/parts/arrow.go
+++ b/parts/arrow.go
@@ -82,7 +82,7 @@ func (p *arrowPart) Least() (*dynparquet.DynamicRow, error) {
 		return nil, err
 	}
 	defer p.schema.PutPooledParquetSchema(pooledSchema)
-	p.minRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, dynCols, 0)
+	p.minRow, err = pqarrow.RecordToDynamicRow(pooledSchema.Schema, p.record, dynCols, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (p *arrowPart) Most() (*dynparquet.DynamicRow, error) {
 		return nil, err
 	}
 	defer p.schema.PutPooledParquetSchema(pooledSchema)
-	p.maxRow, err = pqarrow.RecordToDynamicRow(p.schema, pooledSchema.Schema, p.record, dynCols, int(p.record.NumRows()-1))
+	p.maxRow, err = pqarrow.RecordToDynamicRow(pooledSchema.Schema, p.record, dynCols, int(p.record.NumRows()-1))
 	if err != nil {
 		return nil, err
 	}

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -69,7 +69,7 @@ func (w *singlePassThroughWriter) Close() error { return nil }
 func (w *singlePassThroughWriter) Reset(_ io.Writer) {}
 
 // RecordToRow converts an arrow record with dynamic columns into a row using a dynamic parquet schema.
-func RecordToRow(schema *dynparquet.Schema, final *parquet.Schema, record arrow.Record, index int) (parquet.Row, error) {
+func RecordToRow(final *parquet.Schema, record arrow.Record, index int) (parquet.Row, error) {
 	w := &singlePassThroughWriter{}
 	if err := recordToRows(w, record, index, index+1, final.Fields()); err != nil {
 		return nil, err
@@ -338,12 +338,12 @@ func RecordDynamicCols(record arrow.Record) (columns map[string][]string) {
 	return
 }
 
-func RecordToDynamicRow(dynSchema *dynparquet.Schema, pqSchema *parquet.Schema, record arrow.Record, dyncols map[string][]string, index int) (*dynparquet.DynamicRow, error) {
+func RecordToDynamicRow(pqSchema *parquet.Schema, record arrow.Record, dyncols map[string][]string, index int) (*dynparquet.DynamicRow, error) {
 	if index >= int(record.NumRows()) {
 		return nil, io.EOF
 	}
 
-	row, err := RecordToRow(dynSchema, pqSchema, record, index)
+	row, err := RecordToRow(pqSchema, record, index)
 	if err != nil {
 		return nil, err
 	}

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -71,20 +71,18 @@ func (w *singlePassThroughWriter) Reset(_ io.Writer) {}
 // RecordToRow converts an arrow record with dynamic columns into a row using a dynamic parquet schema.
 func RecordToRow(schema *dynparquet.Schema, final *parquet.Schema, record arrow.Record, index int) (parquet.Row, error) {
 	w := &singlePassThroughWriter{}
-	if err := recordToRows(w, schema.FindDynamicColumnForConcreteColumn, record, index, index+1, final.Fields()); err != nil {
+	if err := recordToRows(w, record, index, index+1, final.Fields()); err != nil {
 		return nil, err
 	}
 	return w.rows[0], nil
 }
-
-type dynamicColumnVerifier func(string) (dynparquet.ColumnDefinition, bool)
 
 // recordToRows converts a full arrow record to parquet rows which are written
 // to the parquet writer.
 // The caller should use recordStart=0 and recordEnd=record.NumRows() to convert
 // the entire record. Alternatively, the caller may only convert a subset of
 // rows by specifying a range of [recordStart, recordEnd).
-func recordToRows(w dynparquet.ParquetWriter, dcv dynamicColumnVerifier, record arrow.Record, recordStart, recordEnd int, finalFields []parquet.Field) error {
+func recordToRows(w dynparquet.ParquetWriter, record arrow.Record, recordStart, recordEnd int, finalFields []parquet.Field) error {
 	numRows := recordEnd - recordStart
 	schema := record.Schema()
 	row := make(parquet.Row, len(finalFields))
@@ -93,7 +91,7 @@ func recordToRows(w dynparquet.ParquetWriter, dcv dynamicColumnVerifier, record 
 		f := finalFields[i]
 		name := f.Name()
 		def := 0
-		if _, ok := dcv(name); ok {
+		if f.Optional() {
 			def = 1
 		}
 		idx := schema.FieldIndices(name)
@@ -113,6 +111,8 @@ func recordToRows(w dynparquet.ParquetWriter, dcv dynamicColumnVerifier, record 
 			writers[i] = writeDictionary(def, i, recordStart, a)
 		case *array.Int32:
 			writers[i] = writeInt32(def, i, recordStart, a)
+		case *array.Uint64:
+			writers[i] = writeUint64(def, i, recordStart, a)
 		case *array.Int64:
 			writers[i] = writeInt64(def, i, recordStart, a)
 		case *array.String:
@@ -147,6 +147,19 @@ func writeGeneral(def, column, startIdx int, a arrow.Array) arrowToParquet {
 		}
 		return append(w,
 			parquet.ValueOf(a.GetOneForMarshal(row+startIdx)).Level(0, def, column),
+		)
+	}
+}
+
+func writeUint64(def, column, startIdx int, a *array.Uint64) arrowToParquet {
+	return func(w parquet.Row, row int) parquet.Row {
+		if a.IsNull(row + startIdx) {
+			return append(w,
+				parquet.Value{}.Level(0, 0, column),
+			)
+		}
+		return append(w,
+			parquet.Int64Value(int64(a.Value(row+startIdx))).Level(0, def, column),
 		)
 	}
 }
@@ -380,7 +393,7 @@ func RecordsToFile(schema *dynparquet.Schema, w dynparquet.ParquetWriter, recs [
 	finalFields := ps.Schema.Fields()
 
 	for _, r := range recs {
-		if err := recordToRows(w, schema.FindDynamicColumnForConcreteColumn, r, 0, int(r.NumRows()), finalFields); err != nil {
+		if err := recordToRows(w, r, 0, int(r.NumRows()), finalFields); err != nil {
 			return err
 		}
 	}

--- a/pqarrow/parquet_test.go
+++ b/pqarrow/parquet_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/apache/arrow/go/v15/arrow/memory"
 	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
-
-	"github.com/polarsignals/frostdb/dynparquet"
 )
 
 type noopWriter struct{}
@@ -82,7 +80,7 @@ func BenchmarkRecordsToFile(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := recordToRows(
-			noopWriter{}, func(string) (dynparquet.ColumnDefinition, bool) { return dynparquet.ColumnDefinition{}, false }, record, 0, numRows, parquetFields.Fields(),
+			noopWriter{}, record, 0, numRows, parquetFields.Fields(),
 		); err != nil {
 			b.Fatal(err)
 		}
@@ -165,11 +163,11 @@ func TestRecordToRows_list(t *testing.T) {
 
 	parquetFields := parquet.Group{}
 	for _, f := range r.Schema().Fields() {
-		parquetFields[f.Name] = parquet.Node(nil)
+		parquetFields[f.Name] = parquet.Required(parquet.Node(nil))
 	}
 	clone := &cloneWriter{}
 	if err := recordToRows(
-		clone, func(string) (dynparquet.ColumnDefinition, bool) { return dynparquet.ColumnDefinition{}, false }, r, 0, int(r.NumRows()), parquetFields.Fields(),
+		clone, r, 0, int(r.NumRows()), parquetFields.Fields(),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -507,7 +507,7 @@ func Test_RecordToRow(t *testing.T) {
 	require.NoError(t, err)
 	defer dynschema.PutPooledParquetSchema(ps)
 
-	row, err := pqarrow.RecordToRow(dynschema, ps.Schema, record, 0)
+	row, err := pqarrow.RecordToRow(ps.Schema, record, 0)
 	require.NoError(t, err)
 	require.Equal(t, "[<null> hello world <null> 10 20]", fmt.Sprintf("%v", row))
 }


### PR DESCRIPTION
We preiviously were not detecting uint64 arrow arrays and weren't casting them correctly to an int64 array for Parquet. This adds the switch statement to correctly perform this conversion.

We were also assuming that ONLY dynamic columns needed to have a definition level of 1, but we have other columns that also support nullable values. This removes the dynamic column check and correctly checks the parquet optionality instead.