### PR TITLE
Fix query concurrency

### DIFF
--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -447,13 +447,12 @@ func Build(
 				ordered = false
 			}
 			var sync PhysicalPlan
-			if len(prev) > 1 {
-				// These aggregate operators need to be synchronized.
-				if ordered && len(plan.Aggregation.GroupExprs) > 0 {
-					sync = NewOrderedSynchronizer(pool, len(prev), plan.Aggregation.GroupExprs)
-				} else {
-					sync = Synchronize(len(prev))
-				}
+			// These aggregate operators need to be synchronized.
+			// NOTE: that in the case of concurrency 1 we still add a syncronizer because the Aggregation operator expects a final aggregation to be performed.
+			if ordered && len(plan.Aggregation.GroupExprs) > 0 {
+				sync = NewOrderedSynchronizer(pool, len(prev), plan.Aggregation.GroupExprs)
+			} else {
+				sync = Synchronize(len(prev))
 			}
 			seed := maphash.MakeSeed()
 			for i := 0; i < len(prev); i++ {

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -254,29 +254,29 @@ func (p *noopOperator) Draw() *Diagram {
 	return p.next.Draw()
 }
 
-type execOptions struct {
+type ExecOptions struct {
 	orderedAggregations bool
 	overrideInput       []PhysicalPlan
 	readMode            logicalplan.ReadMode
 	concurrency         int
 }
 
-func NewExecOptions() execOptions {
-	return execOptions{
+func NewExecOptions() ExecOptions {
+	return ExecOptions{
 		concurrency: defaultConcurrency,
 	}
 }
 
-type Option func(o *execOptions)
+type Option func(o *ExecOptions)
 
 func WithReadMode(m logicalplan.ReadMode) Option {
-	return func(o *execOptions) {
+	return func(o *ExecOptions) {
 		o.readMode = m
 	}
 }
 
 func WithOrderedAggregations() Option {
-	return func(o *execOptions) {
+	return func(o *ExecOptions) {
 		o.orderedAggregations = true
 	}
 }
@@ -284,13 +284,13 @@ func WithOrderedAggregations() Option {
 // WithOverrideInput can be used to provide an input stage on top of which the
 // Build function can build the physical plan.
 func WithOverrideInput(input []PhysicalPlan) Option {
-	return func(o *execOptions) {
+	return func(o *ExecOptions) {
 		o.overrideInput = input
 	}
 }
 
 func WithConcurrency(concurrency int) Option {
-	return func(o *execOptions) {
+	return func(o *ExecOptions) {
 		o.concurrency = concurrency
 	}
 }
@@ -511,7 +511,7 @@ func Build(
 }
 
 func shouldPlanOrderedAggregate(
-	execOpts execOptions, oInfo *planOrderingInfo, agg *logicalplan.Aggregation,
+	execOpts ExecOptions, oInfo *planOrderingInfo, agg *logicalplan.Aggregation,
 ) (bool, error) {
 	if !execOpts.orderedAggregations {
 		// Ordered aggregations disabled.

--- a/query/physicalplan/physicalplan.go
+++ b/query/physicalplan/physicalplan.go
@@ -17,8 +17,7 @@ import (
 	"github.com/polarsignals/frostdb/recovery"
 )
 
-// TODO: Make this smarter.
-var concurrencyHardcoded = runtime.GOMAXPROCS(0)
+var defaultConcurrency = runtime.GOMAXPROCS(0)
 
 type PhysicalPlan interface {
 	Callback(ctx context.Context, r arrow.Record) error
@@ -259,6 +258,13 @@ type execOptions struct {
 	orderedAggregations bool
 	overrideInput       []PhysicalPlan
 	readMode            logicalplan.ReadMode
+	concurrency         int
+}
+
+func NewExecOptions() execOptions {
+	return execOptions{
+		concurrency: defaultConcurrency,
+	}
 }
 
 type Option func(o *execOptions)
@@ -283,6 +289,12 @@ func WithOverrideInput(input []PhysicalPlan) Option {
 	}
 }
 
+func WithConcurrency(concurrency int) Option {
+	return func(o *execOptions) {
+		o.concurrency = concurrency
+	}
+}
+
 func Build(
 	ctx context.Context,
 	pool memory.Allocator,
@@ -294,7 +306,7 @@ func Build(
 	_, span := tracer.Start(ctx, "PhysicalPlan/Build")
 	defer span.End()
 
-	execOpts := execOptions{}
+	execOpts := NewExecOptions()
 	for _, o := range options {
 		o(&execOpts)
 	}
@@ -318,7 +330,7 @@ func Build(
 			// Create noop operators since we don't know what to push the scan
 			// results to. In a following node visit, these noops will have
 			// SetNext called on them and push to the correct operator.
-			plans := make([]PhysicalPlan, concurrencyHardcoded)
+			plans := make([]PhysicalPlan, execOpts.concurrency)
 			for i := range plans {
 				plans[i] = &noopOperator{}
 			}
@@ -333,7 +345,7 @@ func Build(
 			// Create noop operators since we don't know what to push the scan
 			// results to. In a following node visit, these noops will have
 			// SetNext called on them and push to the correct operator.
-			plans := make([]PhysicalPlan, concurrencyHardcoded)
+			plans := make([]PhysicalPlan, execOpts.concurrency)
 			for i := range plans {
 				plans[i] = &noopOperator{}
 			}


### PR DESCRIPTION
The aggregators exepct to have a final aggregation.
In the concurrency = 1 case we weren't correctly aggregating
because no final aggregation was created.

This removes the requirement for concurrency to be > 1 for a syncronizer
and final aggregation to be created.

Ideally in the future we would just schedule a single aggregation that
handles both being a normal and final aggregation but this is a simple
fix for an edge case that isn't important at this point.

Fixes #769 