### PR TITLE
Converter read all pages

### DIFF
--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -480,7 +480,7 @@ func Benchmark_ParquetAggregation(b *testing.B) {
 	b.ResetTimer()
 	b.Run("paruqet_aggregation", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			engine.ScanTable("test").
+			require.NoError(b, engine.ScanTable("test").
 				Filter(
 					logicalplan.Col("timestamp").Gt(logicalplan.Literal(10)),
 				).
@@ -493,7 +493,7 @@ func Benchmark_ParquetAggregation(b *testing.B) {
 					},
 				).Execute(ctx, func(ctx context.Context, r arrow.Record) error {
 				return nil
-			})
+			}))
 		}
 	})
 }

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -433,7 +433,7 @@ func BenchmarkAggregation(b *testing.B) {
 	}
 }
 
-// Benchmark_ParquetAggregation is similar to BenchmarkAggregation but uses uses Parquet as the storage format.
+// Benchmark_ParquetAggregation is similar to BenchmarkAggregation but uses Parquet as the storage format.
 func Benchmark_ParquetAggregation(b *testing.B) {
 	ctx := context.Background()
 
@@ -478,7 +478,7 @@ func Benchmark_ParquetAggregation(b *testing.B) {
 	)
 
 	b.ResetTimer()
-	b.Run("paruqet_aggregation", func(b *testing.B) {
+	b.Run("parquet_aggregation", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			require.NoError(b, engine.ScanTable("test").
 				Filter(

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -433,6 +433,71 @@ func BenchmarkAggregation(b *testing.B) {
 	}
 }
 
+// Benchmark_ParquetAggregation is similar to BenchmarkAggregation but uses uses Parquet as the storage format.
+func Benchmark_ParquetAggregation(b *testing.B) {
+	ctx := context.Background()
+
+	columnStore, err := New()
+	require.NoError(b, err)
+	defer columnStore.Close()
+
+	db, err := columnStore.DB(ctx, "test")
+	require.NoError(b, err)
+
+	// Insert sample data
+	{
+		config := NewTableConfig(dynparquet.SampleDefinition())
+		table, err := db.Table("test", config)
+		require.NoError(b, err)
+
+		samples := make(dynparquet.Samples, 0, 200_000)
+		for i := 0; i < cap(samples); i++ {
+			samples = append(samples, dynparquet.Sample{
+				Labels: map[string]string{
+					"label1": "value1",
+					"label2": "value" + strconv.Itoa(i%3),
+				},
+				Stacktrace: []uuid.UUID{
+					{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				},
+				Timestamp: int64(i),
+				Value:     int64(i),
+			})
+		}
+
+		r, err := samples.ToRecord()
+		require.NoError(b, err)
+		_, err = table.InsertRecord(ctx, r)
+		require.NoError(b, err)
+		require.NoError(b, table.EnsureCompaction())
+	}
+
+	engine := query.NewEngine(
+		memory.NewGoAllocator(),
+		db.TableProvider(),
+	)
+
+	b.ResetTimer()
+	b.Run("paruqet_aggregation", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			engine.ScanTable("test").
+				Filter(
+					logicalplan.Col("timestamp").Gt(logicalplan.Literal(10)),
+				).
+				Aggregate(
+					[]*logicalplan.AggregationFunction{
+						logicalplan.Sum(logicalplan.Col("value")),
+					},
+					[]logicalplan.Expr{
+						logicalplan.Col("labels.label2"),
+					},
+				).Execute(ctx, func(ctx context.Context, r arrow.Record) error {
+				return nil
+			})
+		}
+	})
+}
+
 func Test_Aggregation_DynCol(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)

--- a/db_test.go
+++ b/db_test.go
@@ -2638,7 +2638,7 @@ func Test_DB_PersistentDiskCompaction_BlockRotation(t *testing.T) {
 	}
 	require.Eventually(t, func() bool {
 		return table.active.index.LevelSize(index.L1) != 0
-	}, time.Second, time.Millisecond*10)
+	}, 3*time.Second, time.Millisecond*10)
 
 	validateRows := func(expected int64) {
 		pool := memory.NewCheckedAllocator(memory.DefaultAllocator)


### PR DESCRIPTION
Discovered some good performance gains during query time of Parquet files that if we read in all the Parquet values into the buffer at once instead of page by page it decreases query times.

```bash
thor@thors-MacBook-Pro ~/.../github.com/polarsignals/frostdb % benchstat before.txt after.txt
name                                        old time/op    new time/op    delta
_ParquetAggregation/paruqet_aggregation-10    16.0ms ± 0%     9.3ms ± 1%  -41.80%  (p=0.000 n=9+10)

name                                        old alloc/op   new alloc/op   delta
_ParquetAggregation/paruqet_aggregation-10    33.0MB ± 0%    37.9MB ± 0%  +14.99%  (p=0.000 n=9+10)

name                                        old allocs/op  new allocs/op  delta
_ParquetAggregation/paruqet_aggregation-10     1.42k ± 0%     1.40k ± 0%   -1.88%  (p=0.000 n=9+10)
```

Slightly more data allocated (due to the larger buffer) but I think it's a worthwhile trade off