### PR TITLE
optimize: skip reading whole column if it's been preread

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -858,7 +858,6 @@ func (c *ParquetConverter) writeColumnToArray(
 					}
 					return true
 				})
-
 			} else {
 				w.Write(c.scratchValues)
 			}


### PR DESCRIPTION
```bash
name               old time/op    new time/op    delta
Query/MergeAll-10     850ms ± 1%     867ms ± 1%  +2.04%  (p=0.000 n=8+10)
Query/Merge-10        854ms ± 2%     861ms ± 1%    ~     (p=0.075 n=10+10)

name               old alloc/op   new alloc/op   delta
Query/MergeAll-10    4.55GB ± 1%    4.25GB ± 1%  -6.47%  (p=0.000 n=10+10)
Query/Merge-10       4.55GB ± 1%    4.27GB ± 1%  -6.10%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
Query/MergeAll-10     47.6M ± 0%     47.6M ± 0%  +0.01%  (p=0.000 n=10+10)
Query/Merge-10        47.6M ± 0%     47.6M ± 0%  +0.01%  (p=0.000 n=10+10)
```