### PR TITLE
pqarrow/builder: Add OptFloat64Builder

### DIFF
--- a/pqarrow/builder/utils.go
+++ b/pqarrow/builder/utils.go
@@ -162,10 +162,14 @@ func AppendGoValue(cb ColumnBuilder, v any) error {
 	switch b := cb.(type) {
 	case *OptBinaryBuilder:
 		return b.Append(v.([]byte))
-	case *OptInt64Builder:
-		b.Append(v.(int64))
 	case *OptBooleanBuilder:
 		b.AppendSingle(v.(bool))
+	case *OptFloat64Builder:
+		b.Append(v.(float64))
+	case *OptInt32Builder:
+		b.Append(v.(int32))
+	case *OptInt64Builder:
+		b.Append(v.(int64))
 	case *array.Int64Builder:
 		b.Append(v.(int64))
 	case *array.Int32Builder:


### PR DESCRIPTION
We mostly need this because it supports the Set and Add methods compared to the upstream Float64Builder.
