### PR TITLE
[WIP/DNM] table: fix behavior on new table block error

### DIFF
--- a/db.go
+++ b/db.go
@@ -715,6 +715,10 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 
 	start := time.Now()
 	if err := wal.Replay(snapshotTx+1, func(_ uint64, record *walpb.Record) error {
+		if record.SizeVT() == 0 {
+			// This was an empty record, skip it.
+			return nil
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -737,6 +741,10 @@ func (db *DB) recover(ctx context.Context, wal WAL) error {
 	performSnapshot := false
 
 	if err := wal.Replay(snapshotTx+1, func(tx uint64, record *walpb.Record) error {
+		if record.SizeVT() == 0 {
+			// This was an empty record, skip it.
+			return nil
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}

--- a/dst/dst_test.go
+++ b/dst/dst_test.go
@@ -239,6 +239,9 @@ func (s *testLogStore) accumulateLogs(logs []types.LogEntry) error {
 		if err := walRec.UnmarshalVT(log.Data); err != nil {
 			return err
 		}
+		if walRec.SizeVT() == 0 {
+			continue
+		}
 		writeInfo, ok := walRec.Entry.EntryType.(*walpb.Entry_Write_)
 		if !ok {
 			continue


### PR DESCRIPTION
Table block creation can fail for a variety of reasons, but we were only
handling the happy case. This commit only overwrites the active block if the
new table block was successfully created, and logs a noop record to the WAL on
error to not block subsequent wal records logs.

Bug found with DST.