### PR TITLE
query/expr: Infer type from arrow.Scalar for parquet Value

### DIFF
--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -15,6 +15,29 @@ import (
 	"github.com/polarsignals/frostdb/dynparquet"
 )
 
+func ParquetValueToArrowScalar(v parquet.Value, dataType arrow.DataType) (scalar.Scalar, error) {
+	switch dataType {
+	case arrow.PrimitiveTypes.Int8:
+		return scalar.NewInt8Scalar(int8(v.Int32())), nil
+	case arrow.PrimitiveTypes.Uint8:
+		return scalar.NewUint8Scalar(uint8(v.Uint32())), nil
+	case arrow.PrimitiveTypes.Int16:
+		return scalar.NewInt16Scalar(int16(v.Int32())), nil
+	case arrow.PrimitiveTypes.Uint16:
+		return scalar.NewUint16Scalar(uint16(v.Uint32())), nil
+	case arrow.PrimitiveTypes.Int32:
+		return scalar.NewInt32Scalar(v.Int32()), nil
+	case arrow.PrimitiveTypes.Uint32:
+		return scalar.NewUint32Scalar(v.Uint32()), nil
+	case arrow.PrimitiveTypes.Int64:
+		return scalar.NewInt64Scalar(v.Int64()), nil
+	case arrow.PrimitiveTypes.Uint64:
+		return scalar.NewUint64Scalar(v.Uint64()), nil
+	default:
+		return nil, fmt.Errorf("unsupported scalar type %s", dataType)
+	}
+}
+
 func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 	switch s := sc.(type) {
 	case *scalar.String:
@@ -22,8 +45,6 @@ func ArrowScalarToParquetValue(sc scalar.Scalar) (parquet.Value, error) {
 	case *scalar.Int64:
 		return parquet.ValueOf(s.Value), nil
 	case *scalar.Int32:
-		return parquet.ValueOf(s.Value), nil
-	case *scalar.Uint64:
 		return parquet.ValueOf(s.Value), nil
 	case *scalar.FixedSizeBinary:
 		width := s.Type.(*arrow.FixedSizeBinaryType).ByteWidth

--- a/query/expr/binaryscalarexpr_test.go
+++ b/query/expr/binaryscalarexpr_test.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"testing"
 
+	"github.com/apache/arrow/go/v15/arrow/scalar"
 	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 
@@ -199,11 +200,11 @@ func TestBinaryScalarOperation(t *testing.T) {
 				},
 				numValues: numValues,
 			}
-			var v parquet.Value
+			var v scalar.Scalar
 			if tc.right == -1 {
-				v = parquet.ValueOf(nil)
+				v = &scalar.Null{}
 			} else {
-				v = parquet.ValueOf(tc.right)
+				v = scalar.NewInt64Scalar(int64(tc.right))
 			}
 			res, err := BinaryScalarOperation(fakeChunk, v, tc.op)
 			require.NoError(t, err)


### PR DESCRIPTION
When comparing we want to use arrow's scalar.Scalar as the type supports a lot more underlying types, like unsigned integers.

Therefore, we want to convert parquet.Values to arrow scalar.Scalar and then compare. That way we can ensure that the unsigned integers, for example, are properly treated and don't overflow.
