### PR TITLE
*: move all metrics registration to the store level

### DIFF
--- a/db.go
+++ b/db.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -60,7 +59,7 @@ type ColumnStore struct {
 	enableWAL           bool
 	manualBlockRotation bool
 	snapshotTriggerSize int64
-	metrics             metrics
+	metrics             globalMetrics
 	recoveryConcurrency int
 
 	// indexDegree is the degree of the btree index (default = 2)
@@ -79,14 +78,8 @@ type ColumnStore struct {
 	// testingOptions are options only used for testing purposes.
 	testingOptions struct {
 		disableReclaimDiskSpaceOnSnapshot bool
-		walTestingOptions                 []wal.TestingOption
+		walTestingOptions                 []wal.Option
 	}
-}
-
-type metrics struct {
-	shutdownDuration  prometheus.Histogram
-	shutdownStarted   prometheus.Counter
-	shutdownCompleted prometheus.Counter
 }
 
 type Option func(*ColumnStore) error
@@ -114,21 +107,7 @@ func New(
 
 	// Register metrics that are updated by the collector.
 	s.reg.MustRegister(&collector{s: s})
-
-	s.metrics = metrics{
-		shutdownDuration: promauto.With(s.reg).NewHistogram(prometheus.HistogramOpts{
-			Name: "frostdb_shutdown_duration",
-			Help: "time it takes for the columnarstore to complete a full shutdown.",
-		}),
-		shutdownStarted: promauto.With(s.reg).NewCounter(prometheus.CounterOpts{
-			Name: "frostdb_shutdown_started",
-			Help: "Indicates a shutdown of the columnarstore has started.",
-		}),
-		shutdownCompleted: promauto.With(s.reg).NewCounter(prometheus.CounterOpts{
-			Name: "frostdb_shutdown_completed",
-			Help: "Indicates a shutdown of the columnarstore has completed.",
-		}),
-	}
+	s.metrics = makeAndRegisterGlobalMetrics(s.reg)
 
 	if s.enableWAL && s.storagePath == "" {
 		return nil, fmt.Errorf("storage path must be configured if WAL is enabled")
@@ -354,13 +333,8 @@ func (s *ColumnStore) recoverDBsFromStorage(ctx context.Context) error {
 	return g.Wait()
 }
 
-type dbMetrics struct {
-	snapshotMetrics *snapshotMetrics
-}
-
 type DB struct {
 	columnStore *ColumnStore
-	reg         prometheus.Registerer
 	logger      log.Logger
 	tracer      trace.Tracer
 	name        string
@@ -389,7 +363,8 @@ type DB struct {
 
 	snapshotInProgress atomic.Bool
 
-	metrics *dbMetrics
+	metrics         snapshotMetrics
+	metricsProvider tableMetricsProvider
 }
 
 // DataSinkSource is a convenience interface for a data source and sink.
@@ -476,20 +451,20 @@ func (s *ColumnStore) DB(ctx context.Context, name string, opts ...DBOption) (*D
 		s.mtx.Lock()
 	}
 
-	reg := prometheus.WrapRegistererWith(prometheus.Labels{"db": name}, s.reg)
 	logger := log.WithPrefix(s.logger, "db", name)
 	db = &DB{
-		columnStore: s,
-		name:        name,
-		mtx:         &sync.RWMutex{},
-		tables:      map[string]*Table{},
-		roTables:    map[string]*Table{},
-		reg:         reg,
-		logger:      logger,
-		tracer:      s.tracer,
-		wal:         &wal.NopWAL{},
-		sources:     s.sources,
-		sinks:       s.sinks,
+		columnStore:     s,
+		name:            name,
+		mtx:             &sync.RWMutex{},
+		tables:          map[string]*Table{},
+		roTables:        map[string]*Table{},
+		logger:          logger,
+		tracer:          s.tracer,
+		wal:             &wal.NopWAL{},
+		sources:         s.sources,
+		sinks:           s.sinks,
+		metrics:         s.metrics.snapshotMetricsForDB(name),
+		metricsProvider: tableMetricsProvider{dbName: name, m: s.metrics},
 	}
 
 	if s.storagePath != "" {
@@ -546,7 +521,15 @@ func (s *ColumnStore) DB(ctx context.Context, name string, opts ...DBOption) (*D
 					delete(s.dbReplaysInProgress, name)
 				}()
 				var err error
-				db.wal, err = db.openWAL(ctx, s.testingOptions.walTestingOptions...)
+				db.wal, err = db.openWAL(
+					ctx,
+					append(
+						[]wal.Option{
+							wal.WithMetrics(s.metrics.metricsForFileWAL(name)),
+							wal.WithStoreMetrics(s.metrics.metricsForWAL(name)),
+						}, s.testingOptions.walTestingOptions...,
+					)...,
+				)
 				return err
 			}(); err != nil {
 				return err
@@ -564,11 +547,6 @@ func (s *ColumnStore) DB(ctx context.Context, name string, opts ...DBOption) (*D
 					table.wal = db.wal
 				}
 			}
-		}
-
-		// Register metrics last to avoid duplicate registration should and of the WAL or storage replay errors occur
-		db.metrics = &dbMetrics{
-			snapshotMetrics: newSnapshotMetrics(reg),
 		}
 		return nil
 	}(); dbSetupErr != nil {
@@ -642,10 +620,9 @@ func (s *ColumnStore) DropDB(name string) error {
 	return os.RemoveAll(filepath.Join(s.DatabasesDir(), name))
 }
 
-func (db *DB) openWAL(ctx context.Context, opts ...wal.TestingOption) (WAL, error) {
+func (db *DB) openWAL(ctx context.Context, opts ...wal.Option) (WAL, error) {
 	wal, err := wal.Open(
 		db.logger,
-		db.reg,
 		db.walDir(),
 		opts...,
 	)
@@ -808,7 +785,7 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 							db,
 							tableName,
 							config,
-							db.reg,
+							db.metricsProvider.metricsForTable(tableName),
 							db.logger,
 							db.tracer,
 							wal,
@@ -1096,7 +1073,7 @@ func (db *DB) readOnlyTable(name string) (*Table, error) {
 		db,
 		name,
 		nil,
-		db.reg,
+		db.metricsProvider.metricsForTable(name),
 		db.logger,
 		db.tracer,
 		db.wal,
@@ -1171,7 +1148,7 @@ func (db *DB) table(name string, config *tablepb.TableConfig, id ulid.ULID) (*Ta
 			db,
 			name,
 			config,
-			db.reg,
+			db.metricsProvider.metricsForTable(name),
 			db.logger,
 			db.tracer,
 			db.wal,

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pingcap/tidb/parser v0.0.0-20231013125129-93a834a6bf8d
 	github.com/planetscale/vtprotobuf v0.6.0
 	github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b
-	github.com/polarsignals/wal v0.0.0-20240514152147-1cd4b81c9b88
+	github.com/polarsignals/wal v0.0.0-20240619104840-9da940027f9c
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b h1:Dbm5itapR0uYIMujR8OntWpDJ/nm5OM6JiaKauLcZ4Y=
 github.com/polarsignals/iceberg-go v0.0.0-20240502213135-2ee70b71e76b/go.mod h1:5T9ChEZjRNhAGGLwH1cqzDA7wXB84SmU+WkXQr/ZAjo=
-github.com/polarsignals/wal v0.0.0-20240514152147-1cd4b81c9b88 h1:FZvQW8MXcNjwLfWDRAatOA83Pof5+iKW7veuInygBXY=
-github.com/polarsignals/wal v0.0.0-20240514152147-1cd4b81c9b88/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
+github.com/polarsignals/wal v0.0.0-20240619104840-9da940027f9c h1:ReFgEXqZ9/y+/9ZdNHOa1L62wqt8mWqoqrWutWj2x+A=
+github.com/polarsignals/wal v0.0.0-20240619104840-9da940027f9c/go.mod h1:EVDHAAe+7GQ33A1/x+/gE+sBPN4toQ0XG5RoLD49xr8=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=

--- a/index/lsm.go
+++ b/index/lsm.go
@@ -63,7 +63,7 @@ type LSM struct {
 type LSMMetrics struct {
 	Compactions        *prometheus.CounterVec
 	LevelSize          *prometheus.GaugeVec
-	CompactionDuration prometheus.Histogram
+	CompactionDuration prometheus.Observer
 }
 
 // LevelConfig is the configuration for a level in the LSM.

--- a/metrics.go
+++ b/metrics.go
@@ -1,6 +1,14 @@
 package frostdb
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/polarsignals/wal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	filewal "github.com/polarsignals/frostdb/wal"
+
+	"github.com/polarsignals/frostdb/index"
+)
 
 var (
 	descTxHighWatermark = prometheus.NewDesc(
@@ -46,5 +54,314 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 			}
 			ch <- prometheus.MustNewConstMetric(descActiveBlockSize, prometheus.GaugeValue, float64(activeBlock.Size()), dbName, tableName)
 		}
+	}
+}
+
+// globalMetrics defines the store-level metrics registered at instantiation.
+// Most metrics are not directly accessed, and instead provided to components
+// at instantiation time with preset labels.
+type globalMetrics struct {
+	shutdownDuration  prometheus.Histogram
+	shutdownStarted   prometheus.Counter
+	shutdownCompleted prometheus.Counter
+	dbMetrics         struct {
+		snapshotMetrics struct {
+			snapshotsTotal            *prometheus.CounterVec
+			snapshotFileSizeBytes     *prometheus.GaugeVec
+			snapshotDurationHistogram *prometheus.HistogramVec
+		}
+		walMetrics struct {
+			bytesWritten          *prometheus.CounterVec
+			entriesWritten        *prometheus.CounterVec
+			appends               *prometheus.CounterVec
+			entryBytesRead        *prometheus.CounterVec
+			entriesRead           *prometheus.CounterVec
+			segmentRotations      *prometheus.CounterVec
+			entriesTruncated      *prometheus.CounterVec
+			truncations           *prometheus.CounterVec
+			lastSegmentAgeSeconds *prometheus.GaugeVec
+		}
+		fileWalMetrics struct {
+			failedLogs            *prometheus.CounterVec
+			lastTruncationAt      *prometheus.GaugeVec
+			walRepairs            *prometheus.CounterVec
+			walRepairsLostRecords *prometheus.CounterVec
+			walCloseTimeouts      *prometheus.CounterVec
+			walQueueSize          *prometheus.GaugeVec
+		}
+	}
+	tableMetrics struct {
+		blockPersisted       *prometheus.CounterVec
+		blockRotated         *prometheus.CounterVec
+		rowsInserted         *prometheus.CounterVec
+		rowBytesInserted     *prometheus.CounterVec
+		zeroRowsInserted     *prometheus.CounterVec
+		rowInsertSize        *prometheus.HistogramVec
+		lastCompletedBlockTx *prometheus.GaugeVec
+		numParts             *prometheus.GaugeVec
+		indexMetrics         struct {
+			compactions        *prometheus.CounterVec
+			levelSize          *prometheus.GaugeVec
+			compactionDuration *prometheus.HistogramVec
+		}
+	}
+}
+
+func makeLabelsForDBMetric(extraLabels ...string) []string {
+	return append([]string{"db"}, extraLabels...)
+}
+
+func makeLabelsForTablesMetrics(extraLabels ...string) []string {
+	return append([]string{"db", "table"}, extraLabels...)
+}
+
+func makeAndRegisterGlobalMetrics(unwrappedReg prometheus.Registerer) globalMetrics {
+	m := globalMetrics{
+		shutdownDuration: promauto.With(unwrappedReg).NewHistogram(prometheus.HistogramOpts{
+			Name: "frostdb_shutdown_duration",
+			Help: "time it takes for the columnarstore to complete a full shutdown.",
+		}),
+		shutdownStarted: promauto.With(unwrappedReg).NewCounter(prometheus.CounterOpts{
+			Name: "frostdb_shutdown_started",
+			Help: "Indicates a shutdown of the columnarstore has started.",
+		}),
+		shutdownCompleted: promauto.With(unwrappedReg).NewCounter(prometheus.CounterOpts{
+			Name: "frostdb_shutdown_completed",
+			Help: "Indicates a shutdown of the columnarstore has completed.",
+		}),
+	}
+
+	// DB metrics.
+	{
+		// Snapshot metrics.
+		{
+			reg := prometheus.WrapRegistererWithPrefix("frostdb_snapshot_", unwrappedReg)
+			m.dbMetrics.snapshotMetrics.snapshotsTotal = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "total",
+				Help: "Total number of snapshots",
+			}, makeLabelsForDBMetric("success"))
+			m.dbMetrics.snapshotMetrics.snapshotFileSizeBytes = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+				Name: "file_size_bytes",
+				Help: "Size of snapshots in bytes",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.snapshotMetrics.snapshotDurationHistogram = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "duration_seconds",
+				Help:    "Duration of snapshots in seconds",
+				Buckets: prometheus.ExponentialBucketsRange(1, 60, 5),
+			}, makeLabelsForDBMetric())
+		}
+		// WAL metrics.
+		{
+			reg := prometheus.WrapRegistererWithPrefix("frostdb_wal_", unwrappedReg)
+			m.dbMetrics.walMetrics.bytesWritten = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "entry_bytes_written",
+				Help: "entry_bytes_written counts the bytes of log entry after encoding." +
+					" Actual bytes written to disk might be slightly higher as it" +
+					" includes headers and index entries.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.entriesWritten = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "entries_written",
+				Help: "entries_written counts the number of entries written.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.appends = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "appends",
+				Help: "appends counts the number of calls to StoreLog(s) i.e." +
+					" number of batches of entries appended.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.entryBytesRead = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "entry_bytes_read",
+				Help: "entry_bytes_read counts the bytes of log entry read from" +
+					" segments before decoding. actual bytes read from disk might be higher" +
+					" as it includes headers and index entries and possible secondary reads" +
+					" for large entries that don't fit in buffers.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.entriesRead = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "entries_read",
+				Help: "entries_read counts the number of calls to get_log.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.segmentRotations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "segment_rotations",
+				Help: "segment_rotations counts how many times we move to a new segment file.",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.walMetrics.entriesTruncated = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "entries_truncated_total",
+				Help: "entries_truncated counts how many log entries have been truncated" +
+					" from the front or back.",
+			}, makeLabelsForDBMetric("type"))
+			m.dbMetrics.walMetrics.truncations = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "truncations_total",
+				Help: "truncations is the number of truncate calls categorized by whether" +
+					" the call was successful or not.",
+			}, makeLabelsForDBMetric("type", "success"))
+			m.dbMetrics.walMetrics.lastSegmentAgeSeconds = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+				Name: "last_segment_age_seconds",
+				Help: "last_segment_age_seconds is a gauge that is set each time we" +
+					" rotate a segment and describes the number of seconds between when" +
+					" that segment file was first created and when it was sealed. this" +
+					" gives a rough estimate how quickly writes are filling the disk.",
+			}, makeLabelsForDBMetric())
+		}
+		// FileWAL metrics.
+		{
+			reg := prometheus.WrapRegistererWithPrefix("frostdb_wal_", unwrappedReg)
+			m.dbMetrics.fileWalMetrics.failedLogs = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "failed_logs_total",
+				Help: "Number of failed WAL logs",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.fileWalMetrics.lastTruncationAt = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+				Name: "last_truncation_at",
+				Help: "The last transaction the WAL was truncated to",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.fileWalMetrics.walRepairs = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "repairs_total",
+				Help: "The number of times the WAL had to be repaired (truncated) due to corrupt records",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.fileWalMetrics.walRepairsLostRecords = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "repairs_lost_records_total",
+				Help: "The number of WAL records lost due to WAL repairs (truncations)",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.fileWalMetrics.walCloseTimeouts = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "close_timeouts_total",
+				Help: "The number of times the WAL failed to close due to a timeout",
+			}, makeLabelsForDBMetric())
+			m.dbMetrics.fileWalMetrics.walQueueSize = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+				Name: "queue_size",
+				Help: "The number of unprocessed requests in the WAL queue",
+			}, makeLabelsForDBMetric())
+		}
+	}
+
+	// Table metrics.
+	{
+		reg := prometheus.WrapRegistererWithPrefix("frostdb_table_", unwrappedReg)
+		m.tableMetrics.blockPersisted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "blocks_persisted_total",
+			Help: "Number of table blocks that have been persisted.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.blockRotated = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "blocks_rotated_total",
+			Help: "Number of table blocks that have been rotated.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.rowsInserted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "rows_inserted_total",
+			Help: "Number of rows inserted into table.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.rowBytesInserted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "row_bytes_inserted_total",
+			Help: "Number of bytes inserted into table.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.zeroRowsInserted = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "zero_rows_inserted_total",
+			Help: "Number of times it was attempted to insert zero rows into the table.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.rowInsertSize = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "row_insert_size",
+			Help:    "Size of batch inserts into table.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.lastCompletedBlockTx = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "last_completed_block_tx",
+			Help: "Last completed block transaction.",
+		}, makeLabelsForTablesMetrics())
+		m.tableMetrics.numParts = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "num_parts",
+			Help: "Number of parts currently active.",
+		}, makeLabelsForTablesMetrics())
+
+		// LSM metrics.
+		{
+			reg := prometheus.WrapRegistererWithPrefix("frostdb_lsm_", unwrappedReg)
+			m.tableMetrics.indexMetrics.compactions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+				Name: "compactions_total",
+				Help: "The total number of compactions that have occurred.",
+			}, makeLabelsForTablesMetrics("level"))
+
+			m.tableMetrics.indexMetrics.levelSize = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+				Name: "level_size_bytes",
+				Help: "The size of the level in bytes.",
+			}, makeLabelsForTablesMetrics("level"))
+
+			m.tableMetrics.indexMetrics.compactionDuration = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+				Name:                        "compaction_total_duration_seconds",
+				Help:                        "Total compaction duration",
+				NativeHistogramBucketFactor: 1.1,
+			}, makeLabelsForTablesMetrics())
+		}
+	}
+	return m
+}
+
+type snapshotMetrics struct {
+	snapshotsTotal            *prometheus.CounterVec
+	snapshotFileSizeBytes     prometheus.Gauge
+	snapshotDurationHistogram prometheus.Observer
+}
+
+func (m globalMetrics) snapshotMetricsForDB(dbName string) snapshotMetrics {
+	return snapshotMetrics{
+		snapshotsTotal:            m.dbMetrics.snapshotMetrics.snapshotsTotal.MustCurryWith(prometheus.Labels{"db": dbName}),
+		snapshotFileSizeBytes:     m.dbMetrics.snapshotMetrics.snapshotFileSizeBytes.WithLabelValues(dbName),
+		snapshotDurationHistogram: m.dbMetrics.snapshotMetrics.snapshotDurationHistogram.WithLabelValues(dbName),
+	}
+}
+
+type tableMetricsProvider struct {
+	dbName string
+	m      globalMetrics
+}
+
+type tableMetrics struct {
+	blockPersisted       prometheus.Counter
+	blockRotated         prometheus.Counter
+	rowsInserted         prometheus.Counter
+	rowBytesInserted     prometheus.Counter
+	zeroRowsInserted     prometheus.Counter
+	rowInsertSize        prometheus.Observer
+	lastCompletedBlockTx prometheus.Gauge
+	numParts             prometheus.Gauge
+
+	indexMetrics index.LSMMetrics
+}
+
+func (p tableMetricsProvider) metricsForTable(tableName string) tableMetrics {
+	return tableMetrics{
+		blockPersisted:       p.m.tableMetrics.blockPersisted.WithLabelValues(p.dbName, tableName),
+		blockRotated:         p.m.tableMetrics.blockRotated.WithLabelValues(p.dbName, tableName),
+		rowsInserted:         p.m.tableMetrics.rowsInserted.WithLabelValues(p.dbName, tableName),
+		rowBytesInserted:     p.m.tableMetrics.rowBytesInserted.WithLabelValues(p.dbName, tableName),
+		zeroRowsInserted:     p.m.tableMetrics.zeroRowsInserted.WithLabelValues(p.dbName, tableName),
+		rowInsertSize:        p.m.tableMetrics.rowInsertSize.WithLabelValues(p.dbName, tableName),
+		lastCompletedBlockTx: p.m.tableMetrics.lastCompletedBlockTx.WithLabelValues(p.dbName, tableName),
+		numParts:             p.m.tableMetrics.numParts.WithLabelValues(p.dbName, tableName),
+		indexMetrics: index.LSMMetrics{
+			Compactions:        p.m.tableMetrics.indexMetrics.compactions.MustCurryWith(prometheus.Labels{"db": p.dbName, "table": tableName}),
+			LevelSize:          p.m.tableMetrics.indexMetrics.levelSize.MustCurryWith(prometheus.Labels{"db": p.dbName, "table": tableName}),
+			CompactionDuration: p.m.tableMetrics.indexMetrics.compactionDuration.WithLabelValues(p.dbName, tableName),
+		},
+	}
+}
+
+func (m globalMetrics) metricsForWAL(dbName string) *wal.Metrics {
+	return &wal.Metrics{
+		BytesWritten:          m.dbMetrics.walMetrics.bytesWritten.WithLabelValues(dbName),
+		EntriesWritten:        m.dbMetrics.walMetrics.entriesWritten.WithLabelValues(dbName),
+		Appends:               m.dbMetrics.walMetrics.appends.WithLabelValues(dbName),
+		EntryBytesRead:        m.dbMetrics.walMetrics.entryBytesRead.WithLabelValues(dbName),
+		EntriesRead:           m.dbMetrics.walMetrics.entriesRead.WithLabelValues(dbName),
+		SegmentRotations:      m.dbMetrics.walMetrics.segmentRotations.WithLabelValues(dbName),
+		EntriesTruncated:      m.dbMetrics.walMetrics.entriesTruncated.MustCurryWith(prometheus.Labels{"db": dbName}),
+		Truncations:           m.dbMetrics.walMetrics.truncations.MustCurryWith(prometheus.Labels{"db": dbName}),
+		LastSegmentAgeSeconds: m.dbMetrics.walMetrics.lastSegmentAgeSeconds.WithLabelValues(dbName),
+	}
+}
+
+func (m globalMetrics) metricsForFileWAL(dbName string) *filewal.Metrics {
+	return &filewal.Metrics{
+		FailedLogs:            m.dbMetrics.fileWalMetrics.failedLogs.WithLabelValues(dbName),
+		LastTruncationAt:      m.dbMetrics.fileWalMetrics.lastTruncationAt.WithLabelValues(dbName),
+		WalRepairs:            m.dbMetrics.fileWalMetrics.walRepairs.WithLabelValues(dbName),
+		WalRepairsLostRecords: m.dbMetrics.fileWalMetrics.walRepairsLostRecords.WithLabelValues(dbName),
+		WalCloseTimeouts:      m.dbMetrics.fileWalMetrics.walCloseTimeouts.WithLabelValues(dbName),
+		WalQueueSize:          m.dbMetrics.fileWalMetrics.walQueueSize.WithLabelValues(dbName),
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,50 @@
+package frostdb
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	descTxHighWatermark = prometheus.NewDesc(
+		"frostdb_tx_high_watermark",
+		"The highest transaction number that has been released to be read",
+		[]string{"db"}, nil,
+	)
+	descActiveBlockSize = prometheus.NewDesc(
+		"frostdb_table_active_block_size",
+		"Size of the active table block in bytes.",
+		[]string{"db", "table"}, nil,
+	)
+)
+
+// collector is a custom prometheus collector that exports metrics from live
+// databases and tables.
+type collector struct {
+	s *ColumnStore
+}
+
+var _ prometheus.Collector = (*collector)(nil)
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descTxHighWatermark
+	ch <- descActiveBlockSize
+}
+
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	for _, dbName := range c.s.DBs() {
+		db, err := c.s.GetDB(dbName)
+		if err != nil {
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(descTxHighWatermark, prometheus.GaugeValue, float64(db.HighWatermark()), dbName)
+		for _, tableName := range db.TableNames() {
+			table, err := db.GetTable(tableName)
+			if err != nil {
+				continue
+			}
+			activeBlock := table.ActiveBlock()
+			if activeBlock == nil {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(descActiveBlockSize, prometheus.GaugeValue, float64(activeBlock.Size()), dbName, tableName)
+		}
+	}
+}

--- a/table.go
+++ b/table.go
@@ -441,16 +441,6 @@ func newTable(
 
 	t.pendingBlocks = make(map[*TableBlock]struct{})
 
-	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "frostdb_table_active_block_size",
-		Help: "Size of the active table block in bytes.",
-	}, func() float64 {
-		if active := t.ActiveBlock(); active != nil {
-			return float64(active.Size())
-		}
-		return 0
-	})
-
 	return t, nil
 }
 

--- a/table.go
+++ b/table.go
@@ -23,8 +23,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
 	"github.com/parquet-go/parquet-go"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
@@ -259,7 +257,7 @@ func NewGenericTable[T any](db *DB, name string, mem memory.Allocator, options .
 type Table struct {
 	db      *DB
 	name    string
-	metrics *tableMetrics
+	metrics tableMetrics
 	logger  log.Logger
 	tracer  trace.Tracer
 
@@ -330,19 +328,6 @@ type Closer interface {
 	Close(cleanup bool) error
 }
 
-type tableMetrics struct {
-	blockPersisted       prometheus.Counter
-	blockRotated         prometheus.Counter
-	rowsInserted         prometheus.Counter
-	rowBytesInserted     prometheus.Counter
-	zeroRowsInserted     prometheus.Counter
-	rowInsertSize        prometheus.Histogram
-	lastCompletedBlockTx prometheus.Gauge
-	numParts             prometheus.Gauge
-
-	indexMetrics *index.LSMMetrics
-}
-
 func schemaFromTableConfig(tableConfig *tablepb.TableConfig) (*dynparquet.Schema, error) {
 	switch schema := tableConfig.Schema.(type) {
 	case *tablepb.TableConfig_DeprecatedSchema:
@@ -359,7 +344,7 @@ func newTable(
 	db *DB,
 	name string,
 	tableConfig *tablepb.TableConfig,
-	reg prometheus.Registerer,
+	metrics tableMetrics,
 	logger log.Logger,
 	tracer trace.Tracer,
 	wal WAL,
@@ -374,8 +359,6 @@ func newTable(
 		return nil, errors.New(msg)
 	}
 
-	reg = prometheus.WrapRegistererWith(prometheus.Labels{"table": name}, reg)
-
 	if tableConfig == nil {
 		tableConfig = defaultTableConfig()
 	}
@@ -386,49 +369,14 @@ func newTable(
 	}
 
 	t := &Table{
-		db:     db,
-		name:   name,
-		logger: logger,
-		tracer: tracer,
-		mtx:    &sync.RWMutex{},
-		wal:    wal,
-		schema: s,
-		metrics: &tableMetrics{
-			numParts: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-				Name: "frostdb_table_num_parts",
-				Help: "Number of parts currently active.",
-			}),
-			blockPersisted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_table_blocks_persisted_total",
-				Help: "Number of table blocks that have been persisted.",
-			}),
-			blockRotated: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_table_blocks_rotated_total",
-				Help: "Number of table blocks that have been rotated.",
-			}),
-			rowsInserted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_table_rows_inserted_total",
-				Help: "Number of rows inserted into table.",
-			}),
-			rowBytesInserted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_table_row_bytes_inserted_total",
-				Help: "Number of bytes inserted into table.",
-			}),
-			zeroRowsInserted: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-				Name: "frostdb_table_zero_rows_inserted_total",
-				Help: "Number of times it was attempted to insert zero rows into the table.",
-			}),
-			rowInsertSize: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-				Name:    "frostdb_table_row_insert_size",
-				Help:    "Size of batch inserts into table.",
-				Buckets: prometheus.ExponentialBuckets(1, 2, 10),
-			}),
-			lastCompletedBlockTx: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-				Name: "frostdb_table_last_completed_block_tx",
-				Help: "Last completed block transaction.",
-			}),
-			indexMetrics: index.NewLSMMetrics(reg),
-		},
+		db:      db,
+		name:    name,
+		logger:  logger,
+		tracer:  tracer,
+		mtx:     &sync.RWMutex{},
+		wal:     wal,
+		schema:  s,
+		metrics: metrics,
 	}
 
 	// Store the table config
@@ -1074,7 +1022,7 @@ func newTableBlock(table *Table, prevTx, tx uint64, id ulid.ULID) (*TableBlock, 
 		table.schema,
 		table.IndexConfig(),
 		table.db.HighWatermark,
-		index.LSMWithMetrics(table.metrics.indexMetrics),
+		index.LSMWithMetrics(&table.metrics.indexMetrics),
 		index.LSMWithLogger(table.logger),
 	)
 	if err != nil {

--- a/testing_opts.go
+++ b/testing_opts.go
@@ -22,7 +22,7 @@ func WithTestingNoDiskSpaceReclaimOnSnapshot() TestingOption {
 	}
 }
 
-func WithTestingWalOptions(opts ...wal.TestingOption) TestingOption {
+func WithTestingWalOptions(opts ...wal.Option) TestingOption {
 	return func(c *ColumnStore) error {
 		c.testingOptions.walTestingOptions = opts
 		return nil

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	walpb "github.com/polarsignals/frostdb/gen/proto/go/frostdb/wal/v1alpha1"
@@ -18,7 +17,6 @@ func TestWAL(t *testing.T) {
 	dir := t.TempDir()
 	w, err := Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		dir,
 	)
 	require.NoError(t, err)
@@ -39,7 +37,6 @@ func TestWAL(t *testing.T) {
 
 	w, err = Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		dir,
 	)
 	require.NoError(t, err)
@@ -70,7 +67,6 @@ func TestWAL(t *testing.T) {
 	require.NoError(t, os.RemoveAll(dir))
 	w, err = Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		dir,
 	)
 	require.NoError(t, err)
@@ -83,7 +79,6 @@ func TestCorruptWAL(t *testing.T) {
 
 	w, err := Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		path,
 	)
 	require.NoError(t, err)
@@ -107,7 +102,6 @@ func TestCorruptWAL(t *testing.T) {
 
 	w, err = Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		path,
 	)
 	require.NoError(t, err)
@@ -128,7 +122,6 @@ func TestUnexpectedTxn(t *testing.T) {
 	func() {
 		w, err := Open(
 			log.NewNopLogger(),
-			prometheus.NewRegistry(),
 			walDir,
 		)
 		require.NoError(t, err)
@@ -147,7 +140,6 @@ func TestUnexpectedTxn(t *testing.T) {
 	}()
 	w, err := Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		walDir,
 	)
 	require.NoError(t, err)
@@ -176,7 +168,6 @@ func TestWALTruncate(t *testing.T) {
 			dir := t.TempDir()
 			w, err := Open(
 				log.NewNopLogger(),
-				prometheus.NewRegistry(),
 				dir,
 			)
 			require.NoError(t, err)
@@ -220,7 +211,6 @@ func TestWALTruncate(t *testing.T) {
 		dir := t.TempDir()
 		w, err := Open(
 			log.NewNopLogger(),
-			prometheus.NewRegistry(),
 			dir,
 		)
 		require.NoError(t, err)
@@ -277,7 +267,6 @@ func TestWALCloseTimeout(t *testing.T) {
 	dir := t.TempDir()
 	w, err := Open(
 		log.NewNopLogger(),
-		prometheus.NewRegistry(),
 		dir,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
At component instantiation time (e.g. db, wal, table), existing metrics are
provided to the components with the correct variable label set. This moves the
metric registration lifecycle to the store level and avoids duplicate
registration panics when e.g. reopening a closed db.