### PR TITLE
Add benchmark: small-window queries scale with total block count

### DIFF
--- a/bench_smallwindow_test.go
+++ b/bench_smallwindow_test.go
@@ -1,0 +1,148 @@
+package frostdb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/polarsignals/frostdb/dynparquet"
+	"github.com/polarsignals/frostdb/query"
+	"github.com/polarsignals/frostdb/query/logicalplan"
+	"github.com/polarsignals/frostdb/samples"
+)
+
+// BenchmarkQuerySmallWindowManyBlocks measures a query over a small, fixed time
+// window as the number of persisted blocks grows. Each block covers a distinct
+// range of timestamps, and the query always asks for only the newest block's
+// range -- so every run matches the same amount of data, and only the number
+// of older, non-matching blocks changes.
+//
+// If blocks were eliminated by their time range before being opened, the cost
+// would be roughly constant across block counts. To serve a query the store
+// opens each persisted block and decodes its Parquet metadata (the footer, and
+// the column/page index), then filters row groups by the predicate only after
+// the block is already open -- there is no step that skips a block whose time
+// range is outside the query. So a small-window query's cost grows with the
+// total number of blocks retained, not with the size of the window.
+//
+// The growth is clearest in allocs/op, which is close to linear in the block
+// count; wall time grows more slowly because blocks are opened concurrently.
+//
+// Run with:
+//
+//	go test -run '^$' -bench BenchmarkQuerySmallWindowManyBlocks -benchmem -benchtime=20x
+func BenchmarkQuerySmallWindowManyBlocks(b *testing.B) {
+	const rowsPerBlock = 200
+
+	for _, numBlocks := range []int{1, 25, 100, 400} {
+		b.Run(fmt.Sprintf("blocks=%d", numBlocks), func(b *testing.B) {
+			ctx := context.Background()
+			// The bucket holds the persisted blocks and survives the store
+			// being closed and reopened below.
+			bucket := objstore.NewInMemBucket()
+			sinksource := NewDefaultObjstoreBucket(bucket)
+
+			writeBlocks(b, sinksource, numBlocks, rowsPerBlock)
+
+			// Reopen against the same bucket. The blocks now live only in the
+			// bucket, so a query reads them back through the bucket-scan path --
+			// the path that opens and decodes each block's Parquet metadata.
+			// This is the state a server is in after a restart, and the state a
+			// long-running server reaches once old blocks leave active memory.
+			c, err := New(
+				WithStoragePath(b.TempDir()),
+				WithWAL(),
+				WithReadWriteStorage(sinksource),
+				WithManualBlockRotation(),
+				WithActiveMemorySize(64*KiB),
+			)
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, c.Close()) })
+			db, err := c.DB(ctx, "bench")
+			require.NoError(b, err)
+			_, err = db.Table("bench", NewTableConfig(dynparquet.SampleDefinition()))
+			require.NoError(b, err)
+
+			engine := query.NewEngine(memory.NewGoAllocator(), db.TableProvider())
+
+			// The window covers ONLY the newest block, regardless of how many
+			// older blocks exist.
+			from := int64(numBlocks-1) * 1000
+			to := from + rowsPerBlock
+
+			var rows int64
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				rows = 0
+				err := engine.ScanTable("bench").
+					Filter(logicalplan.And(
+						logicalplan.Col("timestamp").Gt(logicalplan.Literal(from-1)),
+						logicalplan.Col("timestamp").Lt(logicalplan.Literal(to)),
+					)).
+					Aggregate(
+						[]*logicalplan.AggregationFunction{logicalplan.Sum(logicalplan.Col("value"))},
+						[]logicalplan.Expr{logicalplan.Col("stacktrace")},
+					).
+					Execute(ctx, func(_ context.Context, r arrow.Record) error {
+						rows += r.NumRows()
+						return nil
+					})
+				require.NoError(b, err)
+			}
+			b.StopTimer()
+			// Guard against silently benchmarking an empty query: the window
+			// must match the newest block's rows. Without this a filter or
+			// schema change that matched nothing would still "pass" and just
+			// report fast, flat timings.
+			require.Positive(b, rows, "query matched no rows")
+		})
+	}
+}
+
+// writeBlocks writes numBlocks persisted blocks into the bucket behind
+// sinksource, one per time bucket (block i covers timestamps
+// [i*1000, i*1000+rowsPerBlock)), then closes the store so the blocks live only
+// in the bucket.
+func writeBlocks(b *testing.B, sinksource *DefaultObjstoreBucket, numBlocks, rowsPerBlock int) {
+	b.Helper()
+	ctx := context.Background()
+	c, err := New(
+		WithStoragePath(b.TempDir()),
+		WithWAL(),
+		WithReadWriteStorage(sinksource),
+		WithManualBlockRotation(),
+		WithActiveMemorySize(64*KiB),
+	)
+	require.NoError(b, err)
+	db, err := c.DB(ctx, "bench")
+	require.NoError(b, err)
+	table, err := db.Table("bench", NewTableConfig(dynparquet.SampleDefinition()))
+	require.NoError(b, err)
+
+	for i := 0; i < numBlocks; i++ {
+		base := int64(i) * 1000
+		ss := make(samples.Samples, 0, rowsPerBlock)
+		for r := 0; r < rowsPerBlock; r++ {
+			ss = append(ss, samples.Sample{
+				ExampleType: "cpu",
+				Labels:      map[string]string{"instance": fmt.Sprintf("i-%d", r%8)},
+				Stacktrace:  []uuid.UUID{{byte(r), byte(r >> 8)}},
+				Timestamp:   base + int64(r),
+				Value:       int64(r),
+			})
+		}
+		rec, err := ss.ToRecord()
+		require.NoError(b, err)
+		writeTx, err := table.InsertRecord(ctx, rec)
+		require.NoError(b, err)
+		require.NoError(b, table.RotateBlock(ctx, table.ActiveBlock()))
+		db.Wait(writeTx + 2) // wait for the async block-persist txn
+	}
+	require.NoError(b, c.Close())
+}


### PR DESCRIPTION
## What

Adds `BenchmarkQuerySmallWindowManyBlocks`, which measures a query over a small, fixed time window as the number of persisted blocks grows.

## Why

A query bounded to a small time window still opens and decodes the Parquet metadata of **every** persisted block. In `store.go`, `ProcessFile` opens each block's `data.parquet` (`openBlockFile` → `parquet.OpenFile`) and only *then* applies the predicate to row groups in `filterRowGroups` — there is no step that skips a block whose time range is entirely outside the query window. So the cost of a small-window query grows with the total number of blocks stored, not with the size of the window.

The benchmark makes this visible. It writes N persisted blocks, each covering a distinct time range, then queries a window that only ever covers the newest block — the matched data is identical across runs, only the number of older, non-matching blocks changes. It reopens the store against the same bucket so the blocks are read back through the bucket-scan path rather than from memory, and asserts the query matched the newest block's rows so it can't silently regress into measuring an empty query.

Result (`-benchmem -benchtime=20x`), clearest in allocs/op:

```
blocks=1     5.1 ms    5,297 allocs/op
blocks=25    7.9 ms   12,934 allocs/op
blocks=100  13.7 ms   36,793 allocs/op
blocks=400  28.5 ms  132,202 allocs/op
```

Wall time grows more slowly than allocations because blocks are opened concurrently, but the total work is O(total blocks).

This is a benchmark only — it documents and measures the behaviour, it doesn't change it.

## For comparison: a store that skips non-matching partitions at query time

To sanity-check that this is a property of the default backend and not of the query itself, here is the same shape (N daily partitions, query one day's window) against ClickHouse (`MergeTree`, `PARTITION BY toYYYYMMDD(...)`), read off `EXPLAIN indexes=1`:

```
partitions=1     Parts 1/1
partitions=25    Parts 1/25
partitions=100   Parts 1/100
partitions=400   Parts 1/400      (reads 1 of 400 partitions; wall time flat ~280ms)
```

It reads a single partition regardless of the total — the non-matching partitions are skipped at query time (they are not read, and not deleted), so cost does not grow with retained data. The absolute milliseconds are not comparable (ClickHouse is a separate server with fixed per-query overhead; FrostDB is embedded); the point is the scaling: linear vs flat.

The mechanism that enables this is per-file/partition min/max recorded outside the data file, so the filter can eliminate files before opening them. FrostDB's own Iceberg backend does exactly this (`storage/iceberg.go`), but the default `DefaultObjstoreBucket` does not.

## Context

This came out of investigating slow queries on a self-hosted Parca server backed by FrostDB, where retained data (not query window) drove query latency: https://github.com/guettli/parcareport

Two notes for anyone hitting this:
- The successor storage engine, Great Lakes (per the [Polar Signals / Dash0 announcement](https://www.dash0.com/blog/dash0-acquires-polar-signals)), is described as purpose-built for high-cardinality profiling data. This benchmark documents the limitation in the current default backend of FrostDB, which Parca still ships.
- ClickHouse is an open-source alternative that prunes by time as shown above, and Parca already includes an optional ClickHouse backend.