### PR TITLE
Iceberg maintenance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,12 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-kit/log v0.2.1
 	github.com/google/uuid v1.6.0
+	github.com/oklog/ulid v1.3.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/parquet-go/parquet-go v0.20.1
 	github.com/pingcap/tidb/parser v0.0.0-20231013125129-93a834a6bf8d
 	github.com/planetscale/vtprotobuf v0.6.0
-	github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65
+	github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b
 	github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9
 	github.com/prometheus/client_golang v1.19.0
 	github.com/stretchr/testify v1.9.0
@@ -56,7 +57,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,12 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-kit/log v0.2.1
 	github.com/google/uuid v1.6.0
+	github.com/oklog/ulid v1.3.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/parquet-go/parquet-go v0.20.1
 	github.com/pingcap/tidb/parser v0.0.0-20231013125129-93a834a6bf8d
 	github.com/planetscale/vtprotobuf v0.6.0
-	github.com/polarsignals/iceberg-go v0.0.0-20240430181803-e13d8391680a
+	github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab
 	github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9
 	github.com/prometheus/client_golang v1.19.0
 	github.com/stretchr/testify v1.9.0
@@ -56,7 +57,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
-	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,11 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/go-kit/log v0.2.1
 	github.com/google/uuid v1.6.0
-	github.com/oklog/ulid v1.3.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/parquet-go/parquet-go v0.20.1
 	github.com/pingcap/tidb/parser v0.0.0-20231013125129-93a834a6bf8d
 	github.com/planetscale/vtprotobuf v0.6.0
-	github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab
+	github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65
 	github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9
 	github.com/prometheus/client_golang v1.19.0
 	github.com/stretchr/testify v1.9.0
@@ -57,6 +56,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/planetscale/vtprotobuf v0.6.0 h1:nBeETjudeJ5ZgBHUz1fVHvbqUKnYOXNhsIEa
 github.com/planetscale/vtprotobuf v0.6.0/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab h1:pcpLKvzKIYjna+fXLCCOQUlLwmJquO+Tz9m0CaPiMAM=
-github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
+github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65 h1:MqQO3P1G4IoRThNEHpFM3qEp3fN3YcyLEF5gOCAQr1U=
+github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9 h1:SwUso/MRikI7aLlEelX4k6N107fT4uTAzmtyMTfjr44=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/planetscale/vtprotobuf v0.6.0 h1:nBeETjudeJ5ZgBHUz1fVHvbqUKnYOXNhsIEa
 github.com/planetscale/vtprotobuf v0.6.0/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/iceberg-go v0.0.0-20240430181803-e13d8391680a h1:axEZn58lvncWT4bAkK4jwf6bVvcQzJhDsTLD6LAWcIk=
-github.com/polarsignals/iceberg-go v0.0.0-20240430181803-e13d8391680a/go.mod h1:Pr0quSmxIq62T5G+tEkU/wtnvNIPxpLTWdhhZ4sqxEo=
+github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab h1:pcpLKvzKIYjna+fXLCCOQUlLwmJquO+Tz9m0CaPiMAM=
+github.com/polarsignals/iceberg-go v0.0.0-20240501184911-9fb1ab5314ab/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9 h1:SwUso/MRikI7aLlEelX4k6N107fT4uTAzmtyMTfjr44=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/planetscale/vtprotobuf v0.6.0 h1:nBeETjudeJ5ZgBHUz1fVHvbqUKnYOXNhsIEa
 github.com/planetscale/vtprotobuf v0.6.0/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65 h1:MqQO3P1G4IoRThNEHpFM3qEp3fN3YcyLEF5gOCAQr1U=
-github.com/polarsignals/iceberg-go v0.0.0-20240502190318-726d90d0ca65/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
+github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b h1:Dbm5itapR0uYIMujR8OntWpDJ/nm5OM6JiaKauLcZ4Y=
+github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9 h1:SwUso/MRikI7aLlEelX4k6N107fT4uTAzmtyMTfjr44=
 github.com/polarsignals/wal v0.0.0-20231123092250-5d233119cfc9/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/prometheus/client_golang v1.19.0 h1:ygXvpU1AoN1MhdzckN+PyD9QJOSD4x7kmXYlnfbA6JU=

--- a/storage/iceberg_test.go
+++ b/storage/iceberg_test.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
+	"github.com/parquet-go/parquet-go"
+	"github.com/polarsignals/iceberg-go/catalog"
+	"github.com/polarsignals/iceberg-go/table"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+func Test_IcebergMaintenance(t *testing.T) {
+	defaultWriterOptions = []table.WriterOption{
+		table.WithManifestSizeBytes(8 * 1024 * 1024), // 8MiB manifest size
+		table.WithMergeSchema(),
+		table.WithExpireSnapshotsOlderThan(time.Nanosecond),
+		table.WithMetadataDeleteAfterCommit(),
+		table.WithMetadataPreviousVersionsMax(0),
+	}
+	bucket := objstore.NewInMemBucket()
+	iceberg, err := NewIceberg("/", catalog.NewHDFS("/", bucket), bucket)
+	require.NoError(t, err)
+
+	type Element struct {
+		Name, Symbol string
+		Number       int
+		Mass         float64
+	}
+
+	b := &bytes.Buffer{}
+	err = parquet.Write(b, []Element{
+		{"Hydrogen", "H", 1, 1.00794},
+		{"Helium", "He", 2, 4.002602},
+		{"Lithium", "Li", 3, 6.941},
+		{"Beryllium", "Be", 4, 9.012182},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, iceberg.Upload(ctx, "db/table/ulid/data.parquet", b))
+
+	var modtime time.Time
+	var deleted string
+	require.NoError(t, bucket.Iter(ctx, "", func(name string) error {
+		if strings.HasSuffix(name, ".parquet") { // Found the data file
+			deleted = name
+			id, err := ulid.Parse(filepath.Base(strings.TrimSuffix(name, ".parquet")))
+			require.NoError(t, err)
+			modtime = ulid.Time(id.Time())
+		}
+		return nil
+	}, objstore.WithRecursiveIter))
+
+	b.Reset()
+	err = parquet.Write(b, []Element{
+		{"Boron", "B", 5, 10.811},
+		{"Carbon", "C", 6, 12.0107},
+		{"Nitrogen", "N", 7, 14.0067},
+		{"Oxygen", "O", 8, 15.9994},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, iceberg.Upload(ctx, "db/table/ulid/data.parquet", b))
+
+	iceberg.maxDataFileAge = time.Since(modtime)
+	iceberg.orphanedFileAge = 1
+	require.NoError(t, iceberg.Maintenance(ctx)) // This maintenance will delete the first file from the table; And then remove the file from the bucket
+
+	require.NoError(t, bucket.Iter(ctx, "", func(name string) error {
+		require.NotEqual(t, deleted, name)
+		return nil
+	}, objstore.WithRecursiveIter))
+}


### PR DESCRIPTION
This addresses a feature request from #838 to be able to have the storage engine expire data files that exceed a certain age.

It does this in two parts; one it will delete the data files from the table by performing a normal table writer where it simply removes the entries from the manifests and then commits the change.

Then once those data files are stranded (i.e no snapshot references them anymore) the maintenance code will deem them to be orphaned files and delete them from the bucket. 