### PR TITLE
cmd/parquet-tool: Fix percentage calculation

### DIFF
--- a/cmd/parquet-tool/cmd/dump.go
+++ b/cmd/parquet-tool/cmd/dump.go
@@ -48,7 +48,7 @@ func dump(file string) error {
 					humanize.Bytes(uint64(ds.MetaData.TotalCompressedSize)),
 					humanize.Bytes(uint64(ds.MetaData.TotalUncompressedSize)),
 					fmt.Sprintf("%.2f", float64(ds.MetaData.TotalUncompressedSize-ds.MetaData.TotalCompressedSize)/float64(ds.MetaData.TotalCompressedSize)*100),
-					fmt.Sprintf("%.2f", float64(ds.MetaData.TotalCompressedSize)/float64(rg.TotalByteSize)*100),
+					fmt.Sprintf("%.2f", float64(ds.MetaData.TotalUncompressedSize)/float64(rg.TotalByteSize)*100),
 				})
 		}
 		table.Render()


### PR DESCRIPTION
The total byte size recorded in the row group represents the uncompressed size, so to calculate the percentage correctly we also need to use the uncompressed pages of the column.