### PR TITLE
*: add reusableRegistry

### DIFF
--- a/db.go
+++ b/db.go
@@ -112,6 +112,11 @@ func New(
 		}
 	}
 
+	// Wrap the registry in a reusable registry to allow metrics to be
+	// registered multiple times in cases e.g. where a database is dropped and
+	// subsequently recreated, or a table is dropped and recreated.
+	s.reg = newReusableRegistry(s.reg)
+
 	s.metrics = metrics{
 		shutdownDuration: promauto.With(s.reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "frostdb_shutdown_duration",

--- a/registerer.go
+++ b/registerer.go
@@ -1,0 +1,67 @@
+package frostdb
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// reusableRegistry is a wrapper on top of a prometheus registry that allows
+// metrics to be registered multiple times. This has been specifically designed
+// for use cases where a table or db is dropped then recreated with the same
+// name. If a new collector with the same labels is registered, that metric is
+// reset to 0.
+type reusableRegistry struct {
+	internalReg prometheus.Registerer
+
+	protected struct {
+		sync.Mutex
+		registered map[string]struct{}
+	}
+}
+
+var _ prometheus.Registerer = (*reusableRegistry)(nil)
+
+func newReusableRegistry(reg prometheus.Registerer) *reusableRegistry {
+	r := &reusableRegistry{
+		internalReg: reg,
+	}
+	r.protected.registered = make(map[string]struct{})
+	return r
+}
+
+func (r *reusableRegistry) Register(c prometheus.Collector) error {
+	d := make(chan *prometheus.Desc, 1)
+	c.Describe(d)
+	desc := <-d
+
+	r.protected.Lock()
+	defer r.protected.Unlock()
+	metricDesc := desc.String()
+	if _, ok := r.protected.registered[metricDesc]; ok {
+		_ = r.internalReg.Unregister(c)
+	} else {
+		r.protected.registered[metricDesc] = struct{}{}
+	}
+	return r.internalReg.Register(c)
+}
+
+func (r *reusableRegistry) MustRegister(collectors ...prometheus.Collector) {
+	for _, c := range collectors {
+		if err := r.Register(c); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (r *reusableRegistry) Unregister(c prometheus.Collector) bool {
+	d := make(chan *prometheus.Desc, 1)
+	c.Describe(d)
+	desc := <-d
+
+	r.protected.Lock()
+	defer r.protected.Unlock()
+	metricDesc := desc.String()
+	delete(r.protected.registered, metricDesc)
+	return r.internalReg.Unregister(c)
+}

--- a/registerer_test.go
+++ b/registerer_test.go
@@ -1,0 +1,52 @@
+package frostdb
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuplicateRegistration(t *testing.T) {
+	// Create a reusableRegistry
+	promReg := prometheus.NewRegistry()
+	reg := newReusableRegistry(promReg)
+
+	// Create a test collector.
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test",
+		Help: "test",
+	})
+
+	// Register the collector.
+	reg.MustRegister(c)
+
+	c.Inc()
+	c.Inc()
+
+	checkCounter := func(expValue float64) {
+		mf, err := promReg.Gather()
+		require.NoError(t, err)
+		require.Len(t, mf, 1)
+		require.Len(t, mf[0].Metric, 1)
+		require.Equal(t, expValue, *mf[0].Metric[0].Counter.Value)
+	}
+	checkCounter(2)
+
+	// New collector
+	c = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test",
+		Help: "test",
+	})
+	// Registering the same collector on the vanilla registry should panic.
+	require.Panics(t, func() {
+		promReg.MustRegister(c)
+	}, "should panic when registering the same collector twice")
+
+	// Registering the same collector on the reusable registry should not panic.
+	reg.MustRegister(c)
+
+	c.Inc()
+	// Counter should be reset and show 1.
+	checkCounter(1)
+}


### PR DESCRIPTION
This registry allows the re-registration of metrics when dropping and recreating DBs and tables. In this case, we do not want to panic and simply want to continue exporting the same metrics.

Fixes #716 