### PR TITLE
Revert parquet filtering

### DIFF
--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -802,16 +802,6 @@ func (c *ParquetConverter) writeColumnToArray(
 		}
 	}
 
-	// If values were already read due to the push down of a physical filter. They may be provided to this function to avoid
-	// re-reading them during Arrow conversion.
-	if bitmap != nil && bitmap.GetCardinality() > 0 && len(preReadValues) != 0 {
-		bitmap.Iterate(func(x uint32) bool {
-			w.Write([]parquet.Value{preReadValues[x]})
-			return true
-		})
-		return nil
-	}
-
 	pages := columnChunk.Pages()
 	defer pages.Close()
 	offset := 0
@@ -845,21 +835,27 @@ func (c *ParquetConverter) writeColumnToArray(
 				c.scratchValues = c.scratchValues[:n]
 			}
 
-			reader := p.Values()
-			if _, err := reader.ReadValues(c.scratchValues); err != nil && err != io.EOF {
-				return fmt.Errorf("read values: %w", err)
+			values := c.scratchValues
+			// If values were already read due to the push down of a physical filter. They may be provided to this function to avoid
+			// re-reading them during Arrow conversion.
+			if len(preReadValues) != 0 {
+				values = preReadValues
+			} else {
+				reader := p.Values()
+				if _, err := reader.ReadValues(values); err != nil && err != io.EOF {
+					return fmt.Errorf("read values: %w", err)
+				}
 			}
 
 			if bitmap != nil && bitmap.GetCardinality() > 0 {
-				bitmap.Iterate(func(x uint32) bool {
-					// Check if the value falls within the range of the page.
-					if int(x) >= offset && int(x) < offset+int(p.NumValues()) {
-						w.Write([]parquet.Value{c.scratchValues[int(x)-offset]})
+				for _, i := range bitmap.ToArray() {
+					if offset <= int(i) && int(i) < offset+int(p.NumValues()) {
+						index := int(i) - offset
+						w.Write([]parquet.Value{values[index]})
 					}
-					return true
-				})
+				}
 			} else {
-				w.Write(c.scratchValues)
+				w.Write(values)
 			}
 		}
 		offset += int(p.NumValues())

--- a/pqarrow/arrow.go
+++ b/pqarrow/arrow.go
@@ -17,7 +17,6 @@ import (
 	"github.com/polarsignals/frostdb/pqarrow/convert"
 	"github.com/polarsignals/frostdb/pqarrow/writer"
 	"github.com/polarsignals/frostdb/query/logicalplan"
-	"github.com/polarsignals/frostdb/query/physicalplan"
 )
 
 // ParquetRowGroupToArrowSchema converts a parquet row group to an arrow schema.
@@ -213,10 +212,9 @@ type ParquetConverter struct {
 
 	// Output fields, for each outputSchema.Field(i) there will always be a
 	// corresponding builder.Field(i).
-	outputSchema   *arrow.Schema
-	iterOpts       logicalplan.IterOptions
-	rowGroupFilter physicalplan.BooleanExpression
-	builder        *builder.RecordBuilder
+	outputSchema *arrow.Schema
+	iterOpts     logicalplan.IterOptions
+	builder      *builder.RecordBuilder
 
 	// writers are wrappers over a subset of builder.Fields().
 	writers []MultiColumnWriter
@@ -229,8 +227,6 @@ type ParquetConverter struct {
 	// scratchValues is an array of parquet.Values that is reused during
 	// decoding to avoid allocations.
 	scratchValues []parquet.Value
-	// scratchPreReadValues is an array of parquet.Values that is reused during Parquet filtering
-	scratchPreReadValues [][]parquet.Value
 }
 
 func NewParquetConverter(
@@ -244,15 +240,7 @@ func NewParquetConverter(
 		distinctColInfos: make([]*distinctColInfo, len(iterOpts.DistinctColumns)),
 	}
 
-	if iterOpts.Filter != nil {
-		var err error
-		c.rowGroupFilter, err = physicalplan.BooleanExpr(iterOpts.Filter)
-		if err != nil {
-			// This should never happen, as the filter has already been
-			// validated.
-			panic(fmt.Sprintf("programming error: %v", err))
-		}
-	} else if len(iterOpts.DistinctColumns) != 0 {
+	if iterOpts.Filter == nil && len(iterOpts.DistinctColumns) != 0 {
 		simpleDistinctExprs := true
 		for _, distinctColumn := range iterOpts.DistinctColumns {
 			if _, ok := distinctColumn.(*logicalplan.DynamicColumn); ok ||
@@ -342,21 +330,6 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup, s *
 		// If we get here, we couldn't use the fast path.
 	}
 
-	// Instead of converting every row in a row group we can apply the filter
-	// to the Parquet rows that we've read into memory, and then convert only
-	// the rows that pass the filter. This saves on during Arrow record building.
-	var bm *physicalplan.Bitmap
-	if len(c.scratchPreReadValues) < len(parquetColumns) {
-		c.scratchPreReadValues = make([][]parquet.Value, len(parquetColumns))
-	}
-
-	if c.rowGroupFilter != nil {
-		bm, c.scratchPreReadValues, err = c.rowGroupFilter.EvalParquet(rg, c.scratchPreReadValues)
-		if err != nil {
-			return fmt.Errorf("physical filter of Parquet rows: %w", err)
-		}
-	}
-
 	for _, w := range c.writers {
 		for _, col := range w.colIdx {
 			select {
@@ -368,8 +341,6 @@ func (c *ParquetConverter) Convert(ctx context.Context, rg parquet.RowGroup, s *
 					parquetColumns[col],
 					false,
 					w.writer,
-					bm,
-					c.scratchPreReadValues[col]...,
 				); err != nil {
 					return fmt.Errorf("convert parquet column to arrow array: %w", err)
 				}
@@ -650,7 +621,6 @@ func (c *ParquetConverter) writeDistinctSingleColumn(
 			columnChunk,
 			true,
 			info.w,
-			nil,
 		); err != nil {
 			return false, err
 		}
@@ -742,8 +712,6 @@ func (c *ParquetConverter) writeColumnToArray(
 	columnChunk parquet.ColumnChunk,
 	dictionaryOnly bool,
 	w writer.ValueWriter,
-	bitmap *physicalplan.Bitmap,
-	preReadValues ...parquet.Value, // Pre-read values if this column was filtered.
 ) error {
 	repeated := n.Repeated()
 	if !repeated && dictionaryOnly {
@@ -804,7 +772,6 @@ func (c *ParquetConverter) writeColumnToArray(
 
 	pages := columnChunk.Pages()
 	defer pages.Close()
-	offset := 0
 	for {
 		p, err := pages.ReadPage()
 		if err != nil {
@@ -816,13 +783,13 @@ func (c *ParquetConverter) writeColumnToArray(
 		dict := p.Dictionary()
 
 		switch {
-		case bitmap == nil && !repeated && dictionaryOnly && dict != nil && p.NumNulls() == 0:
+		case !repeated && dictionaryOnly && dict != nil && p.NumNulls() == 0:
 			// If we are only writing the dictionary, we don't need to read
 			// the values.
 			if err := w.WritePage(dict.Page()); err != nil {
 				return fmt.Errorf("write dictionary page: %w", err)
 			}
-		case bitmap == nil && !repeated && p.NumNulls() == 0 && dict == nil:
+		case !repeated && p.NumNulls() == 0 && dict == nil:
 			// If the column has no nulls, we can read all values at once
 			// consecutively without worrying about null values.
 			if err := w.WritePage(p); err != nil {
@@ -835,30 +802,14 @@ func (c *ParquetConverter) writeColumnToArray(
 				c.scratchValues = c.scratchValues[:n]
 			}
 
-			values := c.scratchValues
-			// If values were already read due to the push down of a physical filter. They may be provided to this function to avoid
-			// re-reading them during Arrow conversion.
-			if len(preReadValues) != 0 {
-				values = preReadValues
-			} else {
-				reader := p.Values()
-				if _, err := reader.ReadValues(values); err != nil && err != io.EOF {
-					return fmt.Errorf("read values: %w", err)
-				}
+			// We're reading all values in the page so we always expect an io.EOF.
+			reader := p.Values()
+			if _, err := reader.ReadValues(c.scratchValues); err != nil && err != io.EOF {
+				return fmt.Errorf("read values: %w", err)
 			}
 
-			if bitmap != nil && bitmap.GetCardinality() > 0 {
-				for _, i := range bitmap.ToArray() {
-					if offset <= int(i) && int(i) < offset+int(p.NumValues()) {
-						index := int(i) - offset
-						w.Write([]parquet.Value{values[index]})
-					}
-				}
-			} else {
-				w.Write(values)
-			}
+			w.Write(c.scratchValues)
 		}
-		offset += int(p.NumValues())
 	}
 
 	return nil

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -107,9 +107,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		}
 
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			contains := bytes.Contains(value.Bytes(), r)
 			if contains && operator == logicalplan.OpContains || !contains && operator == logicalplan.OpNotContains {
 				bm.AddInt(i)
@@ -119,15 +116,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpEq:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if !right.IsValid() {
-				if value.IsNull() {
-					bm.AddInt(i)
-				}
-				return nil
-			}
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) == 0 {
 				bm.AddInt(i)
 			}
@@ -136,15 +124,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpNotEq:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if !right.IsValid() {
-				if !value.IsNull() {
-					bm.AddInt(i)
-				}
-				return nil
-			}
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) != 0 {
 				bm.AddInt(i)
 			}
@@ -153,9 +132,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpLt:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) < 0 {
 				bm.AddInt(i)
 			}
@@ -164,9 +140,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpLtEq:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) <= 0 {
 				bm.AddInt(i)
 			}
@@ -175,9 +148,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpGt:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) > 0 {
 				bm.AddInt(i)
 			}
@@ -186,9 +156,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpGtEq:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			if ParquetValueCompareArrowScalar(value, right) >= 0 {
 				bm.AddInt(i)
 			}
@@ -197,9 +164,6 @@ func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar,
 		return bm, col, err
 	case logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch:
 		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if value.IsNull() {
-				return nil
-			}
 			match, err := regexp.MatchString(right.String(), value.String())
 			if err != nil {
 				return err
@@ -293,6 +257,9 @@ func forEachParquetValue(chunk parquet.ColumnChunk, vals []parquet.Value, f func
 
 	// Callback for each value in the vals slice
 	for i, v := range vals {
+		if v.IsNull() {
+			continue
+		}
 		if err := f(i, v); err != nil {
 			return nil, err
 		}

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -5,30 +5,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"regexp"
 	"unsafe"
 
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
 	"github.com/apache/arrow/go/v15/arrow/compute"
 	"github.com/apache/arrow/go/v15/arrow/scalar"
-	"github.com/parquet-go/parquet-go"
 
 	"github.com/polarsignals/frostdb/query/logicalplan"
 )
 
 type ArrayRef struct {
 	ColumnName string
-}
-
-func (a *ArrayRef) ColumnChunk(rg parquet.RowGroup) (parquet.ColumnChunk, int, bool) {
-	leaf, ok := rg.Schema().Lookup(a.ColumnName)
-	if !ok {
-		return nil, -1, false
-	}
-
-	return rg.ColumnChunks()[leaf.ColumnIndex], leaf.ColumnIndex, true
 }
 
 func (a *ArrayRef) ArrowArray(r arrow.Record) (arrow.Array, bool, error) {
@@ -48,223 +36,6 @@ type BinaryScalarExpr struct {
 	Left  *ArrayRef
 	Op    logicalplan.Op
 	Right scalar.Scalar
-}
-
-func (e BinaryScalarExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
-	leftData, index, exists := e.Left.ColumnChunk(rg)
-
-	if !exists {
-		res := NewBitmap()
-		switch e.Op {
-		case logicalplan.OpEq:
-			if e.Right.IsValid() { // missing column; looking for == non-nil
-				switch t := e.Right.(type) {
-				case *scalar.Binary:
-					if t.String() != "" { // treat empty string equivalent to nil
-						return res, nil, nil
-					}
-				case *scalar.String:
-					if t.String() != "" { // treat empty string equivalent to nil
-						return res, nil, nil
-					}
-				}
-			}
-		case logicalplan.OpNotEq: // missing column; looking for != nil
-			if !e.Right.IsValid() {
-				return res, nil, nil
-			}
-		case logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq:
-			return res, nil, nil
-		}
-
-		res.AddRange(0, uint64(rg.NumRows()))
-		return res, nil, nil
-	}
-
-	// Reuse the input slice if it's already been allocated
-	if len(in[index]) < int(leftData.NumValues()) {
-		in[index] = make([]parquet.Value, leftData.NumValues())
-	}
-	bm, col, err := BinaryScalarParquetOperation(leftData, e.Right, e.Op, in[index])
-	if err != nil {
-		return nil, nil, err
-	}
-
-	in[index] = col
-	return bm, in, nil
-}
-
-func BinaryScalarParquetOperation(left parquet.ColumnChunk, right scalar.Scalar, operator logicalplan.Op, scratch []parquet.Value) (*Bitmap, []parquet.Value, error) {
-	bm := NewBitmap()
-	switch operator { // TODO(optimize): Use the bloom filter or index to speed up the operation for pages with no matching values
-	case logicalplan.OpContains, logicalplan.OpNotContains:
-		var r []byte
-		switch s := right.(type) {
-		case *scalar.Binary:
-			r = s.Data()
-		case *scalar.String:
-			r = s.Data()
-		}
-
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			contains := bytes.Contains(value.Bytes(), r)
-			if contains && operator == logicalplan.OpContains || !contains && operator == logicalplan.OpNotContains {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpEq:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) == 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpNotEq:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) != 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpLt:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) < 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpLtEq:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) <= 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpGt:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) > 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpGtEq:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			if ParquetValueCompareArrowScalar(value, right) >= 0 {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	case logicalplan.OpRegexMatch, logicalplan.OpRegexNotMatch:
-		col, err := forEachParquetValue(left, scratch, func(i int, value parquet.Value) error {
-			match, err := regexp.MatchString(right.String(), value.String())
-			if err != nil {
-				return err
-			}
-			if match && operator == logicalplan.OpRegexMatch || !match && operator == logicalplan.OpRegexNotMatch {
-				bm.AddInt(i)
-			}
-			return nil
-		})
-		return bm, col, err
-	default:
-		return nil, nil, fmt.Errorf("unsupported operator: %v", operator)
-	}
-}
-
-// ParquetValueCompareArrowScalar compares a parquet.Value to a scalar.Scalar
-// It returns 0 if they are equal, -1 if the parquet.Value is less than the scalar.Scalar, and 1 if the parquet.Value is greater than the scalar.Scalar.
-func ParquetValueCompareArrowScalar(v parquet.Value, s scalar.Scalar) int {
-	switch v.Kind() {
-	case parquet.Boolean:
-		if v.Boolean() == s.(*scalar.Boolean).Value {
-			return 0
-		} else if v.Boolean() {
-			return 1
-		} else {
-			return -1
-		}
-	case parquet.Int32:
-		if v.Int32() == s.(*scalar.Int32).Value {
-			return 0
-		} else if v.Int32() > s.(*scalar.Int32).Value {
-			return 1
-		} else {
-			return -1
-		}
-	case parquet.Int64:
-		if v.Int64() == s.(*scalar.Int64).Value {
-			return 0
-		} else if v.Int64() > s.(*scalar.Int64).Value {
-			return 1
-		} else {
-			return -1
-		}
-	case parquet.Float:
-		if v.Float() == s.(*scalar.Float32).Value {
-			return 0
-		} else if v.Float() > s.(*scalar.Float32).Value {
-			return 1
-		} else {
-			return -1
-		}
-	case parquet.Double:
-		if v.Double() == s.(*scalar.Float64).Value {
-			return 0
-		} else if v.Double() > s.(*scalar.Float64).Value {
-			return 1
-		} else {
-			return -1
-		}
-	case parquet.ByteArray:
-		if string(v.ByteArray()) == s.(*scalar.String).String() {
-			return 0
-		} else if string(v.ByteArray()) > s.(*scalar.String).String() {
-			return 1
-		} else {
-			return -1
-		}
-	default:
-		panic(fmt.Sprintf("unsupported type: %v", v.Kind()))
-	}
-}
-
-func forEachParquetValue(chunk parquet.ColumnChunk, vals []parquet.Value, f func(i int, value parquet.Value) error) ([]parquet.Value, error) {
-	pages := chunk.Pages()
-	defer pages.Close()
-	n := 0
-	for { // Read all the pages into the vals slice
-		p, err := pages.ReadPage()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		reader := p.Values()
-		n, err = reader.ReadValues(vals[n:])
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-	}
-
-	// Callback for each value in the vals slice
-	for i, v := range vals {
-		if v.IsNull() {
-			continue
-		}
-		if err := f(i, v); err != nil {
-			return nil, err
-		}
-	}
-	return vals, nil
 }
 
 func (e BinaryScalarExpr) Eval(r arrow.Record) (*Bitmap, error) {

--- a/query/physicalplan/binaryscalarexpr.go
+++ b/query/physicalplan/binaryscalarexpr.go
@@ -61,24 +61,24 @@ func (e BinaryScalarExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value)
 				switch t := e.Right.(type) {
 				case *scalar.Binary:
 					if t.String() != "" { // treat empty string equivalent to nil
-						return res, in, nil
+						return res, nil, nil
 					}
 				case *scalar.String:
 					if t.String() != "" { // treat empty string equivalent to nil
-						return res, in, nil
+						return res, nil, nil
 					}
 				}
 			}
 		case logicalplan.OpNotEq: // missing column; looking for != nil
 			if !e.Right.IsValid() {
-				return res, in, nil
+				return res, nil, nil
 			}
 		case logicalplan.OpLt, logicalplan.OpLtEq, logicalplan.OpGt, logicalplan.OpGtEq:
-			return res, in, nil
+			return res, nil, nil
 		}
 
 		res.AddRange(0, uint64(rg.NumRows()))
-		return res, in, nil
+		return res, nil, nil
 	}
 
 	// Reuse the input slice if it's already been allocated

--- a/query/physicalplan/filter.go
+++ b/query/physicalplan/filter.go
@@ -178,7 +178,7 @@ func (a *AndExpr) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitma
 	}
 
 	if left.IsEmpty() {
-		return left, lout, nil
+		return left, nil, nil
 	}
 
 	right, rout, err := a.Right.EvalParquet(rg, lout)

--- a/query/physicalplan/filter_test.go
+++ b/query/physicalplan/filter_test.go
@@ -1,11 +1,9 @@
 package physicalplan
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/apache/arrow/go/v15/arrow"
-	"github.com/parquet-go/parquet-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,10 +57,6 @@ var _ BooleanExpression = mockExpression{}
 
 func (e mockExpression) Eval(record arrow.Record) (*Bitmap, error) {
 	return e.evalFn(record)
-}
-
-func (e mockExpression) EvalParquet(_ parquet.RowGroup, _ [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
-	return nil, nil, fmt.Errorf("not implemented")
 }
 
 func (e mockExpression) String() string {

--- a/query/physicalplan/regexpfilter.go
+++ b/query/physicalplan/regexpfilter.go
@@ -6,47 +6,12 @@ import (
 
 	"github.com/apache/arrow/go/v15/arrow"
 	"github.com/apache/arrow/go/v15/arrow/array"
-	"github.com/parquet-go/parquet-go"
 )
 
 type RegExpFilter struct {
 	left     *ArrayRef
 	notMatch bool
 	right    *regexp.Regexp
-}
-
-func (f *RegExpFilter) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*Bitmap, [][]parquet.Value, error) {
-	leftData, index, exists := f.left.ColumnChunk(rg)
-
-	res := NewBitmap()
-	if !exists {
-		emptyMatch := f.right.Match(nil)
-		if (f.notMatch && !emptyMatch) || (!f.notMatch && emptyMatch) {
-			for i := uint32(0); i < uint32(rg.NumRows()); i++ {
-				res.Add(i)
-			}
-			return res, nil, nil
-		}
-		return res, nil, nil
-	}
-
-	// Reuse the input slice if it's already been allocated
-	if len(in[index]) < int(leftData.NumValues()) {
-		in[index] = make([]parquet.Value, leftData.NumValues())
-	}
-	col, err := forEachParquetValue(leftData, in[index], func(i int, v parquet.Value) error {
-		match := f.right.MatchString(v.String())
-		if (f.notMatch && !match) || (!f.notMatch && match) {
-			res.Add(uint32(i))
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	in[index] = col
-	return res, in, nil
 }
 
 func (f *RegExpFilter) Eval(r arrow.Record) (*Bitmap, error) {

--- a/query/physicalplan/regexpfilter.go
+++ b/query/physicalplan/regexpfilter.go
@@ -25,9 +25,9 @@ func (f *RegExpFilter) EvalParquet(rg parquet.RowGroup, in [][]parquet.Value) (*
 			for i := uint32(0); i < uint32(rg.NumRows()); i++ {
 				res.Add(i)
 			}
-			return res, in, nil
+			return res, nil, nil
 		}
-		return res, in, nil
+		return res, nil, nil
 	}
 
 	// Reuse the input slice if it's already been allocated

--- a/table.go
+++ b/table.go
@@ -877,7 +877,7 @@ func (t *Table) Iterator(
 					}
 				}
 			}
-		}, t.logger))
+		}))
 	}
 
 	errg.Go(func() error {


### PR DESCRIPTION
The parquet filter pushdown was a good idea, but the implementation ran into a problem with filtering repeated values. We cannot rely on the row index to filter a slice of parquet values for a repeated field. 

At present I don't have a non O(N) way of filtering a repeated list, so I need to revert these changes for now. 