### PR TITLE
Add file path to reading error

### DIFF
--- a/dynparquet/reader.go
+++ b/dynparquet/reader.go
@@ -23,7 +23,7 @@ type SerializedBuffer struct {
 func ReaderFromBytes(buf []byte) (*SerializedBuffer, error) {
 	f, err := parquet.OpenFile(bytes.NewReader(buf), int64(len(buf)))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error opening file from buffer: %w", err)
 	}
 
 	return NewSerializedBuffer(f)

--- a/pqarrow/parquet.go
+++ b/pqarrow/parquet.go
@@ -363,7 +363,7 @@ func SerializeRecord(r arrow.Record, schema *dynparquet.Schema) (*dynparquet.Ser
 	}
 	f, err := parquet.OpenFile(bytes.NewReader(b.Bytes()), int64(b.Len()))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read buf: %v", err)
 	}
 	buf, err := dynparquet.NewSerializedBuffer(f)
 	if err != nil {

--- a/storage/iceberg.go
+++ b/storage/iceberg.go
@@ -284,7 +284,7 @@ func (i *Iceberg) Scan(ctx context.Context, prefix string, _ *dynparquet.Schema,
 				parquet.FileReadMode(parquet.ReadModeAsync),
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to open file %s: %w", e.DataFile().FilePath(), err)
 			}
 
 			// Get a reader from the file bytes

--- a/store.go
+++ b/store.go
@@ -183,7 +183,7 @@ func (b *DefaultObjstoreBucket) openBlockFile(ctx context.Context, blockName str
 		parquet.FileReadMode(parquet.ReadModeAsync),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open block: %s :%v", blockName, err)
 	}
 
 	return file, nil


### PR DESCRIPTION
This adds some more context to what exactly is failing to open. Especially helpful for knowing which blocks my be broken.
