### PR TITLE
table iterator: Pass in the logger to recovery

### DIFF
--- a/table.go
+++ b/table.go
@@ -885,7 +885,7 @@ func (t *Table) Iterator(
 					}
 				}
 			}
-		}))
+		}, t.logger))
 	}
 
 	errg.Go(func() error {
@@ -1007,7 +1007,7 @@ func (t *Table) SchemaIterator(
 					}
 				}
 			}
-		}))
+		}, t.logger))
 	}
 
 	errg.Go(func() error {


### PR DESCRIPTION
This will allow the recovery handler to log stacktraces during panics