### PR TITLE
unit test

### DIFF
--- a/pqarrow/parquet_test.go
+++ b/pqarrow/parquet_test.go
@@ -316,4 +316,6 @@ func Test_Uint64RecordToRow(t *testing.T) {
 
 	row, err = RecordToRow(schema, r, 2)
 	require.NoError(t, err)
+
+	require.Equal(t, "[2]", fmt.Sprintf("%v", row))
 }


### PR DESCRIPTION
Ensures optional and required uint64 conversions work as expected. This was fixed in commit 1107c99 but this adds a unit test for that behavior.