### PR TITLE
Don't upload a block if it is empty

### DIFF
--- a/table.go
+++ b/table.go
@@ -506,7 +506,7 @@ func (t *Table) writeBlock(block *TableBlock, skipPersist, snapshotDB bool) {
 
 	// Persist the block
 	var err error
-	if !skipPersist {
+	if !skipPersist && block.index.Size() != 0 {
 		err = block.Persist()
 	}
 	t.dropPendingBlock(block)


### PR DESCRIPTION
Check to make sure there is data in the block before calling Persist

Fixes #860 