### PR TITLE
pqarrow/arrowutils: Add sorting support for Struct, RunEndEncoded, FixedSizeBinary

### DIFF
--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -241,6 +241,7 @@ func TakeListColumn(ctx context.Context, a *array.List, idx int, arr []arrow.Arr
 	if !ok {
 		return fmt.Errorf("unexpected value builder type %T for list column", r.ValueBuilder())
 	}
+	defer valueBuilder.Release()
 
 	listValues := a.ListValues().(*array.Dictionary)
 	switch dictV := listValues.Dictionary().(type) {

--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -72,7 +72,10 @@ func Take(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Reco
 	// does not have these columns.
 	var customTake bool
 	for i := 0; i < int(r.NumCols()); i++ {
-		if r.Column(i).DataType().ID() == arrow.DICTIONARY || r.Column(i).DataType().ID() == arrow.LIST {
+		if r.Column(i).DataType().ID() == arrow.DICTIONARY ||
+			r.Column(i).DataType().ID() == arrow.RUN_END_ENCODED ||
+			r.Column(i).DataType().ID() == arrow.LIST ||
+			r.Column(i).DataType().ID() == arrow.STRUCT {
 			customTake = true
 			break
 		}
@@ -108,8 +111,12 @@ func Take(ctx context.Context, r arrow.Record, indices *array.Int32) (arrow.Reco
 		switch arr := r.Column(i).(type) {
 		case *array.Dictionary:
 			g.Go(func() error { return TakeDictColumn(ctx, arr, i, resArr, indices) })
+		case *array.RunEndEncoded:
+			g.Go(func() error { return TakeRunEndEncodedColumn(ctx, arr, i, resArr, indices) })
 		case *array.List:
 			g.Go(func() error { return TakeListColumn(ctx, arr, i, resArr, indices) })
+		case *array.Struct:
+			g.Go(func() error { return TakeStructColumn(ctx, arr, i, resArr, indices) })
 		default:
 			g.Go(func() error { return TakeColumn(ctx, col, i, resArr, indices) })
 		}
@@ -172,6 +179,7 @@ func TakeDictColumn(ctx context.Context, a *array.Dictionary, idx int, arr []arr
 				r.AppendNull()
 				continue
 			}
+			// TODO: Improve this by not copying actual values.
 			idxBuilder.Append(a.GetValueIndex(int(i)))
 		}
 
@@ -179,6 +187,51 @@ func TakeDictColumn(ctx context.Context, a *array.Dictionary, idx int, arr []arr
 		return nil
 	}
 
+	return nil
+}
+
+func TakeRunEndEncodedColumn(ctx context.Context, a *array.RunEndEncoded, idx int, arr []arrow.Array, indices *array.Int32) error {
+	expandedIndexBuilder := array.NewInt32Builder(compute.GetAllocator(ctx))
+	defer expandedIndexBuilder.Release()
+
+	dict := a.Values().(*array.Dictionary)
+	for i := 0; i < a.Len(); i++ {
+		if dict.IsNull(a.GetPhysicalIndex(i)) {
+			expandedIndexBuilder.AppendNull()
+		} else {
+			expandedIndexBuilder.Append(int32(dict.GetValueIndex(a.GetPhysicalIndex(i))))
+		}
+	}
+	expandedIndex := expandedIndexBuilder.NewInt32Array()
+	defer expandedIndex.Release()
+
+	expandedReorderedArr := make([]arrow.Array, 1)
+	if err := TakeColumn(ctx, expandedIndex, 0, expandedReorderedArr, indices); err != nil {
+		return err
+	}
+	expandedReordered := expandedReorderedArr[0].(*array.Int32)
+	defer expandedReordered.Release()
+
+	b := array.NewRunEndEncodedBuilder(
+		compute.GetAllocator(ctx), a.RunEndsArr().DataType(), a.Values().DataType(),
+	)
+	defer b.Release()
+	b.Reserve(indices.Len())
+
+	dictValues := dict.Dictionary().(*array.String)
+	for i := 0; i < expandedReordered.Len(); i++ {
+		if expandedReordered.IsNull(i) {
+			b.AppendNull()
+			continue
+		}
+		reorderedIndex := expandedReordered.Value(i)
+		v := dictValues.Value(int(reorderedIndex))
+		if err := b.AppendValueFromString(v); err != nil {
+			return err
+		}
+	}
+
+	arr[idx] = b.NewRunEndEncodedArray()
 	return nil
 }
 
@@ -220,6 +273,45 @@ func TakeListColumn(ctx context.Context, a *array.List, idx int, arr []arrow.Arr
 	}
 
 	arr[idx] = r.NewArray()
+	return nil
+}
+
+func TakeStructColumn(ctx context.Context, a *array.Struct, idx int, arr []arrow.Array, indices *array.Int32) error {
+	aType := a.Data().DataType().(*arrow.StructType)
+
+	cols := make([]arrow.Array, a.NumField())
+	names := make([]string, a.NumField())
+	defer func() {
+		for _, col := range cols {
+			if col != nil {
+				col.Release()
+			}
+		}
+	}()
+
+	for i := 0; i < a.NumField(); i++ {
+		names[i] = aType.Field(i).Name
+
+		switch f := a.Field(i).(type) {
+		case *array.RunEndEncoded:
+			err := TakeRunEndEncodedColumn(ctx, f, i, cols, indices)
+			if err != nil {
+				return err
+			}
+		default:
+			err := TakeColumn(ctx, f, i, cols, indices)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	takeStruct, err := array.NewStructArray(cols, names)
+	if err != nil {
+		return err
+	}
+
+	arr[idx] = takeStruct
 	return nil
 }
 

--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -148,7 +148,7 @@ func TakeColumn(ctx context.Context, a arrow.Array, idx int, arr []arrow.Array, 
 
 func TakeDictColumn(ctx context.Context, a *array.Dictionary, idx int, arr []arrow.Array, indices *array.Int32) error {
 	switch a.Dictionary().(type) {
-	case *array.String:
+	case *array.String, *array.Binary:
 		r := array.NewDictionaryBuilderWithDict(
 			compute.GetAllocator(ctx), a.DataType().(*arrow.DictionaryType), a.Dictionary(),
 		).(*array.BinaryDictionaryBuilder)

--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -279,6 +279,12 @@ func TakeListColumn(ctx context.Context, a *array.List, idx int, arr []arrow.Arr
 func TakeStructColumn(ctx context.Context, a *array.Struct, idx int, arr []arrow.Array, indices *array.Int32) error {
 	aType := a.Data().DataType().(*arrow.StructType)
 
+	// Immediately, return this struct if it has no fields/columns
+	if a.NumField() == 0 {
+		arr[idx] = a
+		return nil
+	}
+
 	cols := make([]arrow.Array, a.NumField())
 	names := make([]string, a.NumField())
 	defer func() {

--- a/pqarrow/arrowutils/sort.go
+++ b/pqarrow/arrowutils/sort.go
@@ -281,6 +281,9 @@ func TakeStructColumn(ctx context.Context, a *array.Struct, idx int, arr []arrow
 
 	// Immediately, return this struct if it has no fields/columns
 	if a.NumField() == 0 {
+		// If the original record is released and this is released once more,
+		// as usually done, we want to retain it once more.
+		a.Retain()
 		arr[idx] = a
 		return nil
 	}

--- a/pqarrow/arrowutils/sort_test.go
+++ b/pqarrow/arrowutils/sort_test.go
@@ -460,9 +460,8 @@ func TestReorderRecord(t *testing.T) {
 		}
 	})
 	t.Run("List", func(t *testing.T) {
-		mem := memory.NewGoAllocator()
-		// mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-		// defer mem.AssertSize(t, 0)
+		mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+		defer mem.AssertSize(t, 0)
 		b := array.NewRecordBuilder(mem, arrow.NewSchema(
 			[]arrow.Field{
 				{

--- a/pqarrow/arrowutils/sort_test.go
+++ b/pqarrow/arrowutils/sort_test.go
@@ -696,7 +696,6 @@ func (s Samples) Record() arrow.Record {
 		} else {
 			fNullable.AppendNull()
 		}
-
 	}
 	return b.NewRecord()
 }

--- a/query/physicalplan/sampler.go
+++ b/query/physicalplan/sampler.go
@@ -174,6 +174,10 @@ func (s *ReservoirSampler) sliceReservoir() {
 
 // sample implements the reservoir sampling algorithm found https://en.wikipedia.org/wiki/Reservoir_sampling.
 func (s *ReservoirSampler) sample(r arrow.Record, ref *referencedRecord) {
+	// The size can be 0 and in that case we don't want to sample.
+	if s.size == 0 {
+		return
+	}
 	n := s.n + r.NumRows()
 	if s.i == 0 {
 		s.i = float64(s.n) - 1

--- a/query/physicalplan/sampler_test.go
+++ b/query/physicalplan/sampler_test.go
@@ -291,7 +291,7 @@ func Test_Sampler_MaxSizeAllocation(t *testing.T) {
 		allocator: memory.NewCheckedAllocator(memory.NewGoAllocator()),
 	}
 	t.Cleanup(func() {
-		require.Equal(t, allocator.maxUsed, 1024) // Expect the most we allocated was 1024 bytes during materialization
+		require.LessOrEqual(t, allocator.maxUsed, 1024) // Expect the most we allocated was 1024 bytes during materialization
 		allocator.allocator.AssertSize(t, 0)
 	})
 	s := NewReservoirSampler(10, 200, allocator)


### PR DESCRIPTION
The RunEndEncoded part made my brain melt a couple of times. The Struct part is weird cause it _always_ assumes the fields of a struct a multiple when creating the new struct array with `array.NewStructArray(cols, names)`, so I had to figure that out and adjust the schema. FixedSizeBinary is simple compared to the other two. 