### PR TITLE
722 snapshot tx changes

### DIFF
--- a/db.go
+++ b/db.go
@@ -756,7 +756,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 						filepath.Join(table.db.indexDir(), table.name, table.ActiveBlock().ulid.String()), // Any index files are found at <db.indexDir>/<table.name>/<block.id>
 						table.schema,
 						table.IndexConfig(),
-						db.Wait,
+						db.HighWatermark,
 						index.LSMWithMetrics(table.metrics.indexMetrics),
 						index.LSMWithLogger(table.logger),
 					)

--- a/db_test.go
+++ b/db_test.go
@@ -3054,7 +3054,7 @@ func Test_DB_SnapshotDuplicate_Corrupted(t *testing.T) {
 	time.Sleep(1 * time.Second) // wal flushes every 50ms
 
 	// Corrupt the snapshot file.
-	require.NoError(t, os.Truncate(filepath.Join(SnapshotDir(db, 2), snapshotFileName(2)), 100))
+	require.NoError(t, os.Truncate(filepath.Join(SnapshotDir(db, 3), snapshotFileName(3)), 100))
 
 	// Close the database to trigger a snapshot on close
 	require.NoError(t, c.Close())

--- a/db_test.go
+++ b/db_test.go
@@ -1226,9 +1226,9 @@ func TestDBRecover(t *testing.T) {
 			require.NoError(t, err)
 			snapshotTxns = append(snapshotTxns, tx)
 		}
-		expectedSnapshots := []uint64{2, 3}
+		expectedSnapshots := []uint64{3, 5}
 		if blockRotation {
-			expectedSnapshots = append(expectedSnapshots, 6)
+			expectedSnapshots = append(expectedSnapshots, 8)
 		}
 		require.Equal(t, expectedSnapshots, snapshotTxns)
 		return dir
@@ -2862,7 +2862,7 @@ func Test_DB_SnapshotNewerData(t *testing.T) {
 			}
 
 			// Get a snapshot tx
-			tx := db.beginRead()
+			tx, _, commit := db.begin()
 
 			// Insert another write, and force compaction
 			samples := dynparquet.GenerateTestSamples(3)
@@ -2873,7 +2873,18 @@ func Test_DB_SnapshotNewerData(t *testing.T) {
 			require.NoError(t, table.EnsureCompaction())
 
 			// Now perform the snapshot
+			db.Wait(tx - 1)
+			err = db.wal.Log(
+				tx,
+				&walpb.Record{
+					Entry: &walpb.Entry{
+						EntryType: &walpb.Entry_Snapshot_{Snapshot: &walpb.Entry_Snapshot{Tx: tx}},
+					},
+				},
+			)
+			require.NoError(t, err)
 			require.NoError(t, db.snapshotAtTX(ctx, tx, db.offlineSnapshotWriter(tx)))
+			commit()
 			require.NoError(t, db.wal.Truncate(tx))
 			time.Sleep(1 * time.Second) // wal flushes every 50ms
 

--- a/index/lsm_test.go
+++ b/index/lsm_test.go
@@ -96,7 +96,7 @@ func Test_LSM_Basic(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func Test_LSM_DuplicateSentinel(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -155,7 +155,7 @@ func Test_LSM_Compaction(t *testing.T) {
 		{Level: L0, MaxSize: 1, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L1, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -178,7 +178,7 @@ func Test_LSM_CascadeCompaction(t *testing.T) {
 		{Level: 3, MaxSize: 2281, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: 4, MaxSize: 2281},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func Test_LSM_InOrderInsert(t *testing.T) {
 		{Level: L1, MaxSize: 1024 * 1024 * 1024, Type: CompactionTypeParquetMemory, Compact: compactParts},
 		{Level: L2, MaxSize: 1024 * 1024 * 1024},
 	},
-		func(uint64) {},
+		func() uint64 { return math.MaxUint64 },
 	)
 	require.NoError(t, err)
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -465,7 +465,7 @@ func WriteSnapshot(ctx context.Context, tx uint64, db *DB, w io.Writer) error {
 				},
 			}
 
-			if err := block.Index().Snapshot(func(p parts.Part) error {
+			if err := block.Index().Snapshot(tx, func(p parts.Part) error {
 				granuleMeta := &snapshotpb.Granule{}
 				partMeta := &snapshotpb.Part{
 					StartOffset:     int64(offW.offset),

--- a/table.go
+++ b/table.go
@@ -1040,7 +1040,7 @@ func newTableBlock(table *Table, prevTx, tx uint64, id ulid.ULID) (*TableBlock, 
 		filepath.Join(table.db.indexDir(), table.name, id.String()), // Any index files are found at <db.indexDir>/<table.name>/<block.id>
 		table.schema,
 		table.IndexConfig(),
-		table.db.Wait,
+		table.db.HighWatermark,
 		index.LSMWithMetrics(table.metrics.indexMetrics),
 		index.LSMWithLogger(table.logger),
 	)


### PR DESCRIPTION
Reopening this tx PR.

Snapshots now grab a write tx. This prevents from other writes coming in and getting compacted into L1+ before the snapshot completes thus allowing tx > snapshot_tx from making it into the snapshot.

Snapshots now also filter out any writes in L0 that are > snapshot_tx from the snapshot write.