### PR TITLE
wal: correctly set nextTx on Truncate

### DIFF
--- a/wal/wal.go
+++ b/wal/wal.go
@@ -410,7 +410,7 @@ func (w *FileWAL) process() {
 				// last index are now 0. The underlying WAL will allow a
 				// record with any index to be written, however we only
 				// want to allow the next index to be logged.
-				w.protected.nextTx = truncateTx + 1
+				w.protected.nextTx = truncateTx
 				// Remove any records that have not yet been written and
 				// are now below the nextTx.
 				for w.protected.queue.Len() > 0 {


### PR DESCRIPTION
On Truncate(k), if k was logged to the WAL the behavior is unchanged. However, if k had not yet been logged to the WAL, the WAL performed a full reset of the WAL and set the next expected txn to k+1. This is incorrect, since the semantics of truncate are that k becomes the first entry in the WAL after truncation.